### PR TITLE
fix: download only the selected Hugging Face GGUF

### DIFF
--- a/downloads/download_manager.py
+++ b/downloads/download_manager.py
@@ -16,14 +16,17 @@ def build_download_command(model):
     """Build the subprocess command list needed to download *model*.
 
     Raises:
-        ValueError: If ``model["source"]`` is not a supported provider.
+        ValueError: If the model is missing required provider download metadata.
     """
     source = model.get("source")
     if source == "Hugging Face":
         repo_id = model.get("id") or model.get("name")
         if not repo_id:
             raise ValueError("missing Hugging Face repository id")
-        return ["hf_api_download", repo_id]
+        target_file = model.get("target_file")
+        if not target_file:
+            raise ValueError("missing Hugging Face target file")
+        return ["hf_api_download", repo_id, target_file]
 
     if source == "Ollama":
         model_name = model.get("name")

--- a/downloads/runner.py
+++ b/downloads/runner.py
@@ -5,7 +5,7 @@ review (candidate #5). Two runners, both consume a ``DownloadStore``
 + the shared ``STATE`` singleton (imported from ``download_service``):
 
 - :func:`run_hf_download`: ``hf_api_download`` sentinel command →
-  HuggingFace snapshot_download via subprocess.
+  one exact Hugging Face file via subprocess.
 - :func:`run_streamed_command`: every other command (e.g. ``ollama
   pull``) → stdout-streamed subprocess.
 
@@ -63,6 +63,26 @@ def _repo_id_from_hf_command(command) -> str:
     return command[1] if len(command) > 1 else ""
 
 
+def _target_file_from_hf_command(command) -> str:
+    """Extract the exact repository filename from an HF API command payload."""
+    if not is_hf_api_command(command):
+        return ""
+    return command[2] if len(command) > 2 else ""
+
+
+def _hf_download_script() -> str:
+    """Return the subprocess script used to download one exact HF file."""
+    return (
+        "from huggingface_hub import hf_hub_download; "
+        "import sys; "
+        "hf_hub_download("
+        "repo_id=sys.argv[1], "
+        "filename=sys.argv[2], "
+        "local_dir='models'"
+        ")"
+    )
+
+
 def _cancel_requested(state, target_id: str) -> bool:
     latest = state.store.get_job_by_target(target_id)
     return bool(latest and latest.get("cancel_requested"))
@@ -100,23 +120,27 @@ def _finalize_terminal(state, target_id: str, return_code, cancelled: bool, *, l
 
 
 def run_hf_download(state, target_id: str, command) -> None:
-    """Run a HuggingFace snapshot_download for *target_id*.
+    """Download the exact Hugging Face target file for *target_id*.
 
-    The HF runner is unique: it inlines a Python ``-c`` script that
-    calls :func:`huggingface_hub.snapshot_download` with
-    ``allow_patterns=['*.gguf']`` and a fixed ``local_dir='models'``.
-    The script receives the repo id as ``argv[1]``.
-
-    The subprocess inherits ``HF_TOKEN`` via
-    :func:`_service_popen_kwargs` so authenticated downloads work
-    when ``AIMODEL_HF_TOKEN`` is configured.
+    The command payload contains the repository id and selected filename.
+    A subprocess calls :func:`huggingface_hub.hf_hub_download` so the
+    existing terminate/kill cancellation behavior remains intact.
     """
     repo_id = _repo_id_from_hf_command(command)
+    target_file = _target_file_from_hf_command(command)
     if not repo_id:
         state.store.update_job(
             target_id,
             status="failed",
             detail="missing Hugging Face repository id",
+            return_code=1,
+        )
+        return
+    if not target_file:
+        state.store.update_job(
+            target_id,
+            status="failed",
+            detail="missing Hugging Face target file",
             return_code=1,
         )
         return
@@ -127,18 +151,8 @@ def run_hf_download(state, target_id: str, command) -> None:
         detail="Downloading",
         progress="",
     )
-    hf_script = (
-        "from huggingface_hub import snapshot_download; "
-        "import sys; "
-        "snapshot_download("
-        "repo_id=sys.argv[1], "
-        "allow_patterns=['*.gguf'], "
-        "local_dir='models', "
-        "local_dir_use_symlinks=False"
-        ")"
-    )
     process = subprocess.Popen(
-        [sys.executable, "-c", hf_script, repo_id],
+        [sys.executable, "-c", _hf_download_script(), repo_id, target_file],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         text=True,

--- a/tests/test_download_service_worker.py
+++ b/tests/test_download_service_worker.py
@@ -101,7 +101,13 @@ class TestClaimNextQueued:
         assert claimed is None
 
     def test_skips_active_jobs(self, store):
-        model = {"source": "Hugging Face", "name": "test/model", "publisher": "test", "id": "test/model"}
+        model = {
+            "source": "Hugging Face",
+            "name": "test/model",
+            "publisher": "test",
+            "id": "test/model",
+            "target_file": "model.Q4_K_M.gguf",
+        }
         job, _ = store.upsert_job(model)
         store.update_job(job["target_id"], status="running", detail="Downloading")
 
@@ -134,7 +140,15 @@ class TestGetJobByTarget:
 class TestListJobs:
     def test_lists_all_jobs(self, store):
         store.upsert_job({"source": "Ollama", "name": "a", "publisher": "ollama"})
-        store.upsert_job({"source": "Hugging Face", "name": "b", "publisher": "x", "id": "b"})
+        store.upsert_job(
+            {
+                "source": "Hugging Face",
+                "name": "b",
+                "publisher": "x",
+                "id": "b",
+                "target_file": "b.Q4_K_M.gguf",
+            }
+        )
         jobs = store.list_jobs(limit=10)
         assert len(jobs) == 2
 

--- a/tests/test_downloads_store.py
+++ b/tests/test_downloads_store.py
@@ -23,12 +23,15 @@ def _make_store(tmp_path):
 
 
 def _make_model(target_id: str = "test/repo", source: str = "Hugging Face", name: str = "test/repo"):
-    return {
+    model = {
         "source": source,
         "publisher": "test",
         "id": target_id,
         "name": name,
     }
+    if source == "Hugging Face":
+        model["target_file"] = "model.Q4_K_M.gguf"
+    return model
 
 
 # ---------------------------------------------------------------------------
@@ -175,7 +178,15 @@ def test_delete_missing_job_returns_not_found(tmp_path):
 def test_normalize_target_ids_collapses_duplicates(tmp_path):
     store = _make_store(tmp_path)
     # Insert two rows that should normalize to the same target_id
-    store.upsert_job({"source": "Hugging Face", "publisher": "x", "id": "owner/repo", "name": "owner/repo"})
+    store.upsert_job(
+        {
+            "source": "Hugging Face",
+            "publisher": "x",
+            "id": "owner/repo",
+            "name": "owner/repo",
+            "target_file": "model.Q4_K_M.gguf",
+        }
+    )
     # Force a different format that should normalize to the same canonical form
     with store.lock, store._connect() as conn:
         conn.execute(

--- a/tests/test_hf_single_file_download.py
+++ b/tests/test_hf_single_file_download.py
@@ -1,0 +1,47 @@
+"""Regression tests for targeted Hugging Face GGUF downloads."""
+
+from __future__ import annotations
+
+import pytest
+
+from downloads.download_manager import build_download_command
+from downloads.runner import _hf_download_script, _target_file_from_hf_command
+
+
+def test_hf_download_command_carries_selected_target_file():
+    model = {
+        "source": "Hugging Face",
+        "id": "Qwen/example-GGUF",
+        "target_file": "example-Q4_K_M.gguf",
+    }
+
+    assert build_download_command(model) == [
+        "hf_api_download",
+        "Qwen/example-GGUF",
+        "example-Q4_K_M.gguf",
+    ]
+
+
+def test_hf_download_command_rejects_missing_target_file():
+    model = {"source": "Hugging Face", "id": "Qwen/example-GGUF"}
+
+    with pytest.raises(ValueError, match="missing Hugging Face target file"):
+        build_download_command(model)
+
+
+def test_hf_runner_extracts_exact_target_file():
+    assert (
+        _target_file_from_hf_command(
+            ["hf_api_download", "Qwen/example-GGUF", "nested/example-Q4_K_M.gguf"]
+        )
+        == "nested/example-Q4_K_M.gguf"
+    )
+
+
+def test_hf_runner_script_downloads_one_exact_file():
+    script = _hf_download_script()
+
+    assert "hf_hub_download" in script
+    assert "filename=sys.argv[2]" in script
+    assert "snapshot_download" not in script
+    assert "*.gguf" not in script


### PR DESCRIPTION
## Status

Draft implementation in progress. Regression tests are committed before production changes.

## Scope

- carry the selected Hugging Face `target_file` into the download job payload
- download that exact file with `hf_hub_download`
- reject new HF download jobs that do not identify a concrete target file
- keep the existing subprocess cancellation architecture
