### PR TITLE
fix: align non-paginated provider flags

### DIFF
--- a/providers/ollama_provider.py
+++ b/providers/ollama_provider.py
@@ -387,11 +387,8 @@ def search_ollama_models(query, specs, local_models, page=0, page_size=15):
     except (ValueError, AttributeError) as exc:
         errors.append(f"Ollama parse failed: {exc}")
 
-    # Ollama returns all results at once (no pagination support)
-    # Slice to page_size for consistency with HF pagination
+    # Ollama returns all results at once (no page-offset support).
+    # Keep the result cap for consistency, but never advertise a next page.
     limited_results = results[:page_size] if len(results) > page_size else results
 
-    # has_more_pages is True if we have more results than page_size
-    has_more_pages = len(results) > page_size
-
-    return limited_results, errors, has_more_pages
+    return limited_results, errors, False

--- a/tests/test_nonpaginated_provider_flags.py
+++ b/tests/test_nonpaginated_provider_flags.py
@@ -1,7 +1,8 @@
 """Regression coverage for non-paginated provider search flags."""
 
-from pathlib import Path
 from unittest.mock import patch
+
+from pathlib import Path
 
 from providers.docker_provider import DockerProvider
 from providers.mlx_provider import MLXProvider
@@ -24,7 +25,9 @@ def test_ollama_search_never_advertises_page_navigation(monkeypatch):
         text = "".join(
             f'<a href="/library/model-{index}">model-{index}</a>' for index in range(3)
         )
-        headers = {}
+
+        def __init__(self):
+            self.headers = {}
 
     class Session:
         def get(self, *args, **kwargs):

--- a/tests/test_nonpaginated_provider_flags.py
+++ b/tests/test_nonpaginated_provider_flags.py
@@ -1,7 +1,5 @@
 """Regression coverage for non-paginated provider search flags."""
 
-from unittest.mock import patch
-
 from pathlib import Path
 
 from providers.docker_provider import DockerProvider
@@ -49,16 +47,22 @@ def test_ollama_search_never_advertises_page_navigation(monkeypatch):
     assert has_more is False
 
 
-def test_docker_search_never_advertises_page_navigation():
+def test_docker_search_never_advertises_page_navigation(monkeypatch):
     """Docker Model Runner search has no page-offset contract."""
-    provider = DockerProvider()
 
-    with patch("providers.docker_provider.get_session") as mock_session:
-        response = mock_session.return_value.get.return_value
-        response.status_code = 200
-        response.json.return_value = ["org/model-a", "org/model-b", "org/model-c"]
+    class Response:
+        status_code = 200
 
-        result = provider.search("model", SPECS, limit=2)
+        def json(self):
+            return ["org/model-a", "org/model-b", "org/model-c"]
+
+    class Session:
+        def get(self, *args, **kwargs):
+            return Response()
+
+    monkeypatch.setattr("providers.docker_provider.get_session", lambda: Session())
+
+    result = DockerProvider().search("model", SPECS, limit=2)
 
     assert len(result.results) == 2
     assert result.has_more_pages is False

--- a/tests/test_nonpaginated_provider_flags.py
+++ b/tests/test_nonpaginated_provider_flags.py
@@ -1,7 +1,5 @@
 """Regression coverage for non-paginated provider search flags."""
 
-from pathlib import Path
-
 from providers.docker_provider import DockerProvider
 from providers.mlx_provider import MLXProvider
 from providers.ollama_provider import search_ollama_models
@@ -68,7 +66,7 @@ def test_docker_search_never_advertises_page_navigation(monkeypatch):
     assert result.has_more_pages is False
 
 
-def test_mlx_search_never_advertises_page_navigation(monkeypatch, tmp_path: Path):
+def test_mlx_search_never_advertises_page_navigation(monkeypatch, tmp_path):
     """MLX local-cache search has no page-offset contract."""
     for index in range(3):
         (tmp_path / f"models--mlx-community--model-{index}").mkdir()

--- a/tests/test_nonpaginated_provider_flags.py
+++ b/tests/test_nonpaginated_provider_flags.py
@@ -8,7 +8,12 @@ from providers.mlx_provider import MLXProvider
 from providers.ollama_provider import search_ollama_models
 
 
-SPECS = {"has_gpu": False, "ram_total": 16.0}
+SPECS = {
+    "has_gpu": False,
+    "ram_total": 16.0,
+    "ram_free": 16.0,
+    "vram_free": 0.0,
+}
 
 
 def test_ollama_search_never_advertises_page_navigation(monkeypatch):

--- a/tests/test_nonpaginated_provider_flags.py
+++ b/tests/test_nonpaginated_provider_flags.py
@@ -1,0 +1,70 @@
+"""Regression coverage for non-paginated provider search flags."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from providers.docker_provider import DockerProvider
+from providers.mlx_provider import MLXProvider
+from providers.ollama_provider import search_ollama_models
+
+
+SPECS = {"has_gpu": False, "ram_total": 16.0}
+
+
+def test_ollama_search_never_advertises_page_navigation(monkeypatch):
+    """Ollama ignores page offsets, so it must not advertise a next page."""
+
+    class Response:
+        status_code = 200
+        text = "".join(
+            f'<a href="/library/model-{index}">model-{index}</a>' for index in range(3)
+        )
+        headers = {}
+
+    class Session:
+        def get(self, *args, **kwargs):
+            return Response()
+
+    monkeypatch.setattr("providers.ollama_provider.get_session", lambda: Session())
+    monkeypatch.setattr("providers.ollama_provider.get_ollama_model_metadata", lambda *_: None)
+
+    results, errors, has_more = search_ollama_models(
+        "model",
+        SPECS,
+        [],
+        page=0,
+        page_size=2,
+    )
+
+    assert len(results) == 2
+    assert errors == []
+    assert has_more is False
+
+
+def test_docker_search_never_advertises_page_navigation():
+    """Docker Model Runner search has no page-offset contract."""
+    provider = DockerProvider()
+
+    with patch("providers.docker_provider.get_session") as mock_session:
+        response = mock_session.return_value.get.return_value
+        response.status_code = 200
+        response.json.return_value = ["org/model-a", "org/model-b", "org/model-c"]
+
+        result = provider.search("model", SPECS, limit=2)
+
+    assert len(result.results) == 2
+    assert result.has_more_pages is False
+
+
+def test_mlx_search_never_advertises_page_navigation(monkeypatch, tmp_path: Path):
+    """MLX local-cache search has no page-offset contract."""
+    for index in range(3):
+        (tmp_path / f"models--mlx-community--model-{index}").mkdir()
+
+    monkeypatch.setattr("providers.mlx_provider._MLX_CACHE_PATHS", [tmp_path])
+    monkeypatch.setattr(MLXProvider, "_estimate_dir_size", staticmethod(lambda _path: 1.0))
+
+    result = MLXProvider().search("model", SPECS, limit=2)
+
+    assert len(result.results) == 2
+    assert result.has_more_pages is False

--- a/tests/test_nonpaginated_provider_flags.py
+++ b/tests/test_nonpaginated_provider_flags.py
@@ -1,9 +1,5 @@
 """Regression coverage for non-paginated provider search flags."""
 
-from providers.docker_provider import DockerProvider
-from providers.mlx_provider import MLXProvider
-from providers.ollama_provider import search_ollama_models
-
 
 SPECS = {
     "has_gpu": False,
@@ -15,6 +11,7 @@ SPECS = {
 
 def test_ollama_search_never_advertises_page_navigation(monkeypatch):
     """Ollama ignores page offsets, so it must not advertise a next page."""
+    from providers.ollama_provider import search_ollama_models
 
     class Response:
         status_code = 200
@@ -47,6 +44,7 @@ def test_ollama_search_never_advertises_page_navigation(monkeypatch):
 
 def test_docker_search_never_advertises_page_navigation(monkeypatch):
     """Docker Model Runner search has no page-offset contract."""
+    from providers.docker_provider import DockerProvider
 
     class Response:
         status_code = 200
@@ -68,6 +66,8 @@ def test_docker_search_never_advertises_page_navigation(monkeypatch):
 
 def test_mlx_search_never_advertises_page_navigation(monkeypatch, tmp_path):
     """MLX local-cache search has no page-offset contract."""
+    from providers.mlx_provider import MLXProvider
+
     for index in range(3):
         (tmp_path / f"models--mlx-community--model-{index}").mkdir()
 


### PR DESCRIPTION
## Scope

- stop Ollama search from advertising `has_more_pages=True` when its `page` argument is ignored
- keep result limiting behavior unchanged
- pin Docker and MLX as non-paginated providers with regression coverage
- preserve the canonical capability contract where only Hugging Face is paginated

This PR does not add pagination to local/runtime providers; it only makes their result metadata truthful.