### PR TITLE
chore: re-export provider capability helpers

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -16,9 +16,9 @@ from typing import Any
 
 from providers.base import SearchResult
 from providers.capabilities import (
-    ProviderCapabilities,
+    ProviderCapabilities as ProviderCapabilities,
     get_all_provider_capabilities,
-    get_provider_capabilities,
+    get_provider_capabilities as get_provider_capabilities,
 )
 
 

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -15,7 +15,11 @@ from loguru import logger
 from typing import Any
 
 from providers.base import SearchResult
-from providers.capabilities import get_all_provider_capabilities
+from providers.capabilities import (
+    ProviderCapabilities,
+    get_all_provider_capabilities,
+    get_provider_capabilities,
+)
 
 
 class BaseProvider(ABC):

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -1,7 +1,11 @@
 """Regression tests for canonical provider capability metadata."""
 
-from providers import get_all_provider_classes
-from providers.capabilities import get_all_provider_capabilities, get_provider_capabilities
+from providers import (
+    ProviderCapabilities,
+    get_all_provider_capabilities,
+    get_all_provider_classes,
+    get_provider_capabilities,
+)
 
 
 def test_capability_registry_covers_all_registered_providers():
@@ -10,6 +14,13 @@ def test_capability_registry_covers_all_registered_providers():
     capability_slugs = set(get_all_provider_capabilities())
 
     assert registered_slugs == capability_slugs
+
+
+def test_capability_helpers_are_exported_from_provider_package():
+    """Consumers may use the provider package as the public capability import surface."""
+    capabilities = get_provider_capabilities("huggingface")
+    assert isinstance(capabilities, ProviderCapabilities)
+    assert get_all_provider_capabilities()["huggingface"] == capabilities
 
 
 def test_download_capabilities_match_current_download_manager_support():


### PR DESCRIPTION
## Scope

- re-export `ProviderCapabilities`, `get_provider_capabilities`, and `get_all_provider_capabilities` from the `providers` package
- keep `providers.capabilities` as the implementation module
- add regression coverage for the package-level import surface
- preserve all existing capability registry invariants

This PR is API-surface hygiene only; it does not change provider behavior or capability values.