### PR TITLE
fix: expose provider capabilities in REST API

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -29,6 +29,8 @@ from core.utils import (
     extract_params,
     infer_quant_from_name,
 )
+from providers import detect_available_providers
+from providers.capabilities import get_all_provider_capabilities
 from providers.hf_provider import search_hf_models
 from providers.ollama_provider import get_installed_ollama_models, search_ollama_models
 
@@ -37,6 +39,13 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8787
 VALID_MODEL_PROVIDERS = {"all", "ollama", "huggingface"}
 MAX_MODEL_LIMIT = 100
+PROVIDER_API_BASES = {
+    "huggingface": "https://huggingface.co",
+    "ollama": "http://localhost:11434",
+    "lmstudio": "http://localhost:1234",
+    "docker": "http://localhost:12434",
+    "mlx": "local",
+}
 
 
 def smoke_mode_enabled() -> bool:
@@ -46,7 +55,6 @@ def smoke_mode_enabled() -> bool:
 class ModelAPIHandler(BaseHTTPRequestHandler):
     """HTTP request handler for the model API."""
 
-    # Shared state (set by server startup)
     monitor: HardwareMonitor = None  # type: ignore[assignment]
 
     def log_message(self, format, *args):
@@ -151,7 +159,6 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
         specs = self.monitor.get_specs()
         results = []
 
-        # Search providers
         if provider in ("all", "ollama"):
             local = get_installed_ollama_models()
             ollama_results, _, _ = search_ollama_models(query or "*", specs, local, page_size=limit)
@@ -161,13 +168,11 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
             hf_results, _ = search_hf_models(query or "*", specs, {}, limit=limit)
             results.extend(hf_results)
 
-        # Filter
         if use_case != "all":
             results = [r for r in results if r.get("use_case_key") == use_case]
         if min_fit != "all":
             results = [r for r in results if min_fit in r.get("fit", "").lower()]
 
-        # Sort
         if sort_by == "composite":
             results.sort(key=lambda r: r.get("score_composite", 0), reverse=True)
         elif sort_by == "speed":
@@ -177,7 +182,6 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
         elif sort_by == "name":
             results.sort(key=lambda r: r.get("name", "").lower())
 
-        # Serialize
         models = []
         for r in results[:limit]:
             models.append(
@@ -222,7 +226,6 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
         except (ValueError, IndexError):
             return self._error("Invalid 'limit' parameter; expected integer.", 400)
 
-        # Forward to models endpoint with composite sort
         params["sort"] = ["composite"]
         params["limit"] = [str(limit)]
         self._handle_models(params)
@@ -280,25 +283,27 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
         )
 
     def _handle_providers(self):
+        """Return provider availability plus canonical capability metadata."""
+        availability = detect_available_providers()
         providers = []
-        # Check Ollama
-        from core.hardware import check_ollama_running
 
-        providers.append(
-            {
-                "name": "ollama",
-                "available": check_ollama_running(),
-                "api_base": "http://localhost:11434",
-            }
-        )
-        # HuggingFace always available
-        providers.append(
-            {
-                "name": "huggingface",
-                "available": True,
-                "api_base": "https://huggingface.co",
-            }
-        )
+        for slug, capabilities in get_all_provider_capabilities().items():
+            providers.append(
+                {
+                    "name": slug,
+                    "display_name": capabilities.display_name,
+                    "available": availability.get(slug, False),
+                    "api_base": PROVIDER_API_BASES.get(slug, ""),
+                    "capabilities": {
+                        "searchable": capabilities.searchable,
+                        "detectable": capabilities.detectable,
+                        "lists_installed": capabilities.lists_installed,
+                        "downloadable": capabilities.downloadable,
+                        "paginated": capabilities.paginated,
+                    },
+                }
+            )
+
         self._json_response({"providers": providers})
 
 

--- a/api_server.py
+++ b/api_server.py
@@ -55,6 +55,7 @@ def smoke_mode_enabled() -> bool:
 class ModelAPIHandler(BaseHTTPRequestHandler):
     """HTTP request handler for the model API."""
 
+    # Shared state (set by server startup)
     monitor: HardwareMonitor = None  # type: ignore[assignment]
 
     def log_message(self, format, *args):
@@ -159,6 +160,7 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
         specs = self.monitor.get_specs()
         results = []
 
+        # Search providers
         if provider in ("all", "ollama"):
             local = get_installed_ollama_models()
             ollama_results, _, _ = search_ollama_models(query or "*", specs, local, page_size=limit)
@@ -168,11 +170,13 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
             hf_results, _ = search_hf_models(query or "*", specs, {}, limit=limit)
             results.extend(hf_results)
 
+        # Filter
         if use_case != "all":
             results = [r for r in results if r.get("use_case_key") == use_case]
         if min_fit != "all":
             results = [r for r in results if min_fit in r.get("fit", "").lower()]
 
+        # Sort
         if sort_by == "composite":
             results.sort(key=lambda r: r.get("score_composite", 0), reverse=True)
         elif sort_by == "speed":
@@ -182,6 +186,7 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
         elif sort_by == "name":
             results.sort(key=lambda r: r.get("name", "").lower())
 
+        # Serialize
         models = []
         for r in results[:limit]:
             models.append(
@@ -226,6 +231,7 @@ class ModelAPIHandler(BaseHTTPRequestHandler):
         except (ValueError, IndexError):
             return self._error("Invalid 'limit' parameter; expected integer.", 400)
 
+        # Forward to models endpoint with composite sort
         params["sort"] = ["composite"]
         params["limit"] = [str(limit)]
         self._handle_models(params)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from api_server import DEFAULT_HOST, create_server
+from providers.capabilities import get_all_provider_capabilities
 
 
 @pytest.fixture(scope="module")
@@ -70,6 +71,16 @@ def api_server():
         patch("api_server.search_ollama_models", side_effect=fake_search_ollama_models),
         patch("api_server.search_hf_models", side_effect=fake_search_hf_models),
         patch("api_server.get_installed_ollama_models", return_value=[]),
+        patch(
+            "api_server.detect_available_providers",
+            return_value={
+                "huggingface": True,
+                "ollama": False,
+                "lmstudio": True,
+                "docker": False,
+                "mlx": False,
+            },
+        ),
     ]
     for p in patchers:
         p.start()
@@ -198,3 +209,26 @@ class TestProvidersEndpoint:
         data = _get("/api/v1/providers", port)
         assert "providers" in data
         assert len(data["providers"]) >= 1
+
+    def test_providers_cover_canonical_registry(self, api_server):
+        """The API should expose every provider in the canonical capability registry."""
+        _, port = api_server
+        data = _get("/api/v1/providers", port)
+        names = {provider["name"] for provider in data["providers"]}
+        assert names == set(get_all_provider_capabilities())
+
+    def test_providers_expose_canonical_capabilities(self, api_server):
+        """Each API provider entry should mirror its canonical capability flags."""
+        _, port = api_server
+        data = _get("/api/v1/providers", port)
+        by_name = {provider["name"]: provider for provider in data["providers"]}
+
+        for slug, capabilities in get_all_provider_capabilities().items():
+            assert by_name[slug]["display_name"] == capabilities.display_name
+            assert by_name[slug]["capabilities"] == {
+                "searchable": capabilities.searchable,
+                "detectable": capabilities.detectable,
+                "lists_installed": capabilities.lists_installed,
+                "downloadable": capabilities.downloadable,
+                "paginated": capabilities.paginated,
+            }

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -205,6 +205,7 @@ class TestScoresEndpoint:
 
 class TestProvidersEndpoint:
     def test_providers_returns_list(self, api_server):
+        """The providers endpoint should return a non-empty provider list."""
         _, port = api_server
         data = _get("/api/v1/providers", port)
         assert "providers" in data


### PR DESCRIPTION
## Scope

- drive `/api/v1/providers` from the canonical provider capability registry
- expose all canonical providers with `name`, `display_name`, `available`, `api_base`, and capability flags
- preserve the existing `name`, `available`, and `api_base` fields
- keep `/api/v1/models` search-provider support unchanged in this PR
- add regression coverage for registry completeness and capability parity

This is the first consumer of the provider capability contract merged in #10. CLI/TUI adoption remains a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model listings can now be filtered by use case and minimum fitness criteria.
  - Provider information now includes availability and standardized capability details.
  - Provider support information covers Hugging Face, Ollama, LM Studio, Docker, and MLX.
  - The providers endpoint now presents consistent capability data across all supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->