### PR TITLE
fix: validate REST API query parameters

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -35,6 +35,8 @@ from providers.ollama_provider import get_installed_ollama_models, search_ollama
 API_VERSION = "1.0"
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8787
+VALID_MODEL_PROVIDERS = {"all", "ollama", "huggingface"}
+MAX_MODEL_LIMIT = 100
 
 
 def smoke_mode_enabled() -> bool:
@@ -121,10 +123,23 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
     def _handle_models(self, params):
         query = params.get("search", [""])[0]
         provider = params.get("provider", ["all"])[0].lower()
+        if provider not in VALID_MODEL_PROVIDERS:
+            return self._error(
+                f"Invalid 'provider' parameter '{provider}'; expected one of: "
+                f"{', '.join(sorted(VALID_MODEL_PROVIDERS))}.",
+                400,
+            )
+
         try:
             limit = int(params.get("limit", ["20"])[0])
         except (ValueError, IndexError):
             return self._error("Invalid 'limit' parameter; expected integer.", 400)
+        if not 1 <= limit <= MAX_MODEL_LIMIT:
+            return self._error(
+                f"Invalid 'limit' parameter; expected integer between 1 and {MAX_MODEL_LIMIT}.",
+                400,
+            )
+
         min_fit = params.get("min_fit", ["all"])[0].lower()
         use_case = params.get("use_case", ["all"])[0].lower()
         sort_by = params.get("sort", ["composite"])[0].lower()
@@ -217,6 +232,9 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
             context = int(params.get("context", ["4096"])[0])
         except (ValueError, IndexError):
             return self._error("Invalid 'context' parameter; expected integer.", 400)
+        if context <= 0:
+            return self._error("Invalid 'context' parameter; expected a positive integer.", 400)
+
         plans = plan_hardware_for_model(model_name, target_context=context)
         self._json_response(
             {

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -3,6 +3,7 @@
 import json
 import threading
 import time
+import urllib.error
 import urllib.request
 from unittest.mock import patch
 
@@ -91,6 +92,16 @@ def _get(path, port):
         return json.loads(resp.read().decode())
 
 
+def _get_error(path, port):
+    """Return the JSON body and status code for an expected HTTP error."""
+    url = f"http://{DEFAULT_HOST}:{port}{path}"
+    req = urllib.request.Request(url)
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(req, timeout=5)
+    payload = json.loads(exc_info.value.read().decode())
+    return exc_info.value.code, payload
+
+
 class TestHealthEndpoint:
     def test_health_ok(self, api_server):
         _, port = api_server
@@ -136,6 +147,20 @@ class TestModelsEndpoint:
             assert "quality" in model["scores"]
             assert "composite" in model["scores"]
 
+    @pytest.mark.parametrize("provider", ["unknown", "docker", "mlx"])
+    def test_models_reject_unknown_provider(self, api_server, provider):
+        _, port = api_server
+        status, data = _get_error(f"/api/v1/models?provider={provider}", port)
+        assert status == 400
+        assert "provider" in data["error"].lower()
+
+    @pytest.mark.parametrize("limit", ["0", "-1", "101"])
+    def test_models_reject_out_of_range_limit(self, api_server, limit):
+        _, port = api_server
+        status, data = _get_error(f"/api/v1/models?limit={limit}", port)
+        assert status == 400
+        assert "limit" in data["error"].lower()
+
 
 class TestPlanEndpoint:
     def test_plan_returns_hardware_requirements(self, api_server):
@@ -149,6 +174,13 @@ class TestPlanEndpoint:
         _, port = api_server
         data = _get("/api/v1/models/llama-3-8b/plan?context=32768", port)
         assert data["context_length"] == 32768
+
+    @pytest.mark.parametrize("context", ["0", "-1"])
+    def test_plan_rejects_non_positive_context(self, api_server, context):
+        _, port = api_server
+        status, data = _get_error(f"/api/v1/models/llama-3-8b/plan?context={context}", port)
+        assert status == 400
+        assert "context" in data["error"].lower()
 
 
 class TestScoresEndpoint:


### PR DESCRIPTION
## Status

Draft test-first implementation. Regression tests are committed before production changes.

## Scope

- reject unsupported `provider` values with HTTP 400
- require `limit` to stay within 1..100
- reject non-positive model-plan `context`
- keep existing response shape and provider/search behavior unchanged

`page` is intentionally out of scope because the current REST API does not expose a page parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for model provider and result limit parameters, returning clear errors for invalid values.
  * Added validation to reject non-positive context values when generating plans.
  * Invalid API requests now receive a 400 response instead of being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->