### PR TITLE
fix: drive pagination controls from provider capabilities

### DIFF
--- a/search/search_orchestration.py
+++ b/search/search_orchestration.py
@@ -86,7 +86,7 @@ def has_more_pages_for_results(
     page_size: int,
 ) -> bool:
     """Compute whether next-page navigation should be enabled."""
-    if selection_supports_pagination(providers) and hf_result_count > 0:
+    if is_hf_provider_selection(providers) and hf_result_count > 0:
         return hf_result_count == page_size
     if "ollama" in providers and ollama_result_count > 0:
         return False

--- a/search/search_orchestration.py
+++ b/search/search_orchestration.py
@@ -21,9 +21,19 @@ def providers_from_filter(current_filter: str) -> list[str]:
     return _FILTER_TO_SLUGS.get(current_filter, ["ollama"])
 
 
+def selection_supports_pagination(providers: Sequence[str]) -> bool:
+    """Return whether a single-provider selection supports page navigation."""
+    if len(providers) != 1:
+        return False
+    try:
+        return get_provider_capabilities(providers[0]).paginated
+    except KeyError:
+        return False
+
+
 def is_hf_provider_selection(providers: Sequence[str]) -> bool:
-    """Return ``True`` when selection targets Hugging Face only."""
-    return list(providers) == ["huggingface"]
+    """Return ``True`` when selection targets the currently paginated HF provider."""
+    return selection_supports_pagination(providers) and list(providers) == ["huggingface"]
 
 
 def is_multi_provider(providers: Sequence[str]) -> bool:
@@ -76,7 +86,7 @@ def has_more_pages_for_results(
     page_size: int,
 ) -> bool:
     """Compute whether next-page navigation should be enabled."""
-    if "huggingface" in providers and hf_result_count > 0:
+    if selection_supports_pagination(providers) and hf_result_count > 0:
         return hf_result_count == page_size
     if "ollama" in providers and ollama_result_count > 0:
         return False

--- a/tests/test_search_orchestration.py
+++ b/tests/test_search_orchestration.py
@@ -7,6 +7,7 @@ from search.search_orchestration import (
     provider_result_count,
     provider_search_status,
     providers_from_filter,
+    selection_supports_pagination,
     validate_page_request,
 )
 
@@ -57,6 +58,19 @@ def test_provider_search_status_text_for_ollama():
 
 def test_page_info_suffix_for_second_page():
     assert page_info_suffix(1) == " (Page 2)"
+
+
+def test_selection_supports_pagination_uses_capability_registry():
+    assert selection_supports_pagination(["huggingface"]) is True
+    assert selection_supports_pagination(["ollama"]) is False
+    assert selection_supports_pagination(["lmstudio"]) is False
+    assert selection_supports_pagination(["docker"]) is False
+    assert selection_supports_pagination(["mlx"]) is False
+
+
+def test_selection_supports_pagination_rejects_multi_and_unknown():
+    assert selection_supports_pagination(["huggingface", "ollama"]) is False
+    assert selection_supports_pagination(["unknown"]) is False
 
 
 def test_is_hf_provider_selection():


### PR DESCRIPTION
## Scope

- derive single-provider pagination eligibility from canonical provider capability metadata
- keep current behavior where only Hugging Face is paginated
- keep HF-specific result-count pagination logic bounded to Hugging Face
- reject multi-provider and unknown selections for page navigation
- add regression coverage for all current providers

This PR does not add pagination to any new provider; it only makes the existing TUI pagination decision consume the canonical `paginated` capability.