### PR TITLE
fix: make Hugging Face pagination boundaries exact

### DIFF
--- a/providers/hf_provider.py
+++ b/providers/hf_provider.py
@@ -47,7 +47,7 @@ class HuggingFaceProvider:
         **kwargs,
     ) -> SearchResult:
         offset = page * limit
-        results, errors = search_hf_models(
+        response = search_hf_models(
             query,
             specs,
             self.model_info_cache,
@@ -55,11 +55,19 @@ class HuggingFaceProvider:
             offset=offset,
             hf_token=hf_token,
             lookahead=1,
+            return_page_info=True,
         )
+        if len(response) == 3:
+            results, errors, has_more_pages = response
+        else:
+            # Backward-compatible fallback for patched/test doubles that still
+            # return the historical two-item tuple.
+            results, errors = response
+            has_more_pages = len(results) > limit
         return SearchResult(
             results=results[:limit],
             errors=list(errors),
-            has_more_pages=len(results) > limit,
+            has_more_pages=has_more_pages,
         )
 
     def list_installed(self) -> list[str]:
@@ -150,25 +158,37 @@ def search_hf_models(
     offset=0,
     hf_token=None,
     lookahead=0,
+    return_page_info=False,
 ):
     """Search Hugging Face for GGUF models matching *query*.
+
+    Pagination is based on the raw Hugging Face result window, not the
+    compacted list of successfully parsed models. This keeps page boundaries
+    stable when one model in the current page cannot be parsed.
 
     Args:
         query: Free-text search string.
         specs: Hardware specification dict.
         model_info_cache: Shared ``{repo_id: HfApi.model_info}`` cache dict.
         limit: Maximum number of page results requested.
-        offset: Number of results to skip (for pagination).
+        offset: Number of raw results to skip (for pagination).
         hf_token: Optional HuggingFace API token for higher rate limits.
-        lookahead: Extra results to fetch after the page for boundary detection.
+        lookahead: Extra raw results to fetch after the page for boundary detection.
+        return_page_info: Include a third ``has_more_pages`` value when true.
 
     Returns:
-        ``(results: list[dict], errors: list[str])``.
+        Normally ``(results, errors)`` for backward compatibility. When
+        ``return_page_info`` is true, returns ``(results, errors, has_more_pages)``.
     """
     results = []
     errors = []
     found_keys = set()
     window_size = limit + max(int(lookahead), 0)
+
+    def _return(has_more_pages=False):
+        if return_page_info:
+            return results, errors, has_more_pages
+        return results, errors
 
     try:
         api = HfApi(token=hf_token) if hf_token else HfApi()
@@ -179,16 +199,21 @@ def search_hf_models(
             filter="gguf",
             expand=["likes", "siblings", "downloads"],
         )
-        hf_models = list(hf_models_iter)[offset : offset + window_size]
+        raw_window = list(hf_models_iter)[offset : offset + window_size]
     except HfHubHTTPError as exc:
-        msg = _format_hf_http_error(exc)
-        return results, [msg]
+        errors.append(_format_hf_http_error(exc))
+        return _return()
     except RequestException as exc:
-        return results, [f"Hugging Face search failed: {exc}"]
+        errors.append(f"Hugging Face search failed: {exc}")
+        return _return()
     except (ValueError, OSError) as exc:
-        return results, [f"Hugging Face search failed: {exc}"]
+        errors.append(f"Hugging Face search failed: {exc}")
+        return _return()
 
-    for model in hf_models:
+    has_more_pages = len(raw_window) > limit
+    page_models = raw_window[:limit]
+
+    for model in page_models:
         try:
             repo_id = _repo_id_from_model(model)
             if not repo_id:
@@ -258,7 +283,7 @@ def search_hf_models(
         ) as exc:
             errors.append(f"Hugging Face model parse failed: {exc}")
 
-    return results, errors
+    return _return(has_more_pages)
 
 
 def enrich_hf_model_details(model, specs, model_info_cache):

--- a/providers/hf_provider.py
+++ b/providers/hf_provider.py
@@ -54,11 +54,12 @@ class HuggingFaceProvider:
             limit=limit,
             offset=offset,
             hf_token=hf_token,
+            lookahead=1,
         )
         return SearchResult(
-            results=results,
+            results=results[:limit],
             errors=list(errors),
-            has_more_pages=len(results) >= limit,
+            has_more_pages=len(results) > limit,
         )
 
     def list_installed(self) -> list[str]:
@@ -148,6 +149,7 @@ def search_hf_models(
     limit=15,
     offset=0,
     hf_token=None,
+    lookahead=0,
 ):
     """Search Hugging Face for GGUF models matching *query*.
 
@@ -155,27 +157,29 @@ def search_hf_models(
         query: Free-text search string.
         specs: Hardware specification dict.
         model_info_cache: Shared ``{repo_id: HfApi.model_info}`` cache dict.
-        limit: Maximum number of results to return per page.
+        limit: Maximum number of page results requested.
         offset: Number of results to skip (for pagination).
         hf_token: Optional HuggingFace API token for higher rate limits.
+        lookahead: Extra results to fetch after the page for boundary detection.
 
     Returns:
-        ``(results: list[dict], errors: list[str], total_count: int)``.
+        ``(results: list[dict], errors: list[str])``.
     """
     results = []
     errors = []
     found_keys = set()
+    window_size = limit + max(int(lookahead), 0)
 
     try:
         api = HfApi(token=hf_token) if hf_token else HfApi()
         hf_models_iter = api.list_models(
             search=query,
             sort="downloads",
-            limit=limit * 10,
+            limit=offset + window_size,
             filter="gguf",
             expand=["likes", "siblings", "downloads"],
         )
-        hf_models = list(hf_models_iter)[offset : offset + limit]
+        hf_models = list(hf_models_iter)[offset : offset + window_size]
     except HfHubHTTPError as exc:
         msg = _format_hf_http_error(exc)
         return results, [msg]

--- a/tests/test_hf_pagination_boundary.py
+++ b/tests/test_hf_pagination_boundary.py
@@ -39,10 +39,10 @@ def test_parse_failure_does_not_pull_lookahead_into_current_page():
     class FakeModel:
         likes = 0
         downloads = 0
-        siblings = []
 
         def __init__(self, model_id):
             self.modelId = model_id
+            self.siblings = []
 
     raw_models = [
         FakeModel(None),

--- a/tests/test_hf_pagination_boundary.py
+++ b/tests/test_hf_pagination_boundary.py
@@ -4,7 +4,13 @@ from providers.hf_provider import HuggingFaceProvider
 
 
 def _specs():
-    return {"has_gpu": False, "vram_total": 0.0, "vram_free": 0.0, "ram_total": 16.0, "ram_free": 16.0}
+    return {
+        "has_gpu": False,
+        "vram_total": 0.0,
+        "vram_free": 0.0,
+        "ram_total": 16.0,
+        "ram_free": 16.0,
+    }
 
 
 def _results(count):
@@ -26,4 +32,35 @@ def test_lookahead_result_reports_more_and_is_not_exposed():
         result = provider.search("test", _specs(), limit=5, page=2)
 
     assert len(result.results) == 5
+    assert result.has_more_pages is True
+
+
+def test_parse_failure_does_not_pull_lookahead_into_current_page():
+    class FakeModel:
+        likes = 0
+        downloads = 0
+        siblings = []
+
+        def __init__(self, model_id):
+            self.modelId = model_id
+
+    raw_models = [
+        FakeModel(None),
+        FakeModel("test/model-1"),
+        FakeModel("test/model-2"),
+        FakeModel("test/model-3"),
+        FakeModel("test/model-4"),
+        FakeModel("test/model-5"),
+    ]
+
+    provider = HuggingFaceProvider(model_info_cache={})
+    with patch("providers.hf_provider.HfApi.list_models", return_value=raw_models):
+        result = provider.search("test", _specs(), limit=5, page=0)
+
+    assert [item["id"] for item in result.results] == [
+        "test/model-1",
+        "test/model-2",
+        "test/model-3",
+        "test/model-4",
+    ]
     assert result.has_more_pages is True

--- a/tests/test_hf_pagination_boundary.py
+++ b/tests/test_hf_pagination_boundary.py
@@ -4,6 +4,7 @@ from providers.hf_provider import HuggingFaceProvider
 
 
 def _specs():
+    """Return minimal hardware specs for deterministic provider tests."""
     return {
         "has_gpu": False,
         "vram_total": 0.0,
@@ -14,10 +15,12 @@ def _specs():
 
 
 def _results(count):
+    """Build simple parsed-result dictionaries for pagination stubs."""
     return [{"id": f"test/model-{i}"} for i in range(count)]
 
 
 def test_exact_full_final_page_does_not_report_more_pages():
+    """A full final page must not imply another page without lookahead."""
     provider = HuggingFaceProvider(model_info_cache={})
     with patch("providers.hf_provider.search_hf_models", return_value=(_results(5), [])):
         result = provider.search("test", _specs(), limit=5, page=2)
@@ -27,6 +30,7 @@ def test_exact_full_final_page_does_not_report_more_pages():
 
 
 def test_lookahead_result_reports_more_and_is_not_exposed():
+    """One lookahead item should enable Next without leaking into results."""
     provider = HuggingFaceProvider(model_info_cache={})
     with patch("providers.hf_provider.search_hf_models", return_value=(_results(6), [])):
         result = provider.search("test", _specs(), limit=5, page=2)
@@ -36,6 +40,8 @@ def test_lookahead_result_reports_more_and_is_not_exposed():
 
 
 def test_parse_failure_does_not_pull_lookahead_into_current_page():
+    """A failed parse inside the page must not shift the raw page boundary."""
+
     class FakeModel:
         likes = 0
         downloads = 0

--- a/tests/test_hf_pagination_boundary.py
+++ b/tests/test_hf_pagination_boundary.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from providers.hf_provider import HuggingFaceProvider
+
+
+def _specs():
+    return {"has_gpu": False, "vram_total": 0.0, "vram_free": 0.0, "ram_total": 16.0, "ram_free": 16.0}
+
+
+def _results(count):
+    return [{"id": f"test/model-{i}"} for i in range(count)]
+
+
+def test_exact_full_final_page_does_not_report_more_pages():
+    provider = HuggingFaceProvider(model_info_cache={})
+    with patch("providers.hf_provider.search_hf_models", return_value=(_results(5), [])):
+        result = provider.search("test", _specs(), limit=5, page=2)
+
+    assert len(result.results) == 5
+    assert result.has_more_pages is False
+
+
+def test_lookahead_result_reports_more_and_is_not_exposed():
+    provider = HuggingFaceProvider(model_info_cache={})
+    with patch("providers.hf_provider.search_hf_models", return_value=(_results(6), [])):
+        result = provider.search("test", _specs(), limit=5, page=2)
+
+    assert len(result.results) == 5
+    assert result.has_more_pages is True


### PR DESCRIPTION
## Status

Draft implementation in progress. Boundary regression tests are committed before production changes.

## Scope

- distinguish a full final page from a page that actually has another result
- use one-item lookahead without exposing that extra item to callers
- keep page size and existing search result shape unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Hugging Face model search pagination.
  - Correctly indicates when additional results are available, including at page boundaries.
  - Prevents lookahead results from appearing in the current page.
- **Tests**
  - Added coverage for final-page and additional-results pagination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->