### PR TITLE
fix: make package installable from built distributions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,58 @@
+name: Package
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "pyproject.toml"
+      - "cli.py"
+      - "main.py"
+      - "api_server.py"
+      - "config.py"
+      - "tui_app.py"
+      - "app/**"
+      - "core/**"
+      - "downloads/**"
+      - "providers/**"
+      - "results/**"
+      - "search/**"
+      - "terminal_ui/**"
+      - ".github/workflows/package.yml"
+
+jobs:
+  wheel:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Install built wheel
+        run: >-
+          python -c "import glob, subprocess, sys; wheels = glob.glob('dist/*.whl');
+          assert len(wheels) == 1, wheels;
+          subprocess.check_call([sys.executable, '-m', 'pip', 'install', wheels[0]])"
+
+      - name: Verify installed imports
+        run: python -c "import main, cli, api_server; print('installed-import-ok')"
+
+      - name: Verify installed CLI entry point
+        run: ai-model-explorer-cli version

--- a/cli.py
+++ b/cli.py
@@ -1,3 +1,5 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
 
 import click
 from rich.console import Console
@@ -9,6 +11,14 @@ from core.hardware import HardwareMonitor, check_ollama_running
 from downloads.service_client import get_service_health
 
 console = Console()
+
+
+def get_version() -> str:
+    """Return the installed AI Model Explorer package version."""
+    try:
+        return package_version("ai-model-explorer")
+    except PackageNotFoundError:
+        return "0.0.0+local"
 
 
 @click.group()
@@ -99,7 +109,6 @@ def search(query, provider, limit, sort):
             hf_results, _ = search_hf_models(query, specs, {}, limit=limit)
             results.extend(hf_results)
 
-    # Sort
     if sort == "composite":
         results.sort(key=lambda r: r.get("score_composite", 0), reverse=True)
     elif sort == "speed":
@@ -161,7 +170,6 @@ def fit(perfect, limit):
         hf_results, _ = search_hf_models("*", specs, {}, limit=50)
         results.extend(hf_results)
 
-    # Sort by composite score
     results.sort(key=lambda r: r.get("score_composite", 0), reverse=True)
 
     if perfect:
@@ -215,7 +223,6 @@ def recommend(limit, use_case, output_json):
         hf_results, _ = search_hf_models("*", specs, {}, limit=50)
         results.extend(hf_results)
 
-    # Filter by use case and fit
     results = [r for r in results if r.get("use_case_key") == use_case or use_case == "general"]
     results = [r for r in results if "no fit" not in r.get("fit", "").lower()]
     results.sort(key=lambda r: r.get("score_composite", 0), reverse=True)
@@ -380,18 +387,7 @@ def cache_stats():
 @cli.command()
 def version():
     """Show version information."""
-    from pathlib import Path
-
-    version_file = Path(__file__).parent / "pyproject.toml"
-    version_str = "0.1.0"
-    if version_file.exists():
-        import tomllib
-
-        with open(version_file, "rb") as f:
-            data = tomllib.load(f)
-            version_str = data.get("project", {}).get("version", "0.1.0")
-
-    console.print(f"AI Model Explorer v{version_str}")
+    console.print(f"AI Model Explorer v{get_version()}")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "ai-model-explorer"
@@ -26,6 +26,14 @@ dependencies = [
 [project.scripts]
 ai-model-explorer = "main:main"
 ai-model-explorer-cli = "cli:cli"
+
+[tool.setuptools]
+py-modules = ["api_server", "cli", "config", "main", "tui_app"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*", "core*", "downloads*", "providers*", "results*", "search*", "terminal_ui*"]
+exclude = ["tests*", "docs*", "scripts*"]
 
 # ---------------------------------------------------------------------------
 # Ruff — linter & formatter

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -126,6 +126,14 @@ def install_lockfile(venv_python: Path, lockfile: Path, root: Path) -> None:
     )
 
 
+def install_project(venv_python: Path, root: Path) -> None:
+    subprocess.run(
+        [str(venv_python), "-m", "pip", "install", "--no-deps", "-e", "."],
+        check=True,
+        cwd=root,
+    )
+
+
 def bootstrap() -> int:
     ensure_supported_python()
     root = project_root()
@@ -135,6 +143,7 @@ def bootstrap() -> int:
     ensure_pip(venv_python, root)
     lockfile = requirement_path(root, select_dev_lock(system_name))
     install_lockfile(venv_python, lockfile, root)
+    install_project(venv_python, root)
     print(f"[bootstrap] installed from {lockfile.relative_to(root).as_posix()}")
     return 0
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -127,6 +127,9 @@ def install_lockfile(venv_python: Path, lockfile: Path, root: Path) -> None:
 
 
 def install_project(venv_python: Path, root: Path) -> None:
+    if not (root / "pyproject.toml").exists():
+        return
+
     subprocess.run(
         [str(venv_python), "-m", "pip", "install", "--no-deps", "-e", "."],
         check=True,

--- a/tests/test_packaging_regressions.py
+++ b/tests/test_packaging_regressions.py
@@ -27,6 +27,10 @@ def test_pyproject_uses_supported_setuptools_backend():
 def test_bootstrap_installs_project_after_platform_lock(tmp_path, monkeypatch):
     dev = _load_dev_module()
     (tmp_path / "requirements-dev-linux.txt").write_text("pytest==8.4.2\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        "[build-system]\nrequires = ['setuptools>=68']\nbuild-backend = 'setuptools.build_meta'\n",
+        encoding="utf-8",
+    )
 
     venv_python = tmp_path / ".venv" / "bin" / "python"
     venv_python.parent.mkdir(parents=True)

--- a/tests/test_packaging_regressions.py
+++ b/tests/test_packaging_regressions.py
@@ -1,0 +1,68 @@
+"""Regression tests for packaging and installed CLI behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_dev_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "dev.py"
+    spec = importlib.util.spec_from_file_location("dev_script_packaging", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pyproject_uses_supported_setuptools_backend():
+    import tomllib
+
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+
+    assert data["build-system"]["build-backend"] == "setuptools.build_meta"
+
+
+def test_bootstrap_installs_project_after_platform_lock(tmp_path, monkeypatch):
+    dev = _load_dev_module()
+    (tmp_path / "requirements-dev-linux.txt").write_text("pytest==8.4.2\n", encoding="utf-8")
+
+    venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, check, cwd, **kwargs):
+        calls.append(cmd)
+
+        class _Result:
+            returncode = 0
+            stdout = "pip 26.1.1"
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(dev, "project_root", lambda: tmp_path)
+    monkeypatch.setattr(dev.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(dev.subprocess, "run", _fake_run)
+
+    assert dev.bootstrap() == 0
+    assert calls[-1] == [
+        str(venv_python),
+        "-m",
+        "pip",
+        "install",
+        "--no-deps",
+        "-e",
+        ".",
+    ]
+
+
+def test_cli_version_comes_from_distribution_metadata(monkeypatch):
+    import cli
+
+    monkeypatch.setattr(cli, "package_version", lambda name: "9.8.7", raising=False)
+
+    assert cli.get_version() == "9.8.7"


### PR DESCRIPTION
## Summary

- switch the build backend to supported `setuptools.build_meta`
- explicitly declare the flat-layout runtime modules/packages included in built distributions
- install the project itself during bootstrap so console entry points are created
- resolve CLI version from installed distribution metadata instead of reading a source-tree `pyproject.toml`
- add a clean wheel build/install workflow on Ubuntu and Windows

## Test-first verification

The packaging regression commit was run before production changes and failed for the three expected reasons:

1. unsupported `setuptools.backends.legacy:build` backend
2. bootstrap stopped after installing the dependency lock and did not install the project
3. `cli.get_version()` did not exist because version reporting depended on a local `pyproject.toml`

During implementation the existing bootstrap fixtures exposed two stale assertions that modeled a directory without project metadata. `install_project()` now safely skips editable installation when `pyproject.toml` is absent, while the packaging regression fixture includes project metadata and verifies the editable install occurs after the lock install.

## Validation

Current head: `985da534f16e9ab0eab2dde103355540bb63697a`

- CI verify: Ubuntu + Windows, Python 3.12 + 3.14 — passed
- CI smoke: Ubuntu + Windows, Python 3.12 + 3.14 — passed
- Package wheel build/install: Ubuntu + Windows, Python 3.12 — passed
- installed import smoke — passed
- installed `ai-model-explorer-cli version` entry point — passed
- CodeRabbit — passed

## Risk

Low-to-moderate. Packaging metadata and bootstrap behavior change, but runtime provider/search logic is untouched. No dependency ranges were changed.