### PR TITLE
fix: align CLI provider choices with capabilities

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,8 +9,23 @@ import config
 from core import cache_db
 from core.hardware import HardwareMonitor, check_ollama_running
 from downloads.service_client import get_service_health
+from providers.capabilities import get_all_provider_capabilities
 
 console = Console()
+
+
+_CLI_SEARCH_PROVIDER_ORDER = ("ollama", "huggingface")
+
+
+def get_cli_search_provider_choices() -> tuple[str, ...]:
+    """Return CLI search choices validated against canonical provider metadata."""
+    capabilities = get_all_provider_capabilities()
+    supported = tuple(
+        slug
+        for slug in _CLI_SEARCH_PROVIDER_ORDER
+        if slug in capabilities and capabilities[slug].searchable
+    )
+    return ("all", *supported)
 
 
 def get_version() -> str:
@@ -81,7 +96,10 @@ def system_info():
 @cli.command()
 @click.argument("query")
 @click.option(
-    "--provider", "-p", type=click.Choice(["ollama", "huggingface", "all"]), default="all"
+    "--provider",
+    "-p",
+    type=click.Choice(get_cli_search_provider_choices()),
+    default="all",
 )
 @click.option("--limit", "-n", default=10, help="Max results")
 @click.option(

--- a/tests/test_cli_provider_capabilities.py
+++ b/tests/test_cli_provider_capabilities.py
@@ -1,0 +1,20 @@
+"""Regression tests for CLI provider choices backed by canonical metadata."""
+
+from cli import get_cli_search_provider_choices
+from providers.capabilities import get_all_provider_capabilities
+
+
+def test_cli_search_provider_choices_preserve_current_surface_support():
+    """CLI search should still expose only implemented providers plus ``all``."""
+    assert get_cli_search_provider_choices() == ("all", "ollama", "huggingface")
+
+
+def test_cli_search_provider_choices_reference_canonical_searchable_providers():
+    """Every CLI provider choice must exist in canonical metadata and be searchable."""
+    capabilities = get_all_provider_capabilities()
+
+    for slug in get_cli_search_provider_choices():
+        if slug == "all":
+            continue
+        assert slug in capabilities
+        assert capabilities[slug].searchable is True


### PR DESCRIPTION
## Scope

- derive CLI `search --provider` choices through canonical provider capability metadata
- preserve current CLI search support: `all`, `ollama`, `huggingface`
- do not expose LM Studio, Docker, or MLX in CLI search until their execution path is implemented
- add regression tests that ensure CLI choices exist in canonical metadata and remain searchable

This PR consumes the provider capability contract without broadening CLI behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `search --provider` option now offers provider choices based on supported search capabilities.
  - Provider choices preserve the configured order and include only searchable providers.

- **Bug Fixes**
  - Prevented unsupported or non-searchable providers from appearing as search options.

- **Tests**
  - Added coverage to verify provider choices remain accurate and consistent with supported capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->