### PR TITLE
feat: harden download service authentication boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ python -m api_server --port 9000  # Custom port
 |---|---|---|
 | `AIMODEL_HF_TOKEN` | - | Canonical Hugging Face read-only token setting; standard `HF_TOKEN` is accepted as a fallback |
 | `AIMODEL_HF_MODELS_DIR` | OS-specific user-data `models/` directory | Hugging Face GGUF download directory |
-| `AIMODEL_DOWNLOAD_SERVICE_HOST` | `127.0.0.1` | Download-service bind/client host; non-loopback values require `AIMODEL_DOWNLOAD_SERVICE_TOKEN` |
+| `AIMODEL_DOWNLOAD_SERVICE_HOST` | `127.0.0.1` | Download-service bind/client host; non-loopback values are rejected until TLS transport is implemented |
 | `AIMODEL_DOWNLOAD_SERVICE_PORT` | `8765` | Download-service bind/client port |
-| `AIMODEL_DOWNLOAD_SERVICE_TOKEN` | - | Bearer token protecting download-service endpoints except `/health`; required for non-loopback binds |
+| `AIMODEL_DOWNLOAD_SERVICE_TOKEN` | - | Optional bearer token protecting download-service endpoints except `/health`; intended as loopback defence-in-depth |
 | `AIMODEL_DOWNLOAD_MAX_WORKERS` | 2 | Parallel download worker count |
 | `AIMODEL_HF_SEARCH_LIMIT` | 15 | HF results per page |
 | `AIMODEL_HF_SEARCH_MAX_PAGES` | 10 | Max HF pages |
@@ -146,7 +146,6 @@ python -m api_server --port 9000  # Custom port
 AIMODEL_HF_TOKEN=hf_your_token_here
 # HF_TOKEN=hf_your_token_here  # Supported fallback for Hugging Face tooling compatibility
 # AIMODEL_HF_MODELS_DIR=/custom/path/models
-# AIMODEL_DOWNLOAD_SERVICE_HOST=0.0.0.0
 # AIMODEL_DOWNLOAD_SERVICE_TOKEN=replace-with-a-long-random-secret
 AIMODEL_UI_MODE=compact
 AIMODEL_THEME=nord
@@ -186,7 +185,7 @@ llm-terminal/
   requirements/            # Runtime/dev intent + committed platform locks
   downloads/               # Download state, lifecycle, command builder, service client, HF downloader
   results/                 # Table layout, formatting, filtering helpers
-  search/                  # Search cache and provider orchestration
+  search/                   # Search cache and provider orchestration
   scripts/                 # Dev, release, and maintenance utilities (Python + batch)
   terminal_ui/             # Theme/style assets plus isolated legacy UI internals
   providers/
@@ -222,6 +221,6 @@ Where efficiency depends on inference mode: GPU (0.55), GPU+CPU offload (0.30), 
 - `terminal_ui/` now exists mainly for theme/style assets; the legacy experimental UI remains isolated there.
 - Download service data and metadata cache are stored in the OS-specific per-user application data directory by default; `AIMODEL_DOWNLOAD_DB_PATH` and `AIMODEL_CACHE_DB_PATH` can override those paths.
 - Hugging Face GGUF files are stored in the same per-user application data directory under `models/` by default; `AIMODEL_HF_MODELS_DIR` can override the destination.
-- Download service binds to loopback by default. Binding it to `0.0.0.0`, a LAN address, or another non-loopback host requires `AIMODEL_DOWNLOAD_SERVICE_TOKEN`; startup fails closed without one. `/health` stays public for probes, while job, debug, cancellation, deletion, and shutdown endpoints require the bearer token when configured.
+- Download service remains loopback-only. `0.0.0.0`, LAN addresses, and other non-loopback bind/client hosts are rejected until authenticated TLS transport is implemented. `/health` stays public for probes; when `AIMODEL_DOWNLOAD_SERVICE_TOKEN` is configured, job, debug, cancellation, deletion, and shutdown endpoints require the bearer token on loopback.
 - REST API binds to `127.0.0.1:8787` by default (localhost only).
 - Provider auto-detection runs at startup; unavailable providers are silently skipped.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ python -m api_server --port 9000  # Custom port
 |---|---|---|
 | `AIMODEL_HF_TOKEN` | - | Canonical Hugging Face read-only token setting; standard `HF_TOKEN` is accepted as a fallback |
 | `AIMODEL_HF_MODELS_DIR` | OS-specific user-data `models/` directory | Hugging Face GGUF download directory |
+| `AIMODEL_DOWNLOAD_SERVICE_HOST` | `127.0.0.1` | Download-service bind/client host; non-loopback values require `AIMODEL_DOWNLOAD_SERVICE_TOKEN` |
+| `AIMODEL_DOWNLOAD_SERVICE_PORT` | `8765` | Download-service bind/client port |
+| `AIMODEL_DOWNLOAD_SERVICE_TOKEN` | - | Bearer token protecting download-service endpoints except `/health`; required for non-loopback binds |
 | `AIMODEL_DOWNLOAD_MAX_WORKERS` | 2 | Parallel download worker count |
 | `AIMODEL_HF_SEARCH_LIMIT` | 15 | HF results per page |
 | `AIMODEL_HF_SEARCH_MAX_PAGES` | 10 | Max HF pages |
@@ -143,6 +146,8 @@ python -m api_server --port 9000  # Custom port
 AIMODEL_HF_TOKEN=hf_your_token_here
 # HF_TOKEN=hf_your_token_here  # Supported fallback for Hugging Face tooling compatibility
 # AIMODEL_HF_MODELS_DIR=/custom/path/models
+# AIMODEL_DOWNLOAD_SERVICE_HOST=0.0.0.0
+# AIMODEL_DOWNLOAD_SERVICE_TOKEN=replace-with-a-long-random-secret
 AIMODEL_UI_MODE=compact
 AIMODEL_THEME=nord
 ```
@@ -217,5 +222,6 @@ Where efficiency depends on inference mode: GPU (0.55), GPU+CPU offload (0.30), 
 - `terminal_ui/` now exists mainly for theme/style assets; the legacy experimental UI remains isolated there.
 - Download service data and metadata cache are stored in the OS-specific per-user application data directory by default; `AIMODEL_DOWNLOAD_DB_PATH` and `AIMODEL_CACHE_DB_PATH` can override those paths.
 - Hugging Face GGUF files are stored in the same per-user application data directory under `models/` by default; `AIMODEL_HF_MODELS_DIR` can override the destination.
+- Download service binds to loopback by default. Binding it to `0.0.0.0`, a LAN address, or another non-loopback host requires `AIMODEL_DOWNLOAD_SERVICE_TOKEN`; startup fails closed without one. `/health` stays public for probes, while job, debug, cancellation, deletion, and shutdown endpoints require the bearer token when configured.
 - REST API binds to `127.0.0.1:8787` by default (localhost only).
 - Provider auto-detection runs at startup; unavailable providers are silently skipped.

--- a/config.py
+++ b/config.py
@@ -83,6 +83,7 @@ class Settings(BaseSettings):
     download_db_path: Path = Field(default_factory=_default_download_db_path)
     download_service_host: str = "127.0.0.1"
     download_service_port: int = 8765
+    download_service_token: str | None = None
     download_history_limit: int = 50
     download_history_refresh_interval: float = 0.9
     download_poll_request_timeout: float = 0.35

--- a/downloads/api.py
+++ b/downloads/api.py
@@ -14,6 +14,7 @@ up a real subprocess service.
 
 from __future__ import annotations
 
+import hmac
 import json
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import parse_qs, urlparse
@@ -27,8 +28,8 @@ def _has_duplicates(values):
     return len(values) != len(set(values))
 
 
-def _make_handler(state):
-    """Build a Handler class bound to *state*.
+def _make_handler(state, auth_token: str | None = None):
+    """Build a Handler class bound to *state* and an optional bearer token.
 
     BaseHTTPRequestHandler is instantiated per request, so we close
     over *state* in a small factory rather than referencing the
@@ -43,15 +44,21 @@ def _make_handler(state):
     _can_term = _can_terminate_process
 
     class Handler(BaseHTTPRequestHandler):
-        def _json_response(self, status_code, payload):
+        """Serve download-service requests against the factory-bound state."""
+
+        def _json_response(self, status_code, payload, extra_headers=None):
+            """Write one JSON response with optional extra headers."""
             body = json.dumps(payload).encode("utf-8")
             self.send_response(status_code)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
+            for name, value in (extra_headers or {}).items():
+                self.send_header(name, value)
             self.end_headers()
             self.wfile.write(body)
 
         def _read_json(self):
+            """Read and decode the request JSON body, returning an empty dict if absent."""
             length = int(self.headers.get("Content-Length", "0"))
             if length <= 0:
                 return {}
@@ -60,10 +67,33 @@ def _make_handler(state):
                 return {}
             return json.loads(raw)
 
+        def _is_authorized(self) -> bool:
+            """Return whether this request satisfies the configured bearer token."""
+            if not auth_token:
+                return True
+            supplied = self.headers.get("Authorization", "")
+            expected = f"Bearer {auth_token}"
+            return hmac.compare_digest(supplied, expected)
+
+        def _require_auth(self) -> bool:
+            """Reject unauthorized requests and return whether dispatch may continue."""
+            if self._is_authorized():
+                return True
+            self._json_response(
+                401,
+                {"error": "unauthorized"},
+                {"WWW-Authenticate": "Bearer"},
+            )
+            return False
+
         def do_GET(self):
+            """Dispatch GET requests, leaving only the health endpoint public."""
             parsed = urlparse(self.path)
             if parsed.path == "/health":
                 self._json_response(200, {"ok": True, "version": SERVICE_VERSION})
+                return
+
+            if not self._require_auth():
                 return
 
             if parsed.path == "/debug/active":
@@ -91,6 +121,10 @@ def _make_handler(state):
             self._json_response(404, {"error": "not found"})
 
         def do_POST(self):
+            """Dispatch authenticated mutation requests."""
+            if not self._require_auth():
+                return
+
             if self.path == "/jobs":
                 try:
                     payload = self._read_json()
@@ -168,6 +202,7 @@ def _make_handler(state):
             self._json_response(404, {"error": "not found"})
 
         def log_message(self, format, *args):
+            """Suppress the default BaseHTTPRequestHandler access log."""
             return
 
     return Handler
@@ -178,9 +213,12 @@ def _make_handler(state):
 # imported lazily at module-load time (after download_service.py has
 # finished initialising) to break the circular dependency.
 def _build_default_handler():
+    """Build the production handler from process-wide state and settings."""
+    import config
+
     from .download_service import STATE
 
-    return _make_handler(STATE)
+    return _make_handler(STATE, auth_token=config.settings.download_service_token)
 
 
 Handler = _build_default_handler()

--- a/downloads/download_service.py
+++ b/downloads/download_service.py
@@ -21,6 +21,7 @@ files are 200-300 lines each with a single, testable responsibility.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import threading
@@ -36,7 +37,7 @@ import config
 from downloads.runner import process_job
 from downloads.store import DownloadStore
 
-SERVICE_VERSION = "1.7"
+SERVICE_VERSION = "1.8"
 
 
 def download_db_path():
@@ -52,11 +53,37 @@ def service_bind_address() -> tuple[str, int]:
     )
 
 
+def _is_loopback_host(host: str) -> bool:
+    """Return whether *host* is an explicit loopback address or localhost."""
+    normalized = str(host).strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_service_auth_boundary() -> None:
+    """Require a bearer token before allowing a non-loopback service bind."""
+    host, _ = service_bind_address()
+    if _is_loopback_host(host):
+        return
+    if config.settings.download_service_token:
+        return
+    raise RuntimeError(
+        "AIMODEL_DOWNLOAD_SERVICE_TOKEN is required when "
+        "AIMODEL_DOWNLOAD_SERVICE_HOST is not loopback"
+    )
+
+
 def smoke_mode_enabled() -> bool:
+    """Return whether the service should run its bounded smoke check."""
     return os.getenv("AIMODEL_SMOKE") == "1"
 
 
 def ensure_data_dir() -> None:
+    """Create the configured download database directory if needed."""
     download_db_path().parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -165,6 +192,8 @@ def worker_loop():
 
 
 def main():
+    """Run the configured download service or its smoke check."""
+    validate_service_auth_boundary()
     if smoke_mode_enabled():
         return run_smoke_check()
 
@@ -186,6 +215,7 @@ def main():
 
 
 def run_smoke_check() -> int:
+    """Run bounded health and authenticated jobs checks against an ephemeral server."""
     from downloads.api import Handler
 
     STATE.stop_event.clear()
@@ -208,7 +238,11 @@ def run_smoke_check() -> int:
 
     try:
         for path, expected_key in (("/health", "ok"), ("/jobs", "jobs")):
-            with urllib.request.urlopen(f"http://{host}:{port}{path}", timeout=5) as response:
+            request = urllib.request.Request(f"http://{host}:{port}{path}")
+            token = config.settings.download_service_token
+            if token:
+                request.add_header("Authorization", f"Bearer {token}")
+            with urllib.request.urlopen(request, timeout=5) as response:
                 payload = json.loads(response.read().decode("utf-8"))
             if expected_key not in payload:
                 raise SystemExit(f"[smoke] download service check failed for {path}")

--- a/downloads/download_service.py
+++ b/downloads/download_service.py
@@ -65,15 +65,12 @@ def _is_loopback_host(host: str) -> bool:
 
 
 def validate_service_auth_boundary() -> None:
-    """Require a bearer token before allowing a non-loopback service bind."""
+    """Reject non-loopback binds until authenticated TLS transport is supported."""
     host, _ = service_bind_address()
     if _is_loopback_host(host):
         return
-    if config.settings.download_service_token:
-        return
     raise RuntimeError(
-        "AIMODEL_DOWNLOAD_SERVICE_TOKEN is required when "
-        "AIMODEL_DOWNLOAD_SERVICE_HOST is not loopback"
+        "Non-loopback download-service binds are disabled until authenticated TLS transport is supported"
     )
 
 

--- a/downloads/service_client.py
+++ b/downloads/service_client.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import subprocess
 import sys
@@ -15,10 +16,25 @@ except ImportError:  # pragma: no cover - exercised only in lightweight envs
 MIN_SERVICE_VERSION = "1.8"
 
 
+def _is_loopback_host(host: str) -> bool:
+    """Return whether *host* is an explicit loopback address or localhost."""
+    normalized = str(host).strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
 def service_base_url():
-    """Return the configured download-service base URL."""
+    """Return the configured loopback-only download-service base URL."""
     host = config.settings.download_service_host
     port = config.settings.download_service_port
+    if not _is_loopback_host(host):
+        raise RuntimeError(
+            "Non-loopback download-service clients are disabled until authenticated TLS transport is supported"
+        )
     return f"http://{host}:{port}"
 
 
@@ -35,10 +51,11 @@ def _parse_version(version_str):
 
 
 def _request(method, path, payload=None, timeout=2.0):
-    """Send an HTTP request to the download service and return parsed JSON.
+    """Send an HTTP request to the loopback download service and return parsed JSON.
 
     Adds the configured bearer token when present. Raises any network or HTTP
-    errors to the caller.
+    errors to the caller. Non-loopback plaintext targets are rejected before
+    request construction.
     """
     url = f"{service_base_url()}{path}"
     data = None
@@ -62,7 +79,7 @@ def is_service_running():
     try:
         data = _request("GET", "/health", timeout=1.0)
         return bool(data.get("ok"))
-    except (URLError, HTTPError, TimeoutError, ValueError):
+    except (URLError, HTTPError, TimeoutError, ValueError, RuntimeError):
         return False
 
 
@@ -109,7 +126,7 @@ def _wait_for_service(deadline_seconds=6.0):
             health = get_service_health()
             if health.get("ok") and is_service_compatible(health):
                 return True
-        except (URLError, HTTPError, TimeoutError, ValueError):
+        except (URLError, HTTPError, TimeoutError, ValueError, RuntimeError):
             pass
         time.sleep(0.2)
     return False
@@ -128,7 +145,7 @@ def stop_service():
     try:
         _request("POST", "/shutdown", payload={}, timeout=1.0)
         stopped_any = True
-    except (URLError, HTTPError, TimeoutError, ValueError):
+    except (URLError, HTTPError, TimeoutError, ValueError, RuntimeError):
         pass
 
     if psutil is not None:
@@ -164,7 +181,7 @@ def ensure_service_running():
             if is_service_compatible(health):
                 return True
             stop_service()
-        except (URLError, HTTPError, TimeoutError, ValueError):
+        except (URLError, HTTPError, TimeoutError, ValueError, RuntimeError):
             stop_service()
 
     _start_service_process()

--- a/downloads/service_client.py
+++ b/downloads/service_client.py
@@ -12,7 +12,7 @@ try:
 except ImportError:  # pragma: no cover - exercised only in lightweight envs
     psutil = None
 
-MIN_SERVICE_VERSION = "1.7"
+MIN_SERVICE_VERSION = "1.8"
 
 
 def service_base_url():
@@ -35,13 +35,17 @@ def _parse_version(version_str):
 
 
 def _request(method, path, payload=None, timeout=2.0):
-    """Send an HTTP request to the local download service and return parsed JSON.
+    """Send an HTTP request to the download service and return parsed JSON.
 
-    Raises any network or HTTP errors to the caller.
+    Adds the configured bearer token when present. Raises any network or HTTP
+    errors to the caller.
     """
     url = f"{service_base_url()}{path}"
     data = None
     headers = {"Content-Type": "application/json"}
+    token = config.settings.download_service_token
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     if payload is not None:
         data = json.dumps(payload).encode("utf-8")
 

--- a/downloads/service_client.py
+++ b/downloads/service_client.py
@@ -66,20 +66,20 @@ def _parse_version(version_str):
 def _request(method, path, payload=None, timeout=2.0):
     """Send an HTTP request directly to the loopback download service.
 
-    Adds the configured bearer token when present. Non-loopback plaintext targets
-    are rejected before request construction, and environment proxy settings are
-    bypassed so loopback credentials cannot be forwarded to a proxy.
+    Adds the configured bearer token only to the initial request. Non-loopback
+    plaintext targets are rejected before request construction, environment proxy
+    settings are bypassed, and redirects cannot forward the bearer token.
     """
     url = f"{service_base_url()}{path}"
     data = None
     headers = {"Content-Type": "application/json"}
-    token = config.settings.download_service_token
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
     if payload is not None:
         data = json.dumps(payload).encode("utf-8")
 
     req = Request(url=url, data=data, method=method, headers=headers)
+    token = config.settings.download_service_token
+    if token:
+        req.add_unredirected_header("Authorization", f"Bearer {token}")
     with _NO_PROXY_OPENER.open(req, timeout=timeout) as response:
         body = response.read().decode("utf-8")
         if not body:

--- a/downloads/service_client.py
+++ b/downloads/service_client.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 import time
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import ProxyHandler, Request, build_opener
 
 import config
 
@@ -14,6 +14,7 @@ except ImportError:  # pragma: no cover - exercised only in lightweight envs
     psutil = None
 
 MIN_SERVICE_VERSION = "1.8"
+_NO_PROXY_OPENER = build_opener(ProxyHandler({}))
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -27,6 +28,18 @@ def _is_loopback_host(host: str) -> bool:
         return False
 
 
+def _url_host(host: str) -> str:
+    """Return a URL-safe host, bracketing IPv6 literals when required."""
+    normalized = str(host).strip()
+    try:
+        address = ipaddress.ip_address(normalized)
+    except ValueError:
+        return normalized
+    if address.version == 6:
+        return f"[{normalized}]"
+    return normalized
+
+
 def service_base_url():
     """Return the configured loopback-only download-service base URL."""
     host = config.settings.download_service_host
@@ -35,7 +48,7 @@ def service_base_url():
         raise RuntimeError(
             "Non-loopback download-service clients are disabled until authenticated TLS transport is supported"
         )
-    return f"http://{host}:{port}"
+    return f"http://{_url_host(host)}:{port}"
 
 
 def _parse_version(version_str):
@@ -51,11 +64,11 @@ def _parse_version(version_str):
 
 
 def _request(method, path, payload=None, timeout=2.0):
-    """Send an HTTP request to the loopback download service and return parsed JSON.
+    """Send an HTTP request directly to the loopback download service.
 
-    Adds the configured bearer token when present. Raises any network or HTTP
-    errors to the caller. Non-loopback plaintext targets are rejected before
-    request construction.
+    Adds the configured bearer token when present. Non-loopback plaintext targets
+    are rejected before request construction, and environment proxy settings are
+    bypassed so loopback credentials cannot be forwarded to a proxy.
     """
     url = f"{service_base_url()}{path}"
     data = None
@@ -67,7 +80,7 @@ def _request(method, path, payload=None, timeout=2.0):
         data = json.dumps(payload).encode("utf-8")
 
     req = Request(url=url, data=data, method=method, headers=headers)
-    with urlopen(req, timeout=timeout) as response:
+    with _NO_PROXY_OPENER.open(req, timeout=timeout) as response:
         body = response.read().decode("utf-8")
         if not body:
             return {}

--- a/tests/test_download_service_auth.py
+++ b/tests/test_download_service_auth.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import threading
 from http.server import ThreadingHTTPServer
-from types import SimpleNamespace
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 

--- a/tests/test_download_service_auth.py
+++ b/tests/test_download_service_auth.py
@@ -1,0 +1,114 @@
+"""Regression coverage for the download-service authentication boundary."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import ThreadingHTTPServer
+from types import SimpleNamespace
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+import config
+from downloads import download_service, service_client
+from downloads.api import _make_handler
+
+
+class _StoreStub:
+    """Provide the minimal store surface used by the authenticated jobs endpoint."""
+
+    def list_jobs(self, limit=50):
+        """Return deterministic job data for HTTP boundary tests."""
+        return [{"target_id": "model-1", "limit": limit}]
+
+
+class _StateStub:
+    """Provide the minimal state surface required by the HTTP handler."""
+
+    def __init__(self):
+        """Initialize deterministic state and worker metadata."""
+        self.store = _StoreStub()
+        self.worker_thread = None
+
+    def snapshot_active_targets(self):
+        """Return no active targets for diagnostic requests."""
+        return []
+
+
+def test_non_loopback_bind_requires_token(monkeypatch):
+    """Remote download-service binds must fail closed when no token is configured."""
+    monkeypatch.setattr(config.settings, "download_service_host", "0.0.0.0")
+    monkeypatch.setattr(config.settings, "download_service_token", None)
+
+    with pytest.raises(RuntimeError, match="AIMODEL_DOWNLOAD_SERVICE_TOKEN"):
+        download_service.validate_service_auth_boundary()
+
+
+def test_loopback_bind_remains_token_optional(monkeypatch):
+    """Default loopback usage must remain compatible without a bearer token."""
+    monkeypatch.setattr(config.settings, "download_service_host", "127.0.0.1")
+    monkeypatch.setattr(config.settings, "download_service_token", None)
+
+    download_service.validate_service_auth_boundary()
+
+
+def test_service_client_forwards_configured_bearer_token(monkeypatch):
+    """The shared client request helper must attach the configured bearer token."""
+    captured = {}
+
+    class _ResponseStub:
+        """Act as a minimal urlopen response context manager."""
+
+        def __enter__(self):
+            """Return the response stub for context-manager use."""
+            return self
+
+        def __exit__(self, *args):
+            """Leave the context manager without suppressing exceptions."""
+            return False
+
+        def read(self):
+            """Return a deterministic JSON response body."""
+            return b'{"ok": true}'
+
+    def fake_urlopen(request, timeout):
+        """Capture the outbound Authorization header."""
+        captured["authorization"] = request.get_header("Authorization")
+        captured["timeout"] = timeout
+        return _ResponseStub()
+
+    monkeypatch.setattr(config.settings, "download_service_token", "secret-token")
+    monkeypatch.setattr(service_client, "urlopen", fake_urlopen)
+
+    assert service_client.get_service_health(timeout=1.25) == {"ok": True}
+    assert captured == {"authorization": "Bearer secret-token", "timeout": 1.25}
+
+
+def test_handler_keeps_health_public_and_protects_jobs():
+    """A configured token must protect job data while leaving health probes public."""
+    handler = _make_handler(_StateStub(), auth_token="secret-token")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+
+    try:
+        with urlopen(f"http://{host}:{port}/health", timeout=2) as response:
+            health = json.loads(response.read().decode("utf-8"))
+        assert health["ok"] is True
+
+        with pytest.raises(HTTPError) as exc_info:
+            urlopen(f"http://{host}:{port}/jobs", timeout=2)
+        assert exc_info.value.code == 401
+
+        request = Request(f"http://{host}:{port}/jobs")
+        request.add_header("Authorization", "Bearer secret-token")
+        with urlopen(request, timeout=2) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload["jobs"][0]["target_id"] == "model-1"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()

--- a/tests/test_download_service_auth.py
+++ b/tests/test_download_service_auth.py
@@ -73,7 +73,7 @@ def test_service_client_rejects_non_loopback_plaintext_target(monkeypatch):
 
 
 def test_service_client_forwards_configured_bearer_token(monkeypatch):
-    """The shared client request helper must attach the configured bearer token."""
+    """The client must authenticate only the initial service request."""
     captured = {}
 
     class _ResponseStub:
@@ -92,8 +92,10 @@ def test_service_client_forwards_configured_bearer_token(monkeypatch):
             return b'{"ok": true}'
 
     def fake_open(request, timeout):
-        """Capture the outbound Authorization header."""
+        """Capture initial-request and redirectable Authorization state."""
         captured["authorization"] = request.get_header("Authorization")
+        captured["unredirected"] = request.unredirected_hdrs.get("Authorization")
+        captured["redirectable"] = request.headers.get("Authorization")
         captured["timeout"] = timeout
         return _ResponseStub()
 
@@ -102,7 +104,12 @@ def test_service_client_forwards_configured_bearer_token(monkeypatch):
     monkeypatch.setattr(service_client._NO_PROXY_OPENER, "open", fake_open)
 
     assert service_client.get_service_health(timeout=1.25) == {"ok": True}
-    assert captured == {"authorization": "Bearer secret-token", "timeout": 1.25}
+    assert captured == {
+        "authorization": "Bearer secret-token",
+        "unredirected": "Bearer secret-token",
+        "redirectable": None,
+        "timeout": 1.25,
+    }
 
 
 def test_service_client_formats_ipv6_loopback_url(monkeypatch):

--- a/tests/test_download_service_auth.py
+++ b/tests/test_download_service_auth.py
@@ -54,18 +54,18 @@ def test_loopback_bind_remains_token_optional(monkeypatch):
 
 
 def test_service_client_rejects_non_loopback_plaintext_target(monkeypatch):
-    """The client must reject remote HTTP targets before constructing a request."""
+    """The client must reject remote HTTP targets before opening a connection."""
     called = False
 
-    def fake_urlopen(request, timeout):
+    def fake_open(request, timeout):
         """Record any unexpected network attempt."""
         nonlocal called
         called = True
-        raise AssertionError("urlopen must not be called for non-loopback HTTP")
+        raise AssertionError("opener must not be called for non-loopback HTTP")
 
     monkeypatch.setattr(config.settings, "download_service_host", "192.0.2.10")
     monkeypatch.setattr(config.settings, "download_service_token", "secret-token")
-    monkeypatch.setattr(service_client, "urlopen", fake_urlopen)
+    monkeypatch.setattr(service_client._NO_PROXY_OPENER, "open", fake_open)
 
     with pytest.raises(RuntimeError, match="authenticated TLS transport"):
         service_client.get_service_health(timeout=1.25)
@@ -77,7 +77,7 @@ def test_service_client_forwards_configured_bearer_token(monkeypatch):
     captured = {}
 
     class _ResponseStub:
-        """Act as a minimal urlopen response context manager."""
+        """Act as a minimal opener response context manager."""
 
         def __enter__(self):
             """Return the response stub for context-manager use."""
@@ -91,7 +91,7 @@ def test_service_client_forwards_configured_bearer_token(monkeypatch):
             """Return a deterministic JSON response body."""
             return b'{"ok": true}'
 
-    def fake_urlopen(request, timeout):
+    def fake_open(request, timeout):
         """Capture the outbound Authorization header."""
         captured["authorization"] = request.get_header("Authorization")
         captured["timeout"] = timeout
@@ -99,10 +99,29 @@ def test_service_client_forwards_configured_bearer_token(monkeypatch):
 
     monkeypatch.setattr(config.settings, "download_service_host", "127.0.0.1")
     monkeypatch.setattr(config.settings, "download_service_token", "secret-token")
-    monkeypatch.setattr(service_client, "urlopen", fake_urlopen)
+    monkeypatch.setattr(service_client._NO_PROXY_OPENER, "open", fake_open)
 
     assert service_client.get_service_health(timeout=1.25) == {"ok": True}
     assert captured == {"authorization": "Bearer secret-token", "timeout": 1.25}
+
+
+def test_service_client_formats_ipv6_loopback_url(monkeypatch):
+    """IPv6 loopback literals must be bracketed in HTTP URLs."""
+    monkeypatch.setattr(config.settings, "download_service_host", "::1")
+    monkeypatch.setattr(config.settings, "download_service_port", 8765)
+
+    assert service_client.service_base_url() == "http://[::1]:8765"
+
+
+def test_service_client_opener_disables_environment_proxies():
+    """The dedicated loopback opener must carry an empty proxy mapping."""
+    proxy_handlers = [
+        handler
+        for handler in service_client._NO_PROXY_OPENER.handlers
+        if handler.__class__.__name__ == "ProxyHandler"
+    ]
+    assert len(proxy_handlers) == 1
+    assert proxy_handlers[0].proxies == {}
 
 
 def test_handler_keeps_health_public_and_protects_jobs():

--- a/tests/test_download_service_auth.py
+++ b/tests/test_download_service_auth.py
@@ -36,12 +36,12 @@ class _StateStub:
         return []
 
 
-def test_non_loopback_bind_requires_token(monkeypatch):
-    """Remote download-service binds must fail closed when no token is configured."""
+def test_non_loopback_bind_is_rejected_without_tls(monkeypatch):
+    """Remote binds must remain disabled until authenticated TLS transport exists."""
     monkeypatch.setattr(config.settings, "download_service_host", "0.0.0.0")
-    monkeypatch.setattr(config.settings, "download_service_token", None)
+    monkeypatch.setattr(config.settings, "download_service_token", "secret-token")
 
-    with pytest.raises(RuntimeError, match="AIMODEL_DOWNLOAD_SERVICE_TOKEN"):
+    with pytest.raises(RuntimeError, match="authenticated TLS transport"):
         download_service.validate_service_auth_boundary()
 
 
@@ -51,6 +51,25 @@ def test_loopback_bind_remains_token_optional(monkeypatch):
     monkeypatch.setattr(config.settings, "download_service_token", None)
 
     download_service.validate_service_auth_boundary()
+
+
+def test_service_client_rejects_non_loopback_plaintext_target(monkeypatch):
+    """The client must reject remote HTTP targets before constructing a request."""
+    called = False
+
+    def fake_urlopen(request, timeout):
+        """Record any unexpected network attempt."""
+        nonlocal called
+        called = True
+        raise AssertionError("urlopen must not be called for non-loopback HTTP")
+
+    monkeypatch.setattr(config.settings, "download_service_host", "192.0.2.10")
+    monkeypatch.setattr(config.settings, "download_service_token", "secret-token")
+    monkeypatch.setattr(service_client, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="authenticated TLS transport"):
+        service_client.get_service_health(timeout=1.25)
+    assert called is False
 
 
 def test_service_client_forwards_configured_bearer_token(monkeypatch):
@@ -78,6 +97,7 @@ def test_service_client_forwards_configured_bearer_token(monkeypatch):
         captured["timeout"] = timeout
         return _ResponseStub()
 
+    monkeypatch.setattr(config.settings, "download_service_host", "127.0.0.1")
     monkeypatch.setattr(config.settings, "download_service_token", "secret-token")
     monkeypatch.setattr(service_client, "urlopen", fake_urlopen)
 

--- a/tests/test_download_service_auth.py
+++ b/tests/test_download_service_auth.py
@@ -113,15 +113,29 @@ def test_service_client_formats_ipv6_loopback_url(monkeypatch):
     assert service_client.service_base_url() == "http://[::1]:8765"
 
 
-def test_service_client_opener_disables_environment_proxies():
-    """The dedicated loopback opener must carry an empty proxy mapping."""
-    proxy_handlers = [
-        handler
-        for handler in service_client._NO_PROXY_OPENER.handlers
-        if handler.__class__.__name__ == "ProxyHandler"
-    ]
-    assert len(proxy_handlers) == 1
-    assert proxy_handlers[0].proxies == {}
+def test_service_client_bypasses_environment_proxies(monkeypatch):
+    """Loopback service requests must ignore configured HTTP proxy variables."""
+    handler = _make_handler(_StateStub())
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setattr(config.settings, "download_service_host", host)
+    monkeypatch.setattr(config.settings, "download_service_port", port)
+    monkeypatch.setattr(config.settings, "download_service_token", None)
+
+    try:
+        assert service_client.get_service_health(timeout=2) == {
+            "ok": True,
+            "version": "1.8",
+        }
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
 
 
 def test_handler_keeps_health_public_and_protects_jobs():

--- a/tests/test_runtime_endpoint_configuration.py
+++ b/tests/test_runtime_endpoint_configuration.py
@@ -6,28 +6,35 @@ from requests.exceptions import ConnectionError
 
 
 def test_download_service_client_uses_configured_host_and_port(monkeypatch):
+    """Download-service client requests must use the configured loopback endpoint."""
     import config
     from downloads import service_client
 
     captured: dict[str, str] = {}
 
     class ResponseStub:
+        """Provide a minimal response context manager."""
+
         def __enter__(self):
+            """Return the response stub for context-manager use."""
             return self
 
         def __exit__(self, *args):
+            """Leave the context manager without suppressing exceptions."""
             return False
 
         def read(self):
+            """Return a deterministic health response body."""
             return b'{"ok": true}'
 
-    def fake_urlopen(request, timeout):
+    def fake_open(request, timeout):
+        """Capture the exact loopback URL requested by the client."""
         captured["url"] = request.full_url
         return ResponseStub()
 
     monkeypatch.setattr(config.settings, "download_service_host", "127.0.0.42")
     monkeypatch.setattr(config.settings, "download_service_port", 9876)
-    monkeypatch.setattr(service_client, "urlopen", fake_urlopen)
+    monkeypatch.setattr(service_client._NO_PROXY_OPENER, "open", fake_open)
 
     assert service_client.get_service_health() == {"ok": True}
     assert captured["url"] == "http://127.0.0.42:9876/health"

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -1,13 +1,23 @@
+"""Compatibility coverage for the download-service client protocol floor."""
+
 from downloads.service_client import is_service_compatible
 
 
 def test_service_compatibility_true_for_current_version():
-    assert is_service_compatible({"version": "1.7"}) is True
+    """The authenticated 1.8 service protocol must be accepted."""
+    assert is_service_compatible({"version": "1.8"}) is True
+
+
+def test_service_compatibility_false_for_pre_auth_version():
+    """The pre-auth 1.7 service must be restarted rather than reused."""
+    assert is_service_compatible({"version": "1.7"}) is False
 
 
 def test_service_compatibility_false_for_legacy_version():
+    """Older legacy service versions must remain incompatible."""
     assert is_service_compatible({"version": "1.6"}) is False
 
 
 def test_service_compatibility_false_for_missing_version():
+    """A health response without a version must be incompatible."""
     assert is_service_compatible({}) is False


### PR DESCRIPTION
## Scope

- add `AIMODEL_DOWNLOAD_SERVICE_TOKEN` and automatically send it as a bearer token from the shared service client
- keep `/health` public while protecting job data, debug, cancel, delete, create, and shutdown endpoints when a token is configured
- keep the download service loopback-only until authenticated TLS transport is implemented
- fail closed for non-loopback server binds even when a token is configured
- fail closed in the client before any plaintext request is sent to a non-loopback host
- preserve token-optional default loopback behavior
- bump the download-service protocol floor from 1.7 to 1.8 so pre-auth daemons are restarted instead of reused
- add real HTTP boundary regression coverage plus bind/client tests
- document the loopback-only security boundary

Preflight:
- production semantic change is intentional: service protocol 1.7 -> 1.8
- CodeRabbit's plaintext bearer-token finding is addressed by rejecting non-loopback HTTP transport rather than treating bearer auth alone as sufficient
- no test expectations were weakened to pass CI; compatibility tests were updated to the new security contract
- token values are never returned or logged
- new/touched callable paths have docstrings
- combined diff is limited to the download auth boundary, tests, config, and README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional bearer-token authentication for download-service requests.
  * Health checks remain publicly accessible; other endpoints require authorization when configured.

* **Bug Fixes**
  * Restricted download-service connections and bindings to loopback addresses until authenticated TLS is supported.
  * Updated service compatibility checks for version 1.8.

* **Documentation**
  * Clarified authentication and loopback security requirements.
  * Removed unsafe non-loopback configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->