### PR TITLE
fix: pass configured HF token in CLI searches

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -400,7 +400,7 @@ def cache_stats():
     cursor.execute("SELECT source, COUNT(*) FROM model_cache GROUP BY source")
     counts = cursor.fetchall()
 
-    console.print("[bold]Cache Statistics:[/bold]")
+    console.print("\n[bold]Cache Statistics:[/bold]")
     for source, count in counts:
         console.print(f"  {source}: {count} entries")
 

--- a/cli.py
+++ b/cli.py
@@ -28,6 +28,19 @@ def get_cli_search_provider_choices() -> tuple[str, ...]:
     return ("all", *supported)
 
 
+def _search_hf_models(query: str, specs: dict, model_info_cache: dict, *, limit: int):
+    """Search Hugging Face from the CLI using the configured authentication token."""
+    from providers.hf_provider import search_hf_models
+
+    return search_hf_models(
+        query,
+        specs,
+        model_info_cache,
+        limit=limit,
+        hf_token=config.settings.hf_token,
+    )
+
+
 def get_version() -> str:
     """Return the installed AI Model Explorer package version."""
     try:
@@ -110,7 +123,6 @@ def system_info():
 )
 def search(query, provider, limit, sort):
     """Search for models matching QUERY."""
-    from providers.hf_provider import search_hf_models
     from providers.ollama_provider import get_installed_ollama_models, search_ollama_models
 
     monitor = HardwareMonitor()
@@ -124,7 +136,7 @@ def search(query, provider, limit, sort):
             results.extend(ollama_results)
 
         if provider in ("all", "huggingface"):
-            hf_results, _ = search_hf_models(query, specs, {}, limit=limit)
+            hf_results, _ = _search_hf_models(query, specs, {}, limit=limit)
             results.extend(hf_results)
 
     if sort == "composite":
@@ -173,7 +185,6 @@ def search(query, provider, limit, sort):
 @click.option("--limit", "-n", default=5, help="Max results")
 def fit(perfect, limit):
     """Find models that fit your hardware."""
-    from providers.hf_provider import search_hf_models
     from providers.ollama_provider import get_installed_ollama_models, search_ollama_models
 
     monitor = HardwareMonitor()
@@ -185,7 +196,7 @@ def fit(perfect, limit):
         ollama_results, _, _ = search_ollama_models("*", specs, local, page_size=50)
         results.extend(ollama_results)
 
-        hf_results, _ = search_hf_models("*", specs, {}, limit=50)
+        hf_results, _ = _search_hf_models("*", specs, {}, limit=50)
         results.extend(hf_results)
 
     results.sort(key=lambda r: r.get("score_composite", 0), reverse=True)
@@ -226,7 +237,6 @@ def fit(perfect, limit):
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 def recommend(limit, use_case, output_json):
     """Get model recommendations for your hardware."""
-    from providers.hf_provider import search_hf_models
     from providers.ollama_provider import get_installed_ollama_models, search_ollama_models
 
     monitor = HardwareMonitor()
@@ -238,7 +248,7 @@ def recommend(limit, use_case, output_json):
         ollama_results, _, _ = search_ollama_models("*", specs, local, page_size=50)
         results.extend(ollama_results)
 
-        hf_results, _ = search_hf_models("*", specs, {}, limit=50)
+        hf_results, _ = _search_hf_models("*", specs, {}, limit=50)
         results.extend(hf_results)
 
     results = [r for r in results if r.get("use_case_key") == use_case or use_case == "general"]
@@ -390,7 +400,7 @@ def cache_stats():
     cursor.execute("SELECT source, COUNT(*) FROM model_cache GROUP BY source")
     counts = cursor.fetchall()
 
-    console.print("\n[bold]Cache Statistics:[/bold]")
+    console.print("[bold]Cache Statistics:[/bold]")
     for source, count in counts:
         console.print(f"  {source}: {count} entries")
 

--- a/tests/test_cli_hf_token.py
+++ b/tests/test_cli_hf_token.py
@@ -1,0 +1,34 @@
+"""Regression coverage for Hugging Face token propagation in CLI searches."""
+
+from types import SimpleNamespace
+
+import config
+import providers.hf_provider as hf_provider
+from cli import _search_hf_models
+
+
+def test_cli_hf_search_passes_configured_token(monkeypatch):
+    """CLI Hugging Face searches must use the configured authentication token."""
+    captured = {}
+
+    def fake_search(query, specs, model_info_cache, **kwargs):
+        """Capture the arguments passed by the CLI search helper."""
+        captured.update(
+            {
+                "query": query,
+                "specs": specs,
+                "model_info_cache": model_info_cache,
+                **kwargs,
+            }
+        )
+        return [], []
+
+    monkeypatch.setattr(config, "settings", SimpleNamespace(hf_token="hf_cli_test"))
+    monkeypatch.setattr(hf_provider, "search_hf_models", fake_search)
+
+    result = _search_hf_models("llama", {"ram_total": 16}, {}, limit=7)
+
+    assert result == ([], [])
+    assert captured["query"] == "llama"
+    assert captured["limit"] == 7
+    assert captured["hf_token"] == "hf_cli_test"


### PR DESCRIPTION
## Scope

- centralize CLI Hugging Face search calls behind one helper
- pass `config.settings.hf_token` into Hugging Face searches from `search`, `fit`, and `recommend`
- preserve the existing CLI provider surface and search semantics
- add focused regression coverage that captures the forwarded token

Preflight:
- combined diff is limited to `cli.py` and one new test file
- all new/touched callables, including the nested test double, have docstrings
- no test expectations or provider capability flags are weakened