### PR TITLE
fix: serialize shared cache database access

### DIFF
--- a/core/cache_db.py
+++ b/core/cache_db.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 _cache_db_path: Path | None = None
 _init_lock = threading.Lock()
 _conn: sqlite3.Connection | None = None
-_conn_lock = threading.Lock()
+_db_lock = threading.RLock()
 
 
 def get_cache_db_path() -> Path:
@@ -26,10 +26,11 @@ _conn_path: str | None = None
 
 
 def _get_conn() -> sqlite3.Connection:
+    """Return the shared cache connection, reopening it when the configured path changes."""
     global _conn, _conn_path
     current_path = str(Path(get_cache_db_path()))
     if _conn is None or _conn_path != current_path:
-        with _conn_lock:
+        with _db_lock:
             if _conn is None or _conn_path != current_path:
                 if _conn is not None:
                     _conn.close()
@@ -41,8 +42,9 @@ def _get_conn() -> sqlite3.Connection:
 
 
 def _close_conn():
+    """Close and clear the shared cache connection under the database lock."""
     global _conn, _conn_path
-    with _conn_lock:
+    with _db_lock:
         if _conn is not None:
             _conn.close()
             _conn = None
@@ -58,21 +60,26 @@ def _connect():
 
 
 def _execute(sql: str, params=()):
-    """Execute a query on the pooled connection, reconnecting on error."""
-    try:
-        cur = _get_conn().execute(sql, params)
-        _get_conn().commit()
-        return cur
-    except sqlite3.Error:
-        _close_conn()
-        cur = _get_conn().execute(sql, params)
-        _get_conn().commit()
-        return cur
+    """Execute and commit one query while serializing access to the shared connection."""
+    with _db_lock:
+        try:
+            conn = _get_conn()
+            cur = conn.execute(sql, params)
+            conn.commit()
+            return cur
+        except sqlite3.Error:
+            _close_conn()
+            conn = _get_conn()
+            cur = conn.execute(sql, params)
+            conn.commit()
+            return cur
 
 
 def init_db():
-    with _init_lock:
-        _get_conn().execute(
+    """Create cache tables once while serializing schema work with normal queries."""
+    with _init_lock, _db_lock:
+        conn = _get_conn()
+        conn.execute(
             """
                 CREATE TABLE IF NOT EXISTS model_cache (
                     source TEXT NOT NULL,
@@ -83,7 +90,7 @@ def init_db():
                 )
                 """
         )
-        _get_conn().execute(
+        conn.execute(
             """
                 CREATE TABLE IF NOT EXISTS hardware_snapshot (
                     id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -92,6 +99,7 @@ def init_db():
                 )
                 """
         )
+        conn.commit()
 
 
 def get_model_cache(source: str, model_id: str) -> dict | None:

--- a/tests/test_cache_db_concurrency.py
+++ b/tests/test_cache_db_concurrency.py
@@ -1,0 +1,78 @@
+"""Regression coverage for shared SQLite cache connection serialization."""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from core import cache_db
+
+
+def test_execute_serializes_shared_connection_access(monkeypatch):
+    """Concurrent callers must never execute on the shared connection simultaneously."""
+    state_lock = threading.Lock()
+    active = 0
+    max_active = 0
+    calls = 0
+
+    class _ConnectionStub:
+        """Record overlapping execute calls on a shared fake connection."""
+
+        def execute(self, sql, params=()):
+            """Track active execution count while simulating a short SQLite call."""
+            nonlocal active, max_active, calls
+            _ = (sql, params)
+            with state_lock:
+                active += 1
+                calls += 1
+                max_active = max(max_active, active)
+            time.sleep(0.01)
+            with state_lock:
+                active -= 1
+            return self
+
+        def commit(self):
+            """Provide the commit surface expected by the cache helper."""
+            return None
+
+    connection = _ConnectionStub()
+    monkeypatch.setattr(cache_db, "_get_conn", lambda: connection)
+
+    start = threading.Barrier(8)
+
+    def worker():
+        """Start all callers together and execute one cache statement."""
+        start.wait()
+        cache_db._execute("SELECT 1")
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(worker) for _ in range(8)]
+        for future in futures:
+            future.result(timeout=3)
+
+    assert calls == 8
+    assert max_active == 1
+
+
+def test_concurrent_cache_writes_round_trip(tmp_path, monkeypatch):
+    """Concurrent cache writes must all persist and remain readable."""
+    cache_db._close_conn()
+    monkeypatch.setattr(cache_db, "_cache_db_path", tmp_path / "cache.db")
+    cache_db.init_db()
+
+    def write(index: int) -> None:
+        """Write one unique model-cache record."""
+        cache_db.set_model_cache("test", f"model-{index}", {"index": index})
+
+    try:
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(write, index) for index in range(40)]
+            for future in futures:
+                future.result(timeout=3)
+
+        assert [
+            cache_db.get_model_cache("test", f"model-{index}") for index in range(40)
+        ] == [{"index": index} for index in range(40)]
+    finally:
+        cache_db._close_conn()


### PR DESCRIPTION
## Scope

- serialize all access to the shared cache SQLite connection with a re-entrant database lock
- keep connection open/reopen/close lifecycle under the same lock
- serialize schema initialization with normal query execution and commit schema creation explicitly
- preserve the existing reconnect-on-SQLite-error behavior without deadlocking nested connection helpers
- add deterministic regression coverage proving concurrent `_execute()` calls never overlap on the shared connection
- add a real temporary-SQLite concurrent write/read round-trip test

Preflight:
- provider lifecycle audit found no beneficial singleton change: extra providers are stateless and already share the central HTTP session, while persistent provider instances could stale env-derived hosts
- production semantic change is limited to cache DB serialization
- DownloadStore is unchanged because it already uses a per-instance lock with fresh connections
- no test expectations were weakened
- new/touched callable paths have docstrings
- combined diff is limited to `core/cache_db.py` and one focused test file