### PR TITLE
fix: move HF downloads to user data directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ AIMODEL_HF_TOKEN=your_huggingface_token_here
 AIMODEL_HF_SEARCH_LIMIT=15          # Results per page
 AIMODEL_HF_SEARCH_MAX_PAGES=10      # Maximum pages to fetch
 
+# HuggingFace download directory (optional)
+# Defaults to the OS-specific per-user app data directory under models/.
+# AIMODEL_HF_MODELS_DIR=/custom/path/models
+
 # Ollama Settings
 AIMODEL_OLLAMA_API_BASE=http://localhost:11434
 AIMODEL_OLLAMA_TIMEOUT=5

--- a/config.py
+++ b/config.py
@@ -42,6 +42,7 @@ def _default_download_db_path() -> Path:
 
 
 def _default_hf_models_dir() -> Path:
+    """Return the persistent per-user directory used for Hugging Face model files."""
     return _default_data_dir() / "models"
 
 

--- a/config.py
+++ b/config.py
@@ -41,6 +41,10 @@ def _default_download_db_path() -> Path:
     return _default_data_file("downloads.db")
 
 
+def _default_hf_models_dir() -> Path:
+    return _default_data_dir() / "models"
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="AIMODEL_",
@@ -67,6 +71,7 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("AIMODEL_HF_TOKEN", "HF_TOKEN"),
     )
+    hf_models_dir: Path = Field(default_factory=_default_hf_models_dir)
 
     # Ollama settings
     ollama_search_limit: int = 20

--- a/downloads/runner.py
+++ b/downloads/runner.py
@@ -78,7 +78,7 @@ def _hf_download_script() -> str:
         "hf_hub_download("
         "repo_id=sys.argv[1], "
         "filename=sys.argv[2], "
-        "local_dir='models'"
+        "local_dir=sys.argv[3]"
         ")"
     )
 
@@ -126,6 +126,8 @@ def run_hf_download(state, target_id: str, command) -> None:
     A subprocess calls :func:`huggingface_hub.hf_hub_download` so the
     existing terminate/kill cancellation behavior remains intact.
     """
+    import config
+
     repo_id = _repo_id_from_hf_command(command)
     target_file = _target_file_from_hf_command(command)
     if not repo_id:
@@ -145,6 +147,9 @@ def run_hf_download(state, target_id: str, command) -> None:
         )
         return
 
+    models_dir = config.settings.hf_models_dir
+    models_dir.mkdir(parents=True, exist_ok=True)
+
     state.store.update_job(
         target_id,
         status="running",
@@ -152,7 +157,7 @@ def run_hf_download(state, target_id: str, command) -> None:
         progress="",
     )
     process = subprocess.Popen(
-        [sys.executable, "-c", _hf_download_script(), repo_id, target_file],
+        [sys.executable, "-c", _hf_download_script(), repo_id, target_file, str(models_dir)],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         text=True,

--- a/tests/test_hf_models_dir.py
+++ b/tests/test_hf_models_dir.py
@@ -1,7 +1,5 @@
 """Regression coverage for the Hugging Face model download directory."""
 
-from pathlib import Path
-
 from config import Settings, _default_data_dir
 from downloads.runner import _hf_download_script
 

--- a/tests/test_hf_models_dir.py
+++ b/tests/test_hf_models_dir.py
@@ -1,0 +1,29 @@
+"""Regression coverage for the Hugging Face model download directory."""
+
+from pathlib import Path
+
+from config import Settings, _default_data_dir
+from downloads.runner import _hf_download_script
+
+
+def test_hf_models_dir_defaults_to_user_data_directory(monkeypatch):
+    """HF downloads must not default to a repository-relative models directory."""
+    monkeypatch.delenv("AIMODEL_HF_MODELS_DIR", raising=False)
+
+    assert Settings(_env_file=None).hf_models_dir == _default_data_dir() / "models"
+
+
+def test_hf_models_dir_accepts_environment_override(monkeypatch, tmp_path):
+    """Users may explicitly choose a different persistent model directory."""
+    target = tmp_path / "hf-models"
+    monkeypatch.setenv("AIMODEL_HF_MODELS_DIR", str(target))
+
+    assert Settings(_env_file=None).hf_models_dir == target
+
+
+def test_hf_download_script_uses_supplied_directory_argument():
+    """The worker script must use the configured directory passed by its parent process."""
+    script = _hf_download_script()
+
+    assert "local_dir=sys.argv[3]" in script
+    assert "local_dir='models'" not in script


### PR DESCRIPTION
## Scope

- add `AIMODEL_HF_MODELS_DIR` as an optional Hugging Face download-directory override
- default Hugging Face downloads to the OS-specific per-user app data directory under `models/`
- pass the resolved directory into the existing exact-file `hf_hub_download` subprocess without changing the stored download command payload
- create the target directory before starting the worker subprocess
- add regression coverage for the default path, environment override, and subprocess script argument
- document the override in `.env.example`

This removes the current working-directory-dependent `local_dir='models'` behavior while preserving the existing download queue contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for the Hugging Face model download directory.
  - Models now download by default to the per-user application data directory under `models/`.
  - Added support for overriding the download location with the `AIMODEL_HF_MODELS_DIR` environment variable.
  - The configured directory is created automatically when needed.

- **Tests**
  - Added coverage for default directory selection, custom directory overrides, and download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->