### PR TITLE
fix: return promptly after search cancellation

### DIFF
--- a/search/search_orchestrator.py
+++ b/search/search_orchestrator.py
@@ -125,10 +125,9 @@ class SearchOrchestrator:
         ``ollama_page_size`` defaults to ``page_size`` when omitted.
         The orchestrator submits one task per provider to a small
         thread pool (4 workers, sufficient for the 5-provider fan-out).
-        Cancellation is polled both at submission time and between
-        ``as_completed`` yields, so a search that takes 30 seconds
-        is cancelled within 0.25 seconds of ``cancel_check()``
-        returning True.
+        Cancellation is checked before provider work and whenever a
+        provider completes; once observed, the orchestrator returns
+        without waiting for still-running provider workers to finish.
         """
         if self.cancel_check():
             return SearchOutcome(providers=list(providers), cancelled=True)
@@ -173,7 +172,9 @@ class SearchOrchestrator:
             return SearchResult.empty()
 
         futures: dict = {}
-        with ThreadPoolExecutor(max_workers=4) as pool:
+        pool = ThreadPoolExecutor(max_workers=4)
+        wait_for_workers = True
+        try:
             if "ollama" in providers:
                 futures[pool.submit(_search_ollama)] = "ollama"
             if "huggingface" in providers:
@@ -186,6 +187,7 @@ class SearchOrchestrator:
             for future in as_completed(futures):
                 if self.cancel_check():
                     partial_results = ollama_results + hf_results + extra_results
+                    wait_for_workers = False
                     return SearchOutcome(
                         results=partial_results,
                         errors=ollama_errors + hf_errors + extra_errors,
@@ -214,6 +216,8 @@ class SearchOrchestrator:
                 else:
                     extra_results.extend(result.results)
                     extra_errors.extend(result.errors)
+        finally:
+            pool.shutdown(wait=wait_for_workers, cancel_futures=not wait_for_workers)
 
         if self.cancel_check():
             partial_results = ollama_results + hf_results + extra_results

--- a/tests/test_search_cancellation_shutdown.py
+++ b/tests/test_search_cancellation_shutdown.py
@@ -1,0 +1,70 @@
+"""Regression coverage for prompt search cancellation shutdown."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from providers import SearchResult
+from search.search_orchestrator import SearchOrchestrator
+
+
+class _Monitor:
+    def get_specs(self):
+        return {"has_gpu": False, "ram_total": 16.0}
+
+
+class _FastOllama:
+    def search_with_installed(self, query, specs, limit=15, *, page=0):
+        return SearchResult(results=[{"id": "fast"}])
+
+
+class _BlockingHF:
+    def __init__(self, release: threading.Event):
+        self.release = release
+
+    def search(self, query, specs, limit=15, *, page=0, hf_token=None):
+        self.release.wait(timeout=2)
+        return SearchResult(results=[{"id": "slow"}])
+
+
+def test_mid_search_cancel_does_not_wait_for_running_provider():
+    """Cancellation should return before an already-running provider finishes."""
+    release = threading.Event()
+    fast_completed = threading.Event()
+
+    class _FastOllamaWithSignal(_FastOllama):
+        def search_with_installed(self, query, specs, limit=15, *, page=0):
+            result = super().search_with_installed(query, specs, limit=limit, page=page)
+            fast_completed.set()
+            return result
+
+    def cancel_check():
+        return fast_completed.is_set()
+
+    orchestrator = SearchOrchestrator(
+        monitor=_Monitor(),
+        hf_provider=_BlockingHF(release),
+        ollama_provider=_FastOllamaWithSignal(),
+        on_progress=lambda *_: None,
+        cancel_check=cancel_check,
+    )
+
+    timer = threading.Timer(0.75, release.set)
+    timer.start()
+    started = time.monotonic()
+    try:
+        outcome = orchestrator.search(
+            search_id=1,
+            query="test",
+            providers=["ollama", "huggingface"],
+            page=0,
+            page_size=10,
+        )
+    finally:
+        elapsed = time.monotonic() - started
+        release.set()
+        timer.cancel()
+
+    assert outcome.cancelled is True
+    assert elapsed < 0.4

--- a/tests/test_search_cancellation_shutdown.py
+++ b/tests/test_search_cancellation_shutdown.py
@@ -14,38 +14,36 @@ class _Monitor:
         return {"has_gpu": False, "ram_total": 16.0}
 
 
-class _FastOllama:
-    def search_with_installed(self, query, specs, limit=15, *, page=0):
-        return SearchResult(results=[{"id": "fast"}])
-
-
 class _BlockingHF:
-    def __init__(self, release: threading.Event):
+    def __init__(self, started: threading.Event, release: threading.Event):
+        self.started = started
         self.release = release
 
     def search(self, query, specs, limit=15, *, page=0, hf_token=None):
+        self.started.set()
         self.release.wait(timeout=2)
         return SearchResult(results=[{"id": "slow"}])
 
 
 def test_mid_search_cancel_does_not_wait_for_running_provider():
     """Cancellation should return before an already-running provider finishes."""
+    hf_started = threading.Event()
     release = threading.Event()
     fast_completed = threading.Event()
 
-    class _FastOllamaWithSignal(_FastOllama):
+    class _FastOllama:
         def search_with_installed(self, query, specs, limit=15, *, page=0):
-            result = super().search_with_installed(query, specs, limit=limit, page=page)
+            assert hf_started.wait(timeout=1)
             fast_completed.set()
-            return result
+            return SearchResult(results=[{"id": "fast"}])
 
     def cancel_check():
         return fast_completed.is_set()
 
     orchestrator = SearchOrchestrator(
         monitor=_Monitor(),
-        hf_provider=_BlockingHF(release),
-        ollama_provider=_FastOllamaWithSignal(),
+        hf_provider=_BlockingHF(hf_started, release),
+        ollama_provider=_FastOllama(),
         on_progress=lambda *_: None,
         cancel_check=cancel_check,
     )


### PR DESCRIPTION
## Status

Draft test-first implementation. The regression test is committed before production changes.

## Scope

- reproduce cancellation detected after one provider completes while another provider is still running
- ensure `SearchOrchestrator.search()` returns promptly instead of waiting for executor context shutdown
- keep provider result merging, error handling, and normal successful shutdown behavior unchanged

Out of scope: adding active interruption to provider HTTP calls or redesigning cancellation polling frequency.