### PR TITLE
fix: enforce Hugging Face page-info contract

### DIFF
--- a/providers/hf_provider.py
+++ b/providers/hf_provider.py
@@ -57,7 +57,7 @@ class HuggingFaceProvider:
             SearchResult: Matching models, any search errors, and pagination information.
         """
         offset = page * limit
-        response = search_hf_models(
+        results, errors, has_more_pages = search_hf_models(
             query,
             specs,
             self.model_info_cache,
@@ -67,13 +67,6 @@ class HuggingFaceProvider:
             lookahead=1,
             return_page_info=True,
         )
-        if len(response) == 3:
-            results, errors, has_more_pages = response
-        else:
-            # Backward-compatible fallback for patched/test doubles that still
-            # return the historical two-item tuple.
-            results, errors = response
-            has_more_pages = len(results) > limit
         return SearchResult(
             results=results[:limit],
             errors=list(errors),

--- a/tests/test_base_provider_contract.py
+++ b/tests/test_base_provider_contract.py
@@ -214,7 +214,7 @@ def test_polymorphic_dispatch_returns_unified_shape():
         instance = provider_cls()
         if hasattr(instance, "_search_hf_models") or provider_cls.__name__ == "HuggingFaceProvider":
             with patch("providers.hf_provider.search_hf_models") as mock_fn:
-                mock_fn.return_value = ([], [])
+                mock_fn.return_value = ([], [], False)
                 result = instance.search("x", _fake_specs(), limit=5)
         elif provider_cls.__name__ == "OllamaProvider":
             with patch("providers.ollama_provider.search_ollama_models") as mock_fn:

--- a/tests/test_hf_pagination_boundary.py
+++ b/tests/test_hf_pagination_boundary.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from providers.capabilities import get_provider_capabilities
 from providers.hf_provider import HuggingFaceProvider
 
@@ -23,7 +25,10 @@ def _results(count):
 def test_exact_full_final_page_does_not_report_more_pages():
     """A full final page must not imply another page without lookahead."""
     provider = HuggingFaceProvider(model_info_cache={})
-    with patch("providers.hf_provider.search_hf_models", return_value=(_results(5), [])):
+    with patch(
+        "providers.hf_provider.search_hf_models",
+        return_value=(_results(5), [], False),
+    ):
         result = provider.search("test", _specs(), limit=5, page=2)
 
     assert len(result.results) == 5
@@ -33,11 +38,24 @@ def test_exact_full_final_page_does_not_report_more_pages():
 def test_lookahead_result_reports_more_and_is_not_exposed():
     """One lookahead item should enable Next without leaking into results."""
     provider = HuggingFaceProvider(model_info_cache={})
-    with patch("providers.hf_provider.search_hf_models", return_value=(_results(6), [])):
+    with patch(
+        "providers.hf_provider.search_hf_models",
+        return_value=(_results(6), [], True),
+    ):
         result = provider.search("test", _specs(), limit=5, page=2)
 
     assert len(result.results) == 5
     assert result.has_more_pages is True
+
+
+def test_provider_rejects_legacy_two_item_page_info_response():
+    """The paginated provider adapter must fail if page metadata is missing."""
+    provider = HuggingFaceProvider(model_info_cache={})
+    with (
+        patch("providers.hf_provider.search_hf_models", return_value=(_results(5), [])),
+        pytest.raises(ValueError),
+    ):
+        provider.search("test", _specs(), limit=5, page=2)
 
 
 def test_parse_failure_does_not_pull_lookahead_into_current_page():


### PR DESCRIPTION
## Scope

- remove the legacy two-item tuple fallback from `HuggingFaceProvider.search()`
- require the paginated adapter path to receive `(results, errors, has_more_pages)` whenever it requests `return_page_info=True`
- update pagination test doubles to the real three-item contract
- add a regression proving a legacy two-item response fails fast instead of guessing pagination

Preflight:
- production `search_hf_models(..., return_page_info=True)` already returns three items on success and error paths
- two-item compatibility was only exercised by stale pagination test doubles
- non-paginated direct callers of `search_hf_models()` remain unchanged and still receive two items by default
- no pagination semantics were weakened
- touched callables have docstrings
- final diff is limited to `providers/hf_provider.py` and `tests/test_hf_pagination_boundary.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hugging Face model search pagination handling for final pages and additional results.
  * Updated behavior when receiving responses in an unsupported format.

* **Tests**
  * Expanded coverage for pagination boundaries, continuation indicators, and invalid response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->