### PR TITLE
fix: align Hugging Face token environment names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 # Copy this file to .env and fill in your values
 
 # HuggingFace API Token (optional, increases rate limits)
+# Canonical project setting: AIMODEL_HF_TOKEN
+# Standard Hugging Face HF_TOKEN is also accepted as a fallback.
 # Get your token from: https://huggingface.co/settings/tokens
 # Token type: Read-only
 AIMODEL_HF_TOKEN=your_huggingface_token_here

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Literal
 
 from platformdirs import user_data_path
-from pydantic import Field
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 APP_NAME = "ai-model-explorer"
@@ -63,7 +63,10 @@ class Settings(BaseSettings):
     # HuggingFace settings
     hf_search_limit: int = 15
     hf_search_max_pages: int = 10
-    hf_token: str | None = None
+    hf_token: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("AIMODEL_HF_TOKEN", "HF_TOKEN"),
+    )
 
     # Ollama settings
     ollama_search_limit: int = 20

--- a/tests/test_hf_token_settings.py
+++ b/tests/test_hf_token_settings.py
@@ -1,0 +1,27 @@
+"""Regression coverage for Hugging Face token environment aliases."""
+
+from config import Settings
+
+
+def test_hf_token_accepts_project_prefixed_env(monkeypatch):
+    """The project-prefixed token remains the canonical configuration name."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setenv("AIMODEL_HF_TOKEN", "project-token")
+
+    assert Settings(_env_file=None).hf_token == "project-token"
+
+
+def test_hf_token_accepts_standard_hugging_face_env(monkeypatch):
+    """The standard Hugging Face token name remains compatible with README usage."""
+    monkeypatch.delenv("AIMODEL_HF_TOKEN", raising=False)
+    monkeypatch.setenv("HF_TOKEN", "standard-token")
+
+    assert Settings(_env_file=None).hf_token == "standard-token"
+
+
+def test_project_prefixed_hf_token_takes_precedence(monkeypatch):
+    """Prefer explicit project configuration when both token names are present."""
+    monkeypatch.setenv("AIMODEL_HF_TOKEN", "project-token")
+    monkeypatch.setenv("HF_TOKEN", "standard-token")
+
+    assert Settings(_env_file=None).hf_token == "project-token"


### PR DESCRIPTION
## Scope

- keep `AIMODEL_HF_TOKEN` as the canonical project setting
- accept standard Hugging Face `HF_TOKEN` as a fallback for compatibility with README and Hugging Face tooling
- prefer `AIMODEL_HF_TOKEN` when both variables are present
- document the fallback in `.env.example`
- add regression coverage for canonical, fallback, and precedence behavior

This keeps existing project configuration stable while making the documented `HF_TOKEN` path actually work for search as well as downloads.