### PR TITLE
fix: synchronize TUI provider selection

### DIFF
--- a/app/viewer.py
+++ b/app/viewer.py
@@ -21,11 +21,12 @@ _PROVIDER_COMPACT_TAGS = {
 
 
 def cycle_provider_label(labels: Sequence[str], current: str) -> str:
-    """Return the next provider label in a non-empty cyclic selector."""
+    """Return the next provider label, recovering unknown state to the first option."""
     if not labels:
         return current
-    active = current if current in labels else labels[0]
-    return labels[(labels.index(active) + 1) % len(labels)]
+    if current not in labels:
+        return labels[0]
+    return labels[(labels.index(current) + 1) % len(labels)]
 
 
 def provider_compact_tag(label: str) -> str:

--- a/app/viewer.py
+++ b/app/viewer.py
@@ -6,9 +6,9 @@ from collections.abc import Sequence
 
 from textual.containers import Vertical
 from textual.widgets import Input, Select
+from tui_app import AIModelViewer as BaseAIModelViewer
 
 from providers import get_provider_filter_labels
-from tui_app import AIModelViewer as BaseAIModelViewer
 
 
 _PROVIDER_COMPACT_TAGS = {
@@ -89,7 +89,7 @@ class AIModelViewer(BaseAIModelViewer):
 
     def on_select_changed(self, event: Select.Changed) -> None:
         """Apply provider changes made directly through the mounted selector."""
-        if event.select.id != "provider-select" or event.value is Select.NULL:
+        if event.select.id != "provider-select":
             return
         self._apply_provider_filter(str(event.value), sync_widget=False)
 

--- a/app/viewer.py
+++ b/app/viewer.py
@@ -1,0 +1,112 @@
+"""Runtime TUI viewer extensions for provider selection."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from textual.containers import Vertical
+from textual.widgets import Input, Select
+
+from providers import get_provider_filter_labels
+from tui_app import AIModelViewer as BaseAIModelViewer
+
+
+_PROVIDER_COMPACT_TAGS = {
+    "Ollama": "OL",
+    "Hugging Face": "HF",
+    "LM Studio": "LM",
+    "Docker": "DK",
+    "MLX": "MLX",
+}
+
+
+def cycle_provider_label(labels: Sequence[str], current: str) -> str:
+    """Return the next provider label in a non-empty cyclic selector."""
+    if not labels:
+        return current
+    active = current if current in labels else labels[0]
+    return labels[(labels.index(active) + 1) % len(labels)]
+
+
+def provider_compact_tag(label: str) -> str:
+    """Return a short stable tag for a provider label in compact mode."""
+    return _PROVIDER_COMPACT_TAGS.get(label, label[:3].upper() or "-")
+
+
+class AIModelViewer(BaseAIModelViewer):
+    """Run the main viewer with one synchronized provider selector."""
+
+    def __init__(self):
+        """Snapshot available provider labels for both mouse and keyboard selection."""
+        super().__init__()
+        labels = tuple(get_provider_filter_labels())
+        self.provider_filter_labels = labels or ("Ollama",)
+        if self.current_filter not in self.provider_filter_labels:
+            self.current_filter = self.provider_filter_labels[0]
+
+    async def on_mount(self) -> None:
+        """Mount the compact provider selector after the base UI initializes."""
+        super().on_mount()
+        panel = self.query_one("#provider-panel", Vertical)
+        await panel.remove_children()
+        selector = Select(
+            ((label, label) for label in self.provider_filter_labels),
+            value=self.current_filter,
+            allow_blank=False,
+            id="provider-select",
+        )
+        selector.styles.width = "100%"
+        selector.styles.height = 3
+        await panel.mount(selector)
+
+    def _apply_provider_filter(self, label: str, *, sync_widget: bool) -> None:
+        """Apply one provider label and keep the mounted selector synchronized."""
+        if label not in self.provider_filter_labels or label == self.current_filter:
+            return
+
+        self.current_filter = label
+        if sync_widget:
+            try:
+                selector = self.query_one("#provider-select", Select)
+                if selector.value != label:
+                    selector.value = label
+            except Exception:
+                pass
+
+        current_query = self.query_one("#search-input", Input).value.strip()
+        if current_query:
+            self.start_search(current_query)
+            self.update_status(f"Provider switched to {label}. Searching...")
+        else:
+            self.refresh_table()
+            self.update_status(f"Provider filter set to {label}.")
+
+    def action_cycle_provider(self) -> None:
+        """Cycle through the exact provider labels displayed by the selector."""
+        next_filter = cycle_provider_label(self.provider_filter_labels, self.current_filter)
+        self._apply_provider_filter(next_filter, sync_widget=True)
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Apply provider changes made directly through the mounted selector."""
+        if event.select.id != "provider-select" or event.value is Select.NULL:
+            return
+        self._apply_provider_filter(str(event.value), sync_widget=False)
+
+    def _compact_chip_text(self, shown_count: int, total: int) -> str:
+        """Render compact search state using a provider-specific short tag."""
+        provider_short = provider_compact_tag(self.current_filter)
+        use_case_label = self._use_case_compact_tag(self.use_case_filter)
+        sort_label = self._sort_compact_tag(self.sort_mode)
+        fit_label = self._fit_compact_tag(self.fit_filter)
+        gems_label = "ON" if self.hidden_gems_only else "OFF"
+        page_label = str(self.current_page + 1) if self.current_filter == "Hugging Face" else "1"
+
+        return (
+            f"[#8ea3cf]M:[/#8ea3cf][#dbe7ff]{shown_count}/{total}[/#dbe7ff]  "
+            f"[#8ea3cf]P:[/#8ea3cf][#9fe8ff]{provider_short}[/#9fe8ff]  "
+            f"[#8ea3cf]U:[/#8ea3cf][#d1b3ff]{use_case_label}[/#d1b3ff]  "
+            f"[#8ea3cf]S:[/#8ea3cf][#7edfff]{sort_label}[/#7edfff]  "
+            f"[#8ea3cf]F:[/#8ea3cf][#f2c46d]{fit_label}[/#f2c46d]  "
+            f"[#8ea3cf]G:[/#8ea3cf][#4fe08a]{gems_label}[/#4fe08a]  "
+            f"[#8ea3cf]Pg:[/#8ea3cf][#dbe7ff]{page_label}[/#dbe7ff]"
+        )

--- a/app/viewer.py
+++ b/app/viewer.py
@@ -6,9 +6,9 @@ from collections.abc import Sequence
 
 from textual.containers import Vertical
 from textual.widgets import Input, Select
-from tui_app import AIModelViewer as BaseAIModelViewer
 
 from providers import get_provider_filter_labels
+from tui_app import AIModelViewer as BaseAIModelViewer
 
 
 _PROVIDER_COMPACT_TAGS = {

--- a/main.py
+++ b/main.py
@@ -7,11 +7,15 @@ from app.viewer import AIModelViewer
 
 
 def smoke_mode_enabled() -> bool:
+    """Return whether process smoke mode is enabled."""
     return os.getenv("AIMODEL_SMOKE") == "1"
 
 
 def run_smoke_check() -> int:
+    """Boot the runtime viewer in Textual test mode and return its exit code."""
+
     async def _run() -> int:
+        """Run the async Textual smoke session."""
         app = AIModelViewer()
         async with app.run_test() as pilot:
             await pilot.pause(1.5)

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 
-from tui_app import AIModelViewer
+from app.viewer import AIModelViewer
 
 
 def smoke_mode_enabled() -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["app", "core", "downloads", "providers",
-                     "results", "scripts", "search"]
+                     "results", "scripts", "search", "tui_app"]
 
 [tool.ruff.lint.per-file-ignores]
 "tui_app.py" = ["I001", "RUF012", "SIM105", "SIM117", "RUF010"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,11 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["app", "core", "downloads", "providers",
-                     "results", "scripts", "search", "tui_app"]
+                     "results", "scripts", "search"]
 
 [tool.ruff.lint.per-file-ignores]
 "tui_app.py" = ["I001", "RUF012", "SIM105", "SIM117", "RUF010"]
+"app/viewer.py" = ["I001"]
 "tests/test_search_orchestrator.py" = ["SIM108"]
 "downloads/download_service.py" = ["SIM105"]
 "downloads/api.py" = ["SIM105"]

--- a/tests/test_provider_selector_viewer.py
+++ b/tests/test_provider_selector_viewer.py
@@ -1,0 +1,37 @@
+"""Regression coverage for the runtime TUI provider selector."""
+
+from app.viewer import cycle_provider_label, provider_compact_tag
+
+
+def test_cycle_provider_label_uses_full_snapshot():
+    """Cycling must traverse every provider exposed by the selector snapshot."""
+    labels = ("Ollama", "Hugging Face", "LM Studio", "Docker", "MLX")
+
+    current = labels[0]
+    visited = []
+    for _ in range(len(labels)):
+        current = cycle_provider_label(labels, current)
+        visited.append(current)
+
+    assert visited == ["Hugging Face", "LM Studio", "Docker", "MLX", "Ollama"]
+
+
+def test_cycle_provider_label_recovers_from_unknown_current():
+    """An unknown current filter must recover deterministically into the snapshot."""
+    labels = ("Ollama", "Hugging Face")
+
+    assert cycle_provider_label(labels, "Unknown") == "Hugging Face"
+
+
+def test_cycle_provider_label_handles_empty_snapshot():
+    """An empty selector snapshot must preserve the current filter safely."""
+    assert cycle_provider_label((), "Ollama") == "Ollama"
+
+
+def test_provider_compact_tag_distinguishes_optional_providers():
+    """Compact mode must not label optional providers as Ollama."""
+    assert provider_compact_tag("Ollama") == "OL"
+    assert provider_compact_tag("Hugging Face") == "HF"
+    assert provider_compact_tag("LM Studio") == "LM"
+    assert provider_compact_tag("Docker") == "DK"
+    assert provider_compact_tag("MLX") == "MLX"

--- a/tests/test_provider_selector_viewer.py
+++ b/tests/test_provider_selector_viewer.py
@@ -20,7 +20,7 @@ def test_cycle_provider_label_recovers_from_unknown_current():
     """An unknown current filter must recover deterministically into the snapshot."""
     labels = ("Ollama", "Hugging Face")
 
-    assert cycle_provider_label(labels, "Unknown") == "Hugging Face"
+    assert cycle_provider_label(labels, "Unknown") == "Ollama"
 
 
 def test_cycle_provider_label_handles_empty_snapshot():


### PR DESCRIPTION
## Scope

- replace the hard-coded two-provider runtime control with a single compact Textual `Select`
- snapshot the detected provider labels once at viewer initialization and use the exact same snapshot for mouse selection and the `p` keyboard cycle
- keep the existing three-row provider panel footprint
- show distinct compact-mode tags for LM Studio, Docker, and MLX instead of incorrectly falling back to the Ollama tag
- wire `main.py` to the runtime viewer extension so existing smoke mode exercises the real selector integration
- add regression coverage for full provider cycling, invalid-state recovery, empty snapshots, and compact provider tags

Preflight:
- all new/touched callables have docstrings
- `main.py` entrypoint callables were also documented because the file is touched by this PR
- no provider search semantics or capability flags are changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added provider selection to the terminal viewer.
  - Users can cycle through available providers with the keyboard or choose one directly.
  - Changing providers preserves active searches or refreshes displayed results automatically.
  - Added compact provider and status indicators, including pagination state.

- **Bug Fixes**
  - Improved handling when the selected provider is unavailable or when no providers are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->