### PR TITLE
fix: honor configured local runtime endpoints

### DIFF
--- a/downloads/download_service.py
+++ b/downloads/download_service.py
@@ -32,14 +32,21 @@ from typing import Any
 
 from loguru import logger
 
+import config
 from config import _default_data_dir
 from downloads.runner import process_job
 from downloads.store import DownloadStore
 
 DB_PATH = _default_data_dir() / "downloads.db"
-HOST = "127.0.0.1"
-PORT = 8765
 SERVICE_VERSION = "1.7"
+
+
+def service_bind_address() -> tuple[str, int]:
+    """Return the configured download-service bind address."""
+    return (
+        config.settings.download_service_host,
+        config.settings.download_service_port,
+    )
 
 
 def smoke_mode_enabled() -> bool:
@@ -164,7 +171,7 @@ def main():
     worker.start()
     STATE.worker_thread = worker
 
-    server = ThreadingHTTPServer((HOST, PORT), Handler)
+    server = ThreadingHTTPServer(service_bind_address(), Handler)
     STATE.server = server
     try:
         server.serve_forever(poll_interval=0.5)
@@ -184,7 +191,8 @@ def run_smoke_check() -> int:
     worker.start()
     STATE.worker_thread = worker
 
-    server = ThreadingHTTPServer((HOST, 0), Handler)
+    host, _ = service_bind_address()
+    server = ThreadingHTTPServer((host, 0), Handler)
     STATE.server = server
     thread = threading.Thread(
         target=server.serve_forever,
@@ -197,7 +205,7 @@ def run_smoke_check() -> int:
 
     try:
         for path, expected_key in (("/health", "ok"), ("/jobs", "jobs")):
-            with urllib.request.urlopen(f"http://{HOST}:{port}{path}", timeout=5) as response:
+            with urllib.request.urlopen(f"http://{host}:{port}{path}", timeout=5) as response:
                 payload = json.loads(response.read().decode("utf-8"))
             if expected_key not in payload:
                 raise SystemExit(f"[smoke] download service check failed for {path}")

--- a/downloads/service_client.py
+++ b/downloads/service_client.py
@@ -5,15 +5,21 @@ import time
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+import config
+
 try:
     import psutil
 except ImportError:  # pragma: no cover - exercised only in lightweight envs
     psutil = None
 
-SERVICE_HOST = "127.0.0.1"
-SERVICE_PORT = 8765
-SERVICE_BASE_URL = f"http://{SERVICE_HOST}:{SERVICE_PORT}"
 MIN_SERVICE_VERSION = "1.7"
+
+
+def service_base_url():
+    """Return the configured download-service base URL."""
+    host = config.settings.download_service_host
+    port = config.settings.download_service_port
+    return f"http://{host}:{port}"
 
 
 def _parse_version(version_str):
@@ -33,7 +39,7 @@ def _request(method, path, payload=None, timeout=2.0):
 
     Raises any network or HTTP errors to the caller.
     """
-    url = f"{SERVICE_BASE_URL}{path}"
+    url = f"{service_base_url()}{path}"
     data = None
     headers = {"Content-Type": "application/json"}
     if payload is not None:

--- a/providers/ollama_provider.py
+++ b/providers/ollama_provider.py
@@ -37,11 +37,14 @@ class OllamaProvider:
         self.installed: list[str] = []
 
     def detect(self) -> bool:
+        """Return whether the configured Ollama API is reachable."""
         try:
-            from core.hardware import check_ollama_running
-
-            return check_ollama_running()
-        except Exception:
+            response = get_session().get(
+                f"{config.settings.ollama_api_base}/api/tags",
+                timeout=1,
+            )
+            return response.status_code == 200
+        except RequestException:
             return False
 
     def refresh_installed(self) -> None:
@@ -85,6 +88,7 @@ class OllamaProvider:
             self.refresh_installed()
         return self.search(query, specs, limit=limit, page=page, **kwargs)
 
+
 _ollama_meta_cache_lock = threading.Lock()
 
 
@@ -98,7 +102,7 @@ _init_ollama_cache()
 def get_installed_ollama_models():
     """Return a list of locally installed Ollama model name prefixes (lowercase).
 
-    Queries the Ollama REST API at ``http://localhost:11434``.
+    Queries the configured Ollama REST API.
     Returns an empty list if Ollama is not running or the request fails.
     """
     try:

--- a/tests/test_runtime_endpoint_configuration.py
+++ b/tests/test_runtime_endpoint_configuration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from urllib.error import URLError
+from requests.exceptions import ConnectionError
 
 
 def test_download_service_client_uses_configured_host_and_port(monkeypatch):
@@ -67,7 +67,7 @@ def test_ollama_detect_returns_false_when_api_unreachable(monkeypatch):
 
     class SessionStub:
         def get(self, url, timeout):
-            raise URLError("offline")
+            raise ConnectionError("offline")
 
     monkeypatch.setattr(ollama_provider, "get_session", lambda: SessionStub())
 

--- a/tests/test_runtime_endpoint_configuration.py
+++ b/tests/test_runtime_endpoint_configuration.py
@@ -1,0 +1,74 @@
+"""Regression tests for configurable local runtime endpoints."""
+
+from __future__ import annotations
+
+from urllib.error import URLError
+
+
+def test_download_service_client_uses_configured_host_and_port(monkeypatch):
+    import config
+    from downloads import service_client
+
+    captured: dict[str, str] = {}
+
+    class ResponseStub:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return b'{"ok": true}'
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        return ResponseStub()
+
+    monkeypatch.setattr(config.settings, "download_service_host", "127.0.0.42")
+    monkeypatch.setattr(config.settings, "download_service_port", 9876)
+    monkeypatch.setattr(service_client, "urlopen", fake_urlopen)
+
+    assert service_client.get_service_health() == {"ok": True}
+    assert captured["url"] == "http://127.0.0.42:9876/health"
+
+
+def test_download_service_bind_address_uses_settings(monkeypatch):
+    import config
+    from downloads import download_service
+
+    monkeypatch.setattr(config.settings, "download_service_host", "127.0.0.43")
+    monkeypatch.setattr(config.settings, "download_service_port", 9988)
+
+    assert download_service.service_bind_address() == ("127.0.0.43", 9988)
+
+
+def test_ollama_detect_uses_configured_api_health(monkeypatch):
+    import config
+    from providers import ollama_provider
+
+    class ResponseStub:
+        status_code = 200
+
+    class SessionStub:
+        def get(self, url, timeout):
+            assert url == "http://ollama-host.test:11434/api/tags"
+            assert timeout == 1
+            return ResponseStub()
+
+    monkeypatch.setattr(config.settings, "ollama_api_base", "http://ollama-host.test:11434")
+    monkeypatch.setattr(ollama_provider, "get_session", lambda: SessionStub())
+
+    assert ollama_provider.OllamaProvider().detect() is True
+
+
+def test_ollama_detect_returns_false_when_api_unreachable(monkeypatch):
+    from providers import ollama_provider
+
+    class SessionStub:
+        def get(self, url, timeout):
+            raise URLError("offline")
+
+    monkeypatch.setattr(ollama_provider, "get_session", lambda: SessionStub())
+
+    assert ollama_provider.OllamaProvider().detect() is False


### PR DESCRIPTION
## Summary

- honor `AIMODEL_DOWNLOAD_SERVICE_HOST` / `AIMODEL_DOWNLOAD_SERVICE_PORT` in the download-service client
- bind the download-service server to the same configured host/port
- detect Ollama through the configured `ollama_api_base` `/api/tags` endpoint instead of requiring a same-OS Ollama process
- add focused endpoint regression tests

## Test-first verification

The regression-only commit was run before production changes and failed for the three expected behaviors:

1. client still requested `http://127.0.0.1:8765` after settings were changed
2. server had no configuration-backed bind-address path
3. `OllamaProvider.detect()` returned false even when the configured API endpoint was mocked reachable

The unreachable Ollama case remained false as expected.

## Validation

Current head: `42ba2068081745cba7937f1965b3791fc216810e`

- CI verify: Ubuntu + Windows, Python 3.12 + 3.14 — passed
- CI smoke: Ubuntu + Windows, Python 3.12 + 3.14 — passed
- Package wheel build/install: Ubuntu + Windows — passed
- installed import + CLI entrypoint smoke — passed
- CodeRabbit — passed

## Risk

Low. Defaults remain unchanged (`127.0.0.1:8765` and `http://localhost:11434`); the patch only makes existing configuration effective and removes process-name coupling from Ollama availability detection.