### PR TITLE
feat: define canonical provider capabilities

### DIFF
--- a/providers/capabilities.py
+++ b/providers/capabilities.py
@@ -1,0 +1,59 @@
+"""Canonical capability metadata for model providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """Describe behavior that callers may rely on for one provider."""
+
+    slug: str
+    display_name: str
+    searchable: bool = True
+    detectable: bool = True
+    lists_installed: bool = False
+    downloadable: bool = False
+    paginated: bool = False
+
+
+_PROVIDER_CAPABILITIES: dict[str, ProviderCapabilities] = {
+    "huggingface": ProviderCapabilities(
+        slug="huggingface",
+        display_name="Hugging Face",
+        downloadable=True,
+        paginated=True,
+    ),
+    "ollama": ProviderCapabilities(
+        slug="ollama",
+        display_name="Ollama",
+        lists_installed=True,
+        downloadable=True,
+    ),
+    "lmstudio": ProviderCapabilities(
+        slug="lmstudio",
+        display_name="LM Studio",
+        lists_installed=True,
+    ),
+    "docker": ProviderCapabilities(
+        slug="docker",
+        display_name="Docker",
+        lists_installed=True,
+    ),
+    "mlx": ProviderCapabilities(
+        slug="mlx",
+        display_name="MLX",
+        lists_installed=True,
+    ),
+}
+
+
+def get_provider_capabilities(slug: str) -> ProviderCapabilities:
+    """Return capability metadata for *slug* or raise ``KeyError``."""
+    return _PROVIDER_CAPABILITIES[slug]
+
+
+def get_all_provider_capabilities() -> dict[str, ProviderCapabilities]:
+    """Return a copy of the provider capability registry."""
+    return dict(_PROVIDER_CAPABILITIES)

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -1,0 +1,45 @@
+"""Regression tests for canonical provider capability metadata."""
+
+from providers import get_all_provider_classes
+from providers.capabilities import get_all_provider_capabilities, get_provider_capabilities
+
+
+def test_capability_registry_covers_all_registered_providers():
+    """Every provider class exposed by the registry must have capability metadata."""
+    registered_slugs = {provider_cls.slug for provider_cls in get_all_provider_classes()}
+    capability_slugs = set(get_all_provider_capabilities())
+
+    assert registered_slugs == capability_slugs
+
+
+def test_download_capabilities_match_current_download_manager_support():
+    """Only Hugging Face and Ollama currently have download command support."""
+    downloadable = {
+        slug
+        for slug, capabilities in get_all_provider_capabilities().items()
+        if capabilities.downloadable
+    }
+
+    assert downloadable == {"huggingface", "ollama"}
+
+
+def test_only_huggingface_has_real_page_offset_semantics():
+    """Pagination means a page changes the remote/raw result window, not just truncation."""
+    paginated = {
+        slug
+        for slug, capabilities in get_all_provider_capabilities().items()
+        if capabilities.paginated
+    }
+
+    assert paginated == {"huggingface"}
+
+
+def test_huggingface_has_no_local_installed_listing():
+    """Hugging Face discovery is remote and has no provider-local install inventory."""
+    assert get_provider_capabilities("huggingface").lists_installed is False
+
+
+def test_local_runtime_providers_list_installed_models():
+    """Runtime/cache-backed providers expose local model inventories."""
+    for slug in ("ollama", "lmstudio", "docker", "mlx"):
+        assert get_provider_capabilities(slug).lists_installed is True


### PR DESCRIPTION
## Scope

- add a single capability model for provider behavior
- cover all registered providers with capability metadata
- record download support, installed-model listing, detection/search support, and real pagination semantics
- add regression tests preventing registry drift

This PR intentionally does not yet rewire CLI/TUI/API behavior. It establishes the canonical metadata contract first so those surfaces can consume it in a follow-up without mixing architecture and behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized capability information for supported providers, including Hugging Face, Ollama, LM Studio, Docker, and MLX.
  * Provider details now indicate available features such as downloads, pagination, and locally installed model support.
  * Added consistent access to provider capability information for integrations and user interfaces.

* **Tests**
  * Added coverage to verify provider capabilities remain aligned with supported providers and expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->