### PR TITLE
chore: align package version with changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ai-model-explorer"
-version = "1.0.0"
+version = "1.0.1"
 description = "Terminal UI for discovering, comparing, and downloading local LLM models"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -1,7 +1,7 @@
 """Regression coverage for package, CLI, and changelog version alignment."""
 
-import re
 from pathlib import Path
+import re
 
 from cli import get_version
 

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -1,30 +1,29 @@
 """Regression coverage for package, CLI, and changelog version alignment."""
 
 from pathlib import Path
-import re
-
-from cli import get_version
 
 
 _ROOT = Path(__file__).resolve().parents[1]
 
 
 def _project_version() -> str:
-    text = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    match = re.search(r'^version = "([^"]+)"$', text, re.MULTILINE)
-    assert match is not None
-    return match.group(1)
+    for line in (_ROOT / "pyproject.toml").read_text(encoding="utf-8").splitlines():
+        if line.startswith('version = "'):
+            return line.split('"', 2)[1]
+    raise AssertionError("project version not found")
 
 
 def _latest_changelog_version() -> str:
-    text = (_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    match = re.search(r"^## (\d+\.\d+\.\d+)\s+-", text, re.MULTILINE)
-    assert match is not None
-    return match.group(1)
+    for line in (_ROOT / "CHANGELOG.md").read_text(encoding="utf-8").splitlines():
+        if line.startswith("## "):
+            return line.removeprefix("## ").split(" - ", 1)[0].strip()
+    raise AssertionError("changelog version not found")
 
 
 def test_package_cli_and_changelog_versions_match():
     """Published package metadata, CLI output, and latest release notes must stay aligned."""
+    from cli import get_version
+
     project_version = _project_version()
     assert get_version() == project_version
     assert _latest_changelog_version() == project_version

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -1,0 +1,31 @@
+"""Regression coverage for package, CLI, and changelog version alignment."""
+
+import re
+from pathlib import Path
+
+from cli import get_version
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _project_version() -> str:
+    text = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version = "([^"]+)"$', text, re.MULTILINE)
+    assert match is not None
+    return match.group(1)
+
+
+def _latest_changelog_version() -> str:
+    text = (_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    match = re.search(r"^## (\d+\.\d+\.\d+)\s+-", text, re.MULTILINE)
+    assert match is not None
+    return match.group(1)
+
+
+def test_package_cli_and_changelog_versions_match():
+    """Published package metadata, CLI output, and latest release notes must stay aligned."""
+    project_version = _project_version()
+    assert project_version == "1.0.1"
+    assert get_version() == project_version
+    assert _latest_changelog_version() == project_version

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -2,12 +2,14 @@
 
 
 def _root():
+    """Return the repository root for metadata fixtures used by this test module."""
     from pathlib import Path
 
     return Path(__file__).resolve().parents[1]
 
 
 def _project_version() -> str:
+    """Read the declared project version from pyproject.toml."""
     for line in (_root() / "pyproject.toml").read_text(encoding="utf-8").splitlines():
         if line.startswith('version = "'):
             return line.split('"', 2)[1]
@@ -15,6 +17,7 @@ def _project_version() -> str:
 
 
 def _latest_changelog_version() -> str:
+    """Read the latest release version heading from CHANGELOG.md."""
     for line in (_root() / "CHANGELOG.md").read_text(encoding="utf-8").splitlines():
         if line.startswith("## "):
             return line.removeprefix("## ").split(" - ", 1)[0].strip()

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -26,6 +26,5 @@ def _latest_changelog_version() -> str:
 def test_package_cli_and_changelog_versions_match():
     """Published package metadata, CLI output, and latest release notes must stay aligned."""
     project_version = _project_version()
-    assert project_version == "1.0.1"
     assert get_version() == project_version
     assert _latest_changelog_version() == project_version

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -1,20 +1,21 @@
 """Regression coverage for package, CLI, and changelog version alignment."""
 
-from pathlib import Path
 
+def _root():
+    from pathlib import Path
 
-_ROOT = Path(__file__).resolve().parents[1]
+    return Path(__file__).resolve().parents[1]
 
 
 def _project_version() -> str:
-    for line in (_ROOT / "pyproject.toml").read_text(encoding="utf-8").splitlines():
+    for line in (_root() / "pyproject.toml").read_text(encoding="utf-8").splitlines():
         if line.startswith('version = "'):
             return line.split('"', 2)[1]
     raise AssertionError("project version not found")
 
 
 def _latest_changelog_version() -> str:
-    for line in (_ROOT / "CHANGELOG.md").read_text(encoding="utf-8").splitlines():
+    for line in (_root() / "CHANGELOG.md").read_text(encoding="utf-8").splitlines():
         if line.startswith("## "):
             return line.removeprefix("## ").split(" - ", 1)[0].strip()
     raise AssertionError("changelog version not found")


### PR DESCRIPTION
## Scope

- update package metadata from `1.0.0` to the existing latest changelog release `1.0.1`
- keep CLI version resolution on installed package metadata via `importlib.metadata`
- add a release-agnostic regression test that keeps package metadata, CLI version output, and the latest changelog heading aligned

This PR does not introduce a new release; it corrects metadata drift for the already-documented `1.0.1` release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version from 1.0.0 to 1.0.1.

* **Tests**
  * Added checks to ensure the package metadata, CLI-reported version, and latest changelog entry remain aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->