### PR TITLE
fix: poll search cancellation while providers run

### DIFF
--- a/search/search_orchestrator.py
+++ b/search/search_orchestrator.py
@@ -29,7 +29,7 @@ shape.
 from __future__ import annotations
 
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 
 from providers import SearchResult, get_all_provider_classes
@@ -38,25 +38,7 @@ from search.search_orchestration import has_more_pages_for_results
 
 @dataclass
 class SearchOutcome:
-    """The full result of a single search invocation.
-
-    Attributes:
-        results: Concatenated result list (Ollama first, then HF,
-            then the extras — same order as the pre-refactor code).
-        errors: Concatenated error list, capped at the first two
-            by the orchestrator for the status-bar message.
-        has_more_pages: True if pagination should enable the
-            "Next" button. Computed by
-            :func:`search.search_orchestration.has_more_pages_for_results`.
-        result_count: Number of merged results to report in the status
-            message.
-        providers: Echo of the providers list, for downstream
-            status-message builders.
-        cancelled: True if the search was cancelled before all
-            providers returned. The orchestrator still returns a
-            partial :class:`SearchOutcome`; the caller decides
-            whether to apply it.
-    """
+    """The full result of a single search invocation."""
 
     results: list[dict] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
@@ -67,32 +49,7 @@ class SearchOutcome:
 
 
 class SearchOrchestrator:
-    """Coordinates a single multi-provider search.
-
-    Constructor takes the things that vary across invocations as
-    callbacks (``on_progress``, ``cancel_check``) and the things
-    that are stable across invocations as plain values
-    (``monitor``, ``hf_provider``, ``ollama_provider``). The
-    orchestrator is stateless across calls; a single instance can
-    service many searches in series.
-
-    Args:
-        monitor: Anything with a ``get_specs() -> dict`` method.
-            Typically a :class:`core.hardware.HardwareMonitor`.
-        hf_provider: A :class:`providers.hf_provider.HuggingFaceProvider`
-            (or anything matching its duck-typed interface).
-        ollama_provider: A :class:`providers.ollama_provider.OllamaProvider`.
-        on_progress: ``Callable[[int, str], None]`` invoked from
-            worker threads to push progress messages back to the
-            UI. The first arg is the search_id; the second is a
-            human-readable message. In a Textual context, callers
-            should wrap this with ``call_from_thread`` if they
-            want to update widgets.
-        cancel_check: ``Callable[[], bool]`` polled before and
-            between provider submissions. Returning True aborts
-            the search and returns a partial :class:`SearchOutcome`
-            with ``cancelled=True``.
-    """
+    """Coordinates a single multi-provider search."""
 
     def __init__(
         self,
@@ -123,11 +80,10 @@ class SearchOrchestrator:
         """Run a single search across *providers* and return the outcome.
 
         ``ollama_page_size`` defaults to ``page_size`` when omitted.
-        The orchestrator submits one task per provider to a small
-        thread pool (4 workers, sufficient for the 5-provider fan-out).
-        Cancellation is checked before provider work and whenever a
-        provider completes; once observed, the orchestrator returns
-        without waiting for still-running provider workers to finish.
+        Provider futures are polled at a short interval so external
+        cancellation is observed even while every provider is still running.
+        Once cancellation is observed, the orchestrator returns without
+        waiting for still-running provider workers to finish.
         """
         if self.cancel_check():
             return SearchOutcome(providers=list(providers), cancelled=True)
@@ -140,6 +96,16 @@ class SearchOrchestrator:
         hf_errors: list[str] = []
         extra_results: list[dict] = []
         extra_errors: list[str] = []
+
+        def _cancelled_outcome() -> SearchOutcome:
+            partial_results = ollama_results + hf_results + extra_results
+            return SearchOutcome(
+                results=partial_results,
+                errors=ollama_errors + hf_errors + extra_errors,
+                result_count=len(partial_results),
+                providers=list(providers),
+                cancelled=True,
+            )
 
         def _search_ollama():
             if self.cancel_check():
@@ -162,9 +128,7 @@ class SearchOrchestrator:
                 return SearchResult.empty()
             for provider_cls in get_all_provider_classes():
                 if provider_cls.slug == slug:
-                    self.on_progress(
-                        search_id, f"Fetching {provider_cls.display_name} data..."
-                    )
+                    self.on_progress(search_id, f"Fetching {provider_cls.display_name} data...")
                     instance = provider_cls()
                     if instance.detect():
                         return instance.search(query, specs, limit=page_size)
@@ -184,50 +148,47 @@ class SearchOrchestrator:
                 if slug in providers and slug not in ("ollama", "huggingface"):
                     futures[pool.submit(_search_extra, slug)] = slug
 
-            for future in as_completed(futures):
+            pending = set(futures)
+            while pending:
                 if self.cancel_check():
-                    partial_results = ollama_results + hf_results + extra_results
                     wait_for_workers = False
-                    return SearchOutcome(
-                        results=partial_results,
-                        errors=ollama_errors + hf_errors + extra_errors,
-                        result_count=len(partial_results),
-                        providers=list(providers),
-                        cancelled=True,
-                    )
-                label = futures[future]
-                try:
-                    result: SearchResult = future.result()
-                except Exception:
-                    if label == "ollama":
-                        ollama_errors.append("Ollama search failed")
-                    elif label == "huggingface":
-                        hf_errors.append("HuggingFace search failed")
-                    else:
-                        extra_errors.append(f"{label} search failed")
+                    return _cancelled_outcome()
+
+                done, pending = wait(pending, timeout=0.1, return_when=FIRST_COMPLETED)
+                if not done:
                     continue
 
-                if label == "ollama":
-                    ollama_results = result.results
-                    ollama_errors = result.errors
-                elif label == "huggingface":
-                    hf_results = result.results
-                    hf_errors = result.errors
-                else:
-                    extra_results.extend(result.results)
-                    extra_errors.extend(result.errors)
+                for future in done:
+                    if self.cancel_check():
+                        wait_for_workers = False
+                        return _cancelled_outcome()
+
+                    label = futures[future]
+                    try:
+                        result: SearchResult = future.result()
+                    except Exception:
+                        if label == "ollama":
+                            ollama_errors.append("Ollama search failed")
+                        elif label == "huggingface":
+                            hf_errors.append("HuggingFace search failed")
+                        else:
+                            extra_errors.append(f"{label} search failed")
+                        continue
+
+                    if label == "ollama":
+                        ollama_results = result.results
+                        ollama_errors = result.errors
+                    elif label == "huggingface":
+                        hf_results = result.results
+                        hf_errors = result.errors
+                    else:
+                        extra_results.extend(result.results)
+                        extra_errors.extend(result.errors)
         finally:
             pool.shutdown(wait=wait_for_workers, cancel_futures=not wait_for_workers)
 
         if self.cancel_check():
-            partial_results = ollama_results + hf_results + extra_results
-            return SearchOutcome(
-                results=partial_results,
-                errors=ollama_errors + hf_errors + extra_errors,
-                result_count=len(partial_results),
-                providers=list(providers),
-                cancelled=True,
-            )
+            return _cancelled_outcome()
 
         results = ollama_results + hf_results + extra_results
         errors = ollama_errors + hf_errors + extra_errors
@@ -237,12 +198,11 @@ class SearchOrchestrator:
             ollama_result_count=len(ollama_results),
             page_size=page_size,
         )
-        result_count = len(results)
 
         return SearchOutcome(
             results=results,
             errors=errors,
             has_more_pages=has_more_pages,
-            result_count=result_count,
+            result_count=len(results),
             providers=list(providers),
         )

--- a/search/search_orchestrator.py
+++ b/search/search_orchestrator.py
@@ -206,9 +206,6 @@ class SearchOrchestrator:
                     continue
 
                 for future in done:
-                    if self.cancel_check():
-                        wait_for_workers = False
-                        return _cancelled_outcome()
                     label = futures[future]
                     try:
                         result: SearchResult = future.result()

--- a/search/search_orchestrator.py
+++ b/search/search_orchestrator.py
@@ -38,7 +38,25 @@ from search.search_orchestration import has_more_pages_for_results
 
 @dataclass
 class SearchOutcome:
-    """The full result of a single search invocation."""
+    """The full result of a single search invocation.
+
+    Attributes:
+        results: Concatenated result list (Ollama first, then HF,
+            then the extras — same order as the pre-refactor code).
+        errors: Concatenated error list, capped at the first two
+            by the orchestrator for the status-bar message.
+        has_more_pages: True if pagination should enable the
+            "Next" button. Computed by
+            :func:`search.search_orchestration.has_more_pages_for_results`.
+        result_count: Number of merged results to report in the status
+            message.
+        providers: Echo of the providers list, for downstream
+            status-message builders.
+        cancelled: True if the search was cancelled before all
+            providers returned. The orchestrator still returns a
+            partial :class:`SearchOutcome`; the caller decides
+            whether to apply it.
+    """
 
     results: list[dict] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
@@ -49,7 +67,32 @@ class SearchOutcome:
 
 
 class SearchOrchestrator:
-    """Coordinates a single multi-provider search."""
+    """Coordinates a single multi-provider search.
+
+    Constructor takes the things that vary across invocations as
+    callbacks (``on_progress``, ``cancel_check``) and the things
+    that are stable across invocations as plain values
+    (``monitor``, ``hf_provider``, ``ollama_provider``). The
+    orchestrator is stateless across calls; a single instance can
+    service many searches in series.
+
+    Args:
+        monitor: Anything with a ``get_specs() -> dict`` method.
+            Typically a :class:`core.hardware.HardwareMonitor`.
+        hf_provider: A :class:`providers.hf_provider.HuggingFaceProvider`
+            (or anything matching its duck-typed interface).
+        ollama_provider: A :class:`providers.ollama_provider.OllamaProvider`.
+        on_progress: ``Callable[[int, str], None]`` invoked from
+            worker threads to push progress messages back to the
+            UI. The first arg is the search_id; the second is a
+            human-readable message. In a Textual context, callers
+            should wrap this with ``call_from_thread`` if they
+            want to update widgets.
+        cancel_check: ``Callable[[], bool]`` polled before and
+            between provider submissions. Returning True aborts
+            the search and returns a partial :class:`SearchOutcome`
+            with ``cancelled=True``.
+    """
 
     def __init__(
         self,
@@ -80,10 +123,12 @@ class SearchOrchestrator:
         """Run a single search across *providers* and return the outcome.
 
         ``ollama_page_size`` defaults to ``page_size`` when omitted.
+        The orchestrator submits one task per provider to a small
+        thread pool (4 workers, sufficient for the 5-provider fan-out).
         Provider futures are polled at a short interval so external
-        cancellation is observed even while every provider is still running.
-        Once cancellation is observed, the orchestrator returns without
-        waiting for still-running provider workers to finish.
+        cancellation is observed even while every provider is still
+        running; once observed, the orchestrator returns without waiting
+        for still-running provider workers to finish.
         """
         if self.cancel_check():
             return SearchOutcome(providers=list(providers), cancelled=True)
@@ -128,7 +173,9 @@ class SearchOrchestrator:
                 return SearchResult.empty()
             for provider_cls in get_all_provider_classes():
                 if provider_cls.slug == slug:
-                    self.on_progress(search_id, f"Fetching {provider_cls.display_name} data...")
+                    self.on_progress(
+                        search_id, f"Fetching {provider_cls.display_name} data..."
+                    )
                     instance = provider_cls()
                     if instance.detect():
                         return instance.search(query, specs, limit=page_size)
@@ -162,7 +209,6 @@ class SearchOrchestrator:
                     if self.cancel_check():
                         wait_for_workers = False
                         return _cancelled_outcome()
-
                     label = futures[future]
                     try:
                         result: SearchResult = future.result()
@@ -198,11 +244,12 @@ class SearchOrchestrator:
             ollama_result_count=len(ollama_results),
             page_size=page_size,
         )
+        result_count = len(results)
 
         return SearchOutcome(
             results=results,
             errors=errors,
             has_more_pages=has_more_pages,
-            result_count=len(results),
+            result_count=result_count,
             providers=list(providers),
         )

--- a/tests/test_search_cancellation_polling.py
+++ b/tests/test_search_cancellation_polling.py
@@ -1,0 +1,87 @@
+"""Regression coverage for external cancellation polling during provider waits."""
+
+from __future__ import annotations
+
+import threading
+
+from providers import SearchResult
+from search.search_orchestrator import SearchOrchestrator
+
+
+class _Monitor:
+    """Minimal hardware monitor stub for orchestrator tests."""
+
+    def get_specs(self):
+        """Return stable hardware specs."""
+        return {"has_gpu": False, "ram_total": 16.0}
+
+
+class _BlockingHF:
+    """Provider that remains blocked until the test releases it."""
+
+    def __init__(self, started: threading.Event, release: threading.Event):
+        self.started = started
+        self.release = release
+
+    def search(self, query, specs, limit=15, *, page=0, hf_token=None):
+        """Block until released, simulating a long-running provider call."""
+        self.started.set()
+        self.release.wait(timeout=2)
+        return SearchResult(results=[{"id": "hf"}])
+
+
+class _BlockingOllama:
+    """Second provider that remains blocked until the test releases it."""
+
+    def __init__(self, started: threading.Event, release: threading.Event):
+        self.started = started
+        self.release = release
+
+    def search_with_installed(self, query, specs, limit=15, *, page=0):
+        """Block until released, simulating a long-running provider call."""
+        self.started.set()
+        self.release.wait(timeout=2)
+        return SearchResult(results=[{"id": "ollama"}])
+
+
+def test_external_cancel_is_observed_while_all_providers_are_still_running():
+    """Search should stop promptly even when no provider future has completed yet."""
+    hf_started = threading.Event()
+    ollama_started = threading.Event()
+    release = threading.Event()
+    cancel = threading.Event()
+    search_done = threading.Event()
+    holder: dict[str, object] = {}
+
+    orchestrator = SearchOrchestrator(
+        monitor=_Monitor(),
+        hf_provider=_BlockingHF(hf_started, release),
+        ollama_provider=_BlockingOllama(ollama_started, release),
+        on_progress=lambda *_: None,
+        cancel_check=cancel.is_set,
+    )
+
+    def run_search():
+        holder["outcome"] = orchestrator.search(
+            search_id=1,
+            query="test",
+            providers=["ollama", "huggingface"],
+            page=0,
+            page_size=10,
+        )
+        search_done.set()
+
+    thread = threading.Thread(target=run_search)
+    thread.start()
+    try:
+        assert hf_started.wait(timeout=1)
+        assert ollama_started.wait(timeout=1)
+        cancel.set()
+        assert search_done.wait(timeout=0.5)
+    finally:
+        release.set()
+        thread.join(timeout=2)
+
+    outcome = holder["outcome"]
+    assert outcome.cancelled is True
+    assert outcome.results == []


### PR DESCRIPTION
## Scope

- replace blocking `as_completed()` fan-in with short-interval future polling
- observe external cancellation even when every provider future is still running
- preserve partial-result aggregation and non-blocking executor shutdown from #9
- do not attempt to interrupt provider HTTP calls or running threads
- add deterministic regression coverage using blocked providers and event-based cancellation

This is the bounded follow-up to #9: #9 removed shutdown wait after cancellation was observed; this PR makes cancellation observable while all provider futures are still in flight.