### PR TITLE
feat: add backward-compatible structured provider errors

### DIFF
--- a/core/errors.py
+++ b/core/errors.py
@@ -1,0 +1,26 @@
+"""Structured error values shared across provider and orchestration layers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderError:
+    """Machine-readable provider diagnostic that preserves a user-facing message.
+
+    Attributes:
+        provider: Canonical provider slug, such as ``huggingface`` or ``ollama``.
+        code: Stable machine-readable error code.
+        message: Human-readable diagnostic suitable for current UI surfaces.
+        retryable: Whether retrying the same operation may reasonably succeed.
+        status_code: Optional HTTP status code associated with the failure.
+        retry_after_seconds: Optional server-advised retry delay in seconds.
+    """
+
+    provider: str
+    code: str
+    message: str
+    retryable: bool = False
+    status_code: int | None = None
+    retry_after_seconds: float | None = None

--- a/providers/base.py
+++ b/providers/base.py
@@ -36,27 +36,27 @@ class SearchResult:
         errors: Backward-compatible list of human-readable error messages.
             Existing CLI, TUI, REST, and provider callers continue to use
             this surface unchanged during structured-error migration.
-        structured_errors: Machine-readable provider diagnostics. This is
-            additive and may remain empty while a provider has not yet been
-            migrated to populate structured errors.
         has_more_pages: True if the provider has more results beyond
             the current page. For providers without real pagination
             (Ollama), this is computed by comparing result count
             against ``page_size``.
+        structured_errors: Machine-readable provider diagnostics. This is
+            additive and may remain empty while a provider has not yet been
+            migrated to populate structured errors.
     """
 
     results: list[dict] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
-    structured_errors: list[ProviderError] = field(default_factory=list)
     has_more_pages: bool = False
+    structured_errors: list[ProviderError] = field(default_factory=list)
 
     def extend(self, other: SearchResult) -> SearchResult:
         """Merge *other* into a new SearchResult without mutating either input."""
         return SearchResult(
             results=self.results + other.results,
             errors=self.errors + other.errors,
-            structured_errors=self.structured_errors + other.structured_errors,
             has_more_pages=self.has_more_pages or other.has_more_pages,
+            structured_errors=self.structured_errors + other.structured_errors,
         )
 
     @classmethod

--- a/providers/base.py
+++ b/providers/base.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from core.errors import ProviderError
+
 
 @dataclass
 class SearchResult:
@@ -31,9 +33,12 @@ class SearchResult:
     Attributes:
         results: List of model result dicts (each conforming to the
             ``ModelResult`` TypedDict schema in ``core/models.py``).
-        errors: List of human-readable error messages encountered while
-            searching. The provider did not raise — it returned
-            partial results + diagnostics.
+        errors: Backward-compatible list of human-readable error messages.
+            Existing CLI, TUI, REST, and provider callers continue to use
+            this surface unchanged during structured-error migration.
+        structured_errors: Machine-readable provider diagnostics. This is
+            additive and may remain empty while a provider has not yet been
+            migrated to populate structured errors.
         has_more_pages: True if the provider has more results beyond
             the current page. For providers without real pagination
             (Ollama), this is computed by comparing result count
@@ -42,16 +47,19 @@ class SearchResult:
 
     results: list[dict] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    structured_errors: list[ProviderError] = field(default_factory=list)
     has_more_pages: bool = False
 
     def extend(self, other: SearchResult) -> SearchResult:
-        """Merge *other* into a new SearchResult. Non-mutating."""
+        """Merge *other* into a new SearchResult without mutating either input."""
         return SearchResult(
             results=self.results + other.results,
             errors=self.errors + other.errors,
+            structured_errors=self.structured_errors + other.structured_errors,
             has_more_pages=self.has_more_pages or other.has_more_pages,
         )
 
     @classmethod
     def empty(cls) -> SearchResult:
+        """Return an empty result with both diagnostic surfaces initialized."""
         return cls()

--- a/tests/test_search_result_positional_compat.py
+++ b/tests/test_search_result_positional_compat.py
@@ -1,0 +1,11 @@
+from providers.base import SearchResult
+
+
+def test_search_result_third_positional_argument_remains_has_more_pages():
+    """Adding structured errors must not change the legacy positional constructor order."""
+    result = SearchResult([{"id": "test/model"}], ["legacy error"], True)
+
+    assert result.results == [{"id": "test/model"}]
+    assert result.errors == ["legacy error"]
+    assert result.has_more_pages is True
+    assert result.structured_errors == []

--- a/tests/test_structured_provider_errors.py
+++ b/tests/test_structured_provider_errors.py
@@ -1,0 +1,83 @@
+from core.errors import ProviderError
+from providers.base import SearchResult
+
+
+def test_provider_error_carries_machine_readable_metadata():
+    """Structured provider errors should expose stable diagnostic metadata."""
+    error = ProviderError(
+        provider="huggingface",
+        code="rate_limited",
+        message="Hugging Face rate-limited (429).",
+        retryable=True,
+        status_code=429,
+        retry_after_seconds=7.0,
+    )
+
+    assert error.provider == "huggingface"
+    assert error.code == "rate_limited"
+    assert error.message == "Hugging Face rate-limited (429)."
+    assert error.retryable is True
+    assert error.status_code == 429
+    assert error.retry_after_seconds == 7.0
+
+
+def test_search_result_legacy_errors_remain_unchanged():
+    """Existing callers using only string errors must remain source compatible."""
+    result = SearchResult(results=[{"id": "test/model"}], errors=["legacy error"])
+
+    assert result.results == [{"id": "test/model"}]
+    assert result.errors == ["legacy error"]
+    assert result.structured_errors == []
+    assert result.has_more_pages is False
+
+
+def test_search_result_empty_initializes_both_error_surfaces():
+    """Empty results should not share mutable diagnostic lists between instances."""
+    first = SearchResult.empty()
+    second = SearchResult.empty()
+
+    first.errors.append("legacy")
+    first.structured_errors.append(
+        ProviderError(provider="ollama", code="timeout", message="timed out", retryable=True)
+    )
+
+    assert second.errors == []
+    assert second.structured_errors == []
+
+
+def test_search_result_extend_merges_legacy_and_structured_errors():
+    """Extending results should merge both diagnostic surfaces non-mutatingly."""
+    left_error = ProviderError(
+        provider="huggingface",
+        code="rate_limited",
+        message="rate limited",
+        retryable=True,
+        status_code=429,
+    )
+    right_error = ProviderError(
+        provider="ollama",
+        code="unreachable",
+        message="unreachable",
+        retryable=True,
+    )
+    left = SearchResult(
+        results=[{"id": "left"}],
+        errors=["left error"],
+        structured_errors=[left_error],
+        has_more_pages=False,
+    )
+    right = SearchResult(
+        results=[{"id": "right"}],
+        errors=["right error"],
+        structured_errors=[right_error],
+        has_more_pages=True,
+    )
+
+    merged = left.extend(right)
+
+    assert merged.results == [{"id": "left"}, {"id": "right"}]
+    assert merged.errors == ["left error", "right error"]
+    assert merged.structured_errors == [left_error, right_error]
+    assert merged.has_more_pages is True
+    assert left.results == [{"id": "left"}]
+    assert right.results == [{"id": "right"}]


### PR DESCRIPTION
Closes #34

## Scope

- add a frozen `ProviderError` value object in `core/errors.py`
- attach additive `structured_errors` diagnostics to `SearchResult`
- preserve the existing `errors: list[str]` surface unchanged for CLI/TUI/REST callers
- preserve the legacy positional `SearchResult(results, errors, has_more_pages)` constructor order
- make `SearchResult.extend()` merge both diagnostic surfaces
- keep provider execution, error strings, pagination, and transport behavior unchanged

## Self-review

- repository-wide constructor scan found a potential positional-argument compatibility risk; `structured_errors` was therefore appended after `has_more_pages`
- a dedicated regression pins the third positional argument as `has_more_pages`
- this PR defines only the canonical structure; providers do not populate it yet
- no dependency changes

## Acceptance

- legacy `SearchResult(errors=[...])` callers remain valid
- positional constructor compatibility is preserved
- structured diagnostics expose provider, code, message, retryable, status code, and retry-after metadata
- `SearchResult.empty()` initializes independent legacy and structured error lists
- `SearchResult.extend()` merges both surfaces non-mutatingly
- CI and Package must pass before merge