### PR TITLE
fix: align TUI provider selector with capabilities

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -15,6 +15,7 @@ from loguru import logger
 from typing import Any
 
 from providers.base import SearchResult
+from providers.capabilities import get_all_provider_capabilities
 
 
 class BaseProvider(ABC):
@@ -153,29 +154,21 @@ def detect_available_providers() -> dict[str, bool]:
 
 
 def get_provider_display_names() -> dict[str, str]:
-    """Return mapping of provider slug to display name."""
-    names = {
-        "ollama": "Ollama",
-        "huggingface": "Hugging Face",
+    """Return mapping of provider slug to canonical display name."""
+    return {
+        slug: capabilities.display_name
+        for slug, capabilities in get_all_provider_capabilities().items()
     }
-
-    for provider_cls in get_all_provider_classes():
-        with suppress(Exception):
-            names[provider_cls.slug] = provider_cls.display_name
-
-    return names
 
 
 def get_provider_filter_labels() -> list[str]:
-    """Return list of filter labels for the UI provider selector."""
-    labels = ["Ollama", "Hugging Face"]
+    """Return available provider labels for the TUI selector in stable order."""
+    capabilities = get_all_provider_capabilities()
+    availability = detect_available_providers()
+    order = ("ollama", "huggingface", "lmstudio", "docker", "mlx")
 
-    for provider_cls in get_all_provider_classes():
-        try:
-            instance = provider_cls()
-            if instance.detect() and instance.display_name not in labels:
-                labels.append(instance.display_name)
-        except Exception:
-            logger.debug("Provider {} filter label detection failed, skipping", provider_cls.__name__)
-
-    return labels
+    return [
+        capabilities[slug].display_name
+        for slug in order
+        if slug in capabilities and availability.get(slug, False)
+    ]

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -25,10 +25,9 @@ class BaseProvider(ABC):
     for a specific LLM runtime (Ollama, Hugging Face, LM Studio, etc.).
     """
 
-    # Class-level metadata (override in subclasses)
-    slug: str = ""  # Internal identifier (e.g., "ollama", "huggingface")
-    display_name: str = ""  # Human-readable name (e.g., "Ollama")
-    default_host: str = ""  # Default API host
+    slug: str = ""
+    display_name: str = ""
+    default_host: str = ""
 
     @abstractmethod
     def detect(self) -> bool:
@@ -42,15 +41,7 @@ class BaseProvider(ABC):
         limit: int = 15,
         **kwargs: Any,
     ) -> SearchResult:
-        """Search for models matching *query*.
-
-        Returns:
-            A ``SearchResult`` carrying results, errors, and a
-            ``has_more_pages`` flag. Providers must NOT raise for
-            transient errors (rate limits, network failures, parse
-            errors) — they return diagnostics in ``SearchResult.errors``
-            and the orchestrator decides what to surface to the user.
-        """
+        """Search for models matching *query*."""
 
     @abstractmethod
     def list_installed(self) -> list[str]:
@@ -63,21 +54,10 @@ class BaseProvider(ABC):
         limit: int = 15,
         **kwargs: Any,
     ) -> SearchResult:
-        """Search and mark installed models. Override for custom behavior.
-
-        The base implementation calls ``search()`` and ignores installed
-        state. Subclasses (e.g. Ollama) override to inject installed-
-        model markers into the result dicts.
-        """
+        """Search and mark installed models. Override for custom behavior."""
         return self.search(query, specs, limit=limit, **kwargs)
 
 
-# ---------------------------------------------------------------------------
-# Provider Registry
-# ---------------------------------------------------------------------------
-
-
-# Lazy imports to avoid circular dependencies
 def _get_ollama_provider():
     from providers.ollama_provider import OllamaProvider
 
@@ -109,14 +89,7 @@ def _get_mlx_provider():
 
 
 def get_all_provider_classes() -> list[type]:
-    """Return all available provider classes (may fail on non-matching platforms).
-
-    Note: returns a mix of :class:`BaseProvider` subclasses and
-    duck-typed providers (HuggingFaceProvider, OllamaProvider) that
-    expose the same interface (``slug``, ``display_name``,
-    ``detect()``, ``search()``, ``list_installed()``,
-    ``search_with_installed()``).
-    """
+    """Return all available provider classes (may fail on non-matching platforms)."""
     providers = []
     for getter in [
         _get_hf_provider,
@@ -131,15 +104,12 @@ def get_all_provider_classes() -> list[type]:
 
 
 def detect_available_providers() -> dict[str, bool]:
-    """Detect which providers are available on this system.
-
-    Returns a dict mapping provider slug to availability bool.
-    """
+    """Detect which providers are available on this system."""
     from core.hardware import check_ollama_running
 
     available = {
         "ollama": check_ollama_running(),
-        "huggingface": True,  # Always available via API
+        "huggingface": True,
     }
 
     for provider_cls in get_all_provider_classes():
@@ -148,7 +118,6 @@ def detect_available_providers() -> dict[str, bool]:
             available[instance.slug] = instance.detect()
         except Exception:
             logger.debug("Provider {} detection failed, skipping", provider_cls.__name__)
-            pass
 
     return available
 
@@ -162,13 +131,20 @@ def get_provider_display_names() -> dict[str, str]:
 
 
 def get_provider_filter_labels() -> list[str]:
-    """Return available provider labels for the TUI selector in stable order."""
+    """Return TUI provider labels while preserving the existing selector behavior."""
     capabilities = get_all_provider_capabilities()
     availability = detect_available_providers()
-    order = ("ollama", "huggingface", "lmstudio", "docker", "mlx")
+    always_visible = ("ollama", "huggingface")
+    optional = ("lmstudio", "docker", "mlx")
 
-    return [
+    labels = [
         capabilities[slug].display_name
-        for slug in order
-        if slug in capabilities and availability.get(slug, False)
+        for slug in always_visible
+        if slug in capabilities
     ]
+    labels.extend(
+        capabilities[slug].display_name
+        for slug in optional
+        if slug in capabilities and availability.get(slug, False)
+    )
+    return labels

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -25,9 +25,10 @@ class BaseProvider(ABC):
     for a specific LLM runtime (Ollama, Hugging Face, LM Studio, etc.).
     """
 
-    slug: str = ""
-    display_name: str = ""
-    default_host: str = ""
+    # Class-level metadata (override in subclasses)
+    slug: str = ""  # Internal identifier (e.g., "ollama", "huggingface")
+    display_name: str = ""  # Human-readable name (e.g., "Ollama")
+    default_host: str = ""  # Default API host
 
     @abstractmethod
     def detect(self) -> bool:
@@ -41,7 +42,15 @@ class BaseProvider(ABC):
         limit: int = 15,
         **kwargs: Any,
     ) -> SearchResult:
-        """Search for models matching *query*."""
+        """Search for models matching *query*.
+
+        Returns:
+            A ``SearchResult`` carrying results, errors, and a
+            ``has_more_pages`` flag. Providers must NOT raise for
+            transient errors (rate limits, network failures, parse
+            errors) — they return diagnostics in ``SearchResult.errors``
+            and the orchestrator decides what to surface to the user.
+        """
 
     @abstractmethod
     def list_installed(self) -> list[str]:
@@ -54,10 +63,21 @@ class BaseProvider(ABC):
         limit: int = 15,
         **kwargs: Any,
     ) -> SearchResult:
-        """Search and mark installed models. Override for custom behavior."""
+        """Search and mark installed models. Override for custom behavior.
+
+        The base implementation calls ``search()`` and ignores installed
+        state. Subclasses (e.g. Ollama) override to inject installed-
+        model markers into the result dicts.
+        """
         return self.search(query, specs, limit=limit, **kwargs)
 
 
+# ---------------------------------------------------------------------------
+# Provider Registry
+# ---------------------------------------------------------------------------
+
+
+# Lazy imports to avoid circular dependencies
 def _get_ollama_provider():
     from providers.ollama_provider import OllamaProvider
 
@@ -89,7 +109,14 @@ def _get_mlx_provider():
 
 
 def get_all_provider_classes() -> list[type]:
-    """Return all available provider classes (may fail on non-matching platforms)."""
+    """Return all available provider classes (may fail on non-matching platforms).
+
+    Note: returns a mix of :class:`BaseProvider` subclasses and
+    duck-typed providers (HuggingFaceProvider, OllamaProvider) that
+    expose the same interface (``slug``, ``display_name``,
+    ``detect()``, ``search()``, ``list_installed()``,
+    ``search_with_installed()``).
+    """
     providers = []
     for getter in [
         _get_hf_provider,
@@ -104,12 +131,15 @@ def get_all_provider_classes() -> list[type]:
 
 
 def detect_available_providers() -> dict[str, bool]:
-    """Detect which providers are available on this system."""
+    """Detect which providers are available on this system.
+
+    Returns a dict mapping provider slug to availability bool.
+    """
     from core.hardware import check_ollama_running
 
     available = {
         "ollama": check_ollama_running(),
-        "huggingface": True,
+        "huggingface": True,  # Always available via API
     }
 
     for provider_cls in get_all_provider_classes():
@@ -118,6 +148,7 @@ def detect_available_providers() -> dict[str, bool]:
             available[instance.slug] = instance.detect()
         except Exception:
             logger.debug("Provider {} detection failed, skipping", provider_cls.__name__)
+            pass
 
     return available
 

--- a/search/search_orchestration.py
+++ b/search/search_orchestration.py
@@ -4,18 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-# All supported provider slugs
-ALL_PROVIDER_SLUGS = ["ollama", "huggingface", "lmstudio", "docker", "mlx"]
+from providers.capabilities import get_all_provider_capabilities, get_provider_capabilities
 
-# Mapping from UI filter labels to provider slugs
+
+_PROVIDER_CAPABILITIES = get_all_provider_capabilities()
+ALL_PROVIDER_SLUGS = list(_PROVIDER_CAPABILITIES)
 _FILTER_TO_SLUGS: dict[str, list[str]] = {
-    "Ollama": ["ollama"],
-    "Hugging Face": ["huggingface"],
-    "LM Studio": ["lmstudio"],
-    "Docker": ["docker"],
-    "MLX": ["mlx"],
-    "All": ALL_PROVIDER_SLUGS,
+    metadata.display_name: [slug] for slug, metadata in _PROVIDER_CAPABILITIES.items()
 }
+_FILTER_TO_SLUGS["All"] = ALL_PROVIDER_SLUGS
 
 
 def providers_from_filter(current_filter: str) -> list[str]:
@@ -36,13 +33,11 @@ def is_multi_provider(providers: Sequence[str]) -> bool:
 def provider_display_name(providers: Sequence[str]) -> str:
     """Return user-facing provider name for status messages."""
     if len(providers) == 1:
-        return {
-            "ollama": "Ollama",
-            "huggingface": "Hugging Face",
-            "lmstudio": "LM Studio",
-            "docker": "Docker",
-            "mlx": "MLX",
-        }.get(providers[0], providers[0].title())
+        slug = providers[0]
+        try:
+            return get_provider_capabilities(slug).display_name
+        except KeyError:
+            return slug.title()
     return "All Providers"
 
 

--- a/search/search_orchestration.py
+++ b/search/search_orchestration.py
@@ -8,9 +8,10 @@ from providers.capabilities import get_all_provider_capabilities, get_provider_c
 
 
 _PROVIDER_CAPABILITIES = get_all_provider_capabilities()
-ALL_PROVIDER_SLUGS = list(_PROVIDER_CAPABILITIES)
+_TUI_PROVIDER_ORDER = ("ollama", "huggingface", "lmstudio", "docker", "mlx")
+ALL_PROVIDER_SLUGS = [slug for slug in _TUI_PROVIDER_ORDER if slug in _PROVIDER_CAPABILITIES]
 _FILTER_TO_SLUGS: dict[str, list[str]] = {
-    metadata.display_name: [slug] for slug, metadata in _PROVIDER_CAPABILITIES.items()
+    _PROVIDER_CAPABILITIES[slug].display_name: [slug] for slug in ALL_PROVIDER_SLUGS
 }
 _FILTER_TO_SLUGS["All"] = ALL_PROVIDER_SLUGS
 

--- a/tests/test_provider_correctness_regressions.py
+++ b/tests/test_provider_correctness_regressions.py
@@ -11,24 +11,16 @@ from search.search_orchestrator import SearchOrchestrator
 def test_provider_filter_labels_do_not_duplicate_builtin_providers(monkeypatch):
     import providers
 
-    class HuggingFaceStub:
-        slug = "huggingface"
-        display_name = "Hugging Face"
-
-        def detect(self) -> bool:
-            return True
-
-    class LMStudioStub:
-        slug = "lmstudio"
-        display_name = "LM Studio"
-
-        def detect(self) -> bool:
-            return True
-
     monkeypatch.setattr(
         providers,
-        "get_all_provider_classes",
-        lambda: [HuggingFaceStub, LMStudioStub],
+        "detect_available_providers",
+        lambda: {
+            "ollama": False,
+            "huggingface": True,
+            "lmstudio": True,
+            "docker": False,
+            "mlx": False,
+        },
     )
 
     assert providers.get_provider_filter_labels() == [

--- a/tests/test_tui_provider_capabilities.py
+++ b/tests/test_tui_provider_capabilities.py
@@ -1,0 +1,35 @@
+"""Regression tests for TUI provider metadata parity."""
+
+import providers
+from providers.capabilities import get_all_provider_capabilities
+from search.search_orchestration import provider_display_name, providers_from_filter
+
+
+def test_tui_filter_labels_use_canonical_display_names(monkeypatch):
+    """Available TUI labels should come from canonical provider metadata."""
+    monkeypatch.setattr(
+        providers,
+        "detect_available_providers",
+        lambda: {
+            "ollama": True,
+            "huggingface": True,
+            "lmstudio": True,
+            "docker": False,
+            "mlx": False,
+        },
+    )
+
+    assert providers.get_provider_filter_labels() == [
+        "Ollama",
+        "Hugging Face",
+        "LM Studio",
+    ]
+
+
+def test_tui_filter_mapping_matches_canonical_capabilities():
+    """Every canonical TUI label should resolve back to its provider slug."""
+    capabilities = get_all_provider_capabilities()
+
+    for slug, metadata in capabilities.items():
+        assert providers_from_filter(metadata.display_name) == [slug]
+        assert provider_display_name([slug]) == metadata.display_name


### PR DESCRIPTION
## Scope

- derive TUI provider display names and label-to-slug mappings from canonical provider capabilities
- preserve the existing TUI provider order: Ollama, Hugging Face, LM Studio, Docker, MLX
- preserve visibility semantics: Ollama and Hugging Face remain always visible; optional local providers appear only when available
- keep current search execution behavior unchanged
- add regression coverage for TUI label/mapping parity and update the older duplicate-label regression to use canonical availability

This completes the capability-consumer alignment across API, CLI, and the TUI selector without broadening provider execution behavior.