### PR TITLE
fix: align installed markers with provider capabilities

### DIFF
--- a/providers/hf_provider.py
+++ b/providers/hf_provider.py
@@ -15,6 +15,7 @@ from core.utils import (
     parse_retry_after_seconds,
 )
 from providers.base import SearchResult
+from providers.capabilities import get_provider_capabilities
 
 
 class HuggingFaceProvider:
@@ -229,6 +230,8 @@ def search_hf_models(
     has_more_pages = len(raw_window) > limit
     page_models = raw_window[:limit]
 
+    hf_lists_installed = get_provider_capabilities(HuggingFaceProvider.slug).lists_installed
+
     for model in page_models:
         try:
             repo_id = _repo_id_from_model(model)
@@ -265,7 +268,9 @@ def search_hf_models(
 
             fit_str, mode_str, _ = calculate_fit(size, specs)
             result_dict = {
-                "inst": "[grey37]-[/grey37]",
+                "inst": "[grey37]-[/grey37]"
+                if hf_lists_installed
+                else "[grey37]N/A[/grey37]",
                 "source": "Hugging Face",
                 "provider": provider,
                 "publisher": publisher,

--- a/results/results_presenter.py
+++ b/results/results_presenter.py
@@ -55,6 +55,8 @@ def installed_cell_markup(
     align_plain: _AlignPlain,
 ) -> str:
     plain = truncate_plain(installed_text, 8)
+    if "n/a" in plain.lower():
+        return f"[#6b789e]{align_plain('-', width, 'left')}[/#6b789e]"
     marker = "●" if ("✔" in plain or "install" in plain.lower()) else "·"
     if marker == "●":
         return f"[bold #4fe08a]{align_plain(marker, width, 'left')}[/bold #4fe08a]"

--- a/tests/test_hf_pagination_boundary.py
+++ b/tests/test_hf_pagination_boundary.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from providers.capabilities import get_provider_capabilities
 from providers.hf_provider import HuggingFaceProvider
 
 
@@ -70,3 +71,22 @@ def test_parse_failure_does_not_pull_lookahead_into_current_page():
         "test/model-4",
     ]
     assert result.has_more_pages is True
+
+
+def test_hf_results_mark_installed_state_unavailable_from_capabilities():
+    """HF must not present an uninstalled marker when installed listing is unsupported."""
+
+    class FakeModel:
+        modelId = "test/model"
+        likes = 0
+        downloads = 0
+        siblings = []
+
+    assert get_provider_capabilities("huggingface").lists_installed is False
+
+    provider = HuggingFaceProvider(model_info_cache={})
+    with patch("providers.hf_provider.HfApi.list_models", return_value=[FakeModel()]):
+        result = provider.search("test", _specs(), limit=5, page=0)
+
+    assert len(result.results) == 1
+    assert "N/A" in result.results[0]["inst"]

--- a/tests/test_hf_pagination_boundary.py
+++ b/tests/test_hf_pagination_boundary.py
@@ -80,7 +80,9 @@ def test_hf_results_mark_installed_state_unavailable_from_capabilities():
         modelId = "test/model"
         likes = 0
         downloads = 0
-        siblings = []
+
+        def __init__(self):
+            self.siblings = []
 
     assert get_provider_capabilities("huggingface").lists_installed is False
 

--- a/tests/test_results_presenter.py
+++ b/tests/test_results_presenter.py
@@ -45,6 +45,18 @@ def test_installed_cell_markup_detects_installed_marker():
     assert "●" in out
 
 
+def test_installed_cell_markup_renders_unsupported_state_as_dash():
+    out = installed_cell_markup(
+        "N/A",
+        width=3,
+        truncate_plain=_truncate_plain,
+        align_plain=_align_plain,
+    )
+    assert "-" in out
+    assert "·" not in out
+    assert "●" not in out
+
+
 def test_source_cell_markup_hf_uses_provider_color():
     out = source_cell_markup(
         "Hugging Face",


### PR DESCRIPTION
## Scope

- derive Hugging Face installed-state availability from canonical `lists_installed` capability metadata
- mark HF installed state as unavailable instead of presenting it as merely not installed
- render unavailable installed state as a neutral dash in the results table
- preserve existing installed/uninstalled markers for Ollama, LM Studio, Docker, and MLX
- add regression coverage for capability binding and presentation

This PR does not add installed-model discovery to Hugging Face or change local-provider installed detection.