### PR TITLE
feat: populate Hugging Face structured errors

### DIFF
--- a/providers/hf_provider.py
+++ b/providers/hf_provider.py
@@ -26,7 +26,14 @@ _HF_BACKOFF_MAX_SECONDS = 4.0
 
 
 class HuggingFaceProvider:
-    """Class adapter wrapping the module-level :func:`search_hf_models`."""
+    """Class adapter wrapping the module-level :func:`search_hf_models`.
+
+    The free function is preserved for backward compatibility; the
+    class form lets the orchestrator treat HF the same as every other
+    :class:`BaseProvider` subclass. ``refresh_installed()`` is a no-op
+    since HF has no local-install concept; ``enrich()`` is the
+    :func:`enrich_hf_model_details` function.
+    """
 
     slug = "huggingface"
     display_name = "Hugging Face"
@@ -47,7 +54,16 @@ class HuggingFaceProvider:
         hf_token: str | None = None,
         **kwargs,
     ) -> SearchResult:
-        """Search Hugging Face models and return legacy plus structured diagnostics."""
+        """
+        Search Hugging Face models matching the query and hardware specifications.
+
+        Parameters:
+            page (int): Zero-based result page to retrieve.
+
+        Returns:
+            SearchResult: Matching models, any search errors, pagination information,
+            and additive structured diagnostics.
+        """
         offset = page * limit
         structured_errors: list[ProviderError] = []
         results, errors, has_more_pages = search_hf_models(
@@ -81,18 +97,32 @@ def _repo_id_from_model(model):
 
 
 def _select_preferred_gguf(siblings):
-    """Choose the preferred GGUF file from a list of repo sibling objects."""
+    """Choose the preferred GGUF file from a list of repo sibling objects.
+
+    Preference order: Q4_K_M → Q4_0 → Q5_K_M → any ``.gguf``.
+    Returns ``None`` if no GGUF file is found.
+    """
     filenames = [item.rfilename for item in siblings if getattr(item, "rfilename", None)]
     priorities = ["Q4_K_M.gguf", "Q4_0.gguf", "Q5_K_M.gguf"]
+
     for suffix in priorities:
         target = next((name for name in filenames if suffix in name), None)
         if target:
             return target
+
     return next((name for name in filenames if name.endswith(".gguf")), None)
 
 
 def classify_hidden_gem(downloads, likes):
-    """Classify a model as a hidden gem based on its download and like counts."""
+    """Classify a model as a hidden gem based on its download and like counts.
+
+    A hidden gem has significant downloads but low public visibility (few
+    likes relative to download volume).
+
+    Returns:
+        ``(is_gem: bool, gem_score: float)`` — score is higher for more
+        gem-like models.
+    """
     if downloads < 5000:
         return False, 0.0
     if likes > 200:
@@ -165,6 +195,7 @@ def _list_hf_models_with_retry(api, **kwargs):
             if attempt >= _HF_MAX_ATTEMPTS:
                 raise
             time.sleep(_hf_retry_delay_seconds(exc, attempt))
+
     raise RuntimeError("Hugging Face retry loop exhausted unexpectedly")
 
 
@@ -179,7 +210,26 @@ def search_hf_models(
     return_page_info=False,
     _structured_error_sink=None,
 ):
-    """Search Hugging Face while preserving the legacy public tuple contract."""
+    """
+    Search Hugging Face for GGUF models matching a query.
+
+    Args:
+        query: Free-text search string.
+        specs: Hardware specification dictionary used to determine model fit.
+        model_info_cache: Shared cache for Hugging Face repository metadata.
+        limit: Maximum number of models to process.
+        offset: Number of raw search results to skip.
+        hf_token: Optional Hugging Face API token.
+        lookahead: Number of additional raw results to fetch for page-boundary detection.
+        return_page_info: Whether to include the page-availability flag in the return value.
+        _structured_error_sink: Optional internal callback receiving ``ProviderError`` values.
+
+    Returns:
+        A tuple containing the parsed model results and parsing or request errors.
+        When `return_page_info` is true, includes a third boolean indicating whether
+        additional raw results are available. Structured diagnostics are additive and
+        do not change this public tuple shape.
+    """
     results = []
     errors = []
     found_keys = set()
@@ -208,7 +258,15 @@ def search_hf_models(
             )
 
     def _return(has_more_pages=False):
-        """Package results using the established two- or three-item tuple contract."""
+        """
+        Package search results with optional pagination information.
+
+        Parameters:
+            has_more_pages (bool): Whether additional result pages are available.
+
+        Returns:
+            tuple: Search results and errors, optionally followed by a pagination flag.
+        """
         if return_page_info:
             return results, errors, has_more_pages
         return results, errors
@@ -251,6 +309,7 @@ def search_hf_models(
 
     has_more_pages = len(raw_window) > limit
     page_models = raw_window[:limit]
+
     hf_lists_installed = get_provider_capabilities(HuggingFaceProvider.slug).lists_installed
 
     for model in page_models:
@@ -258,6 +317,7 @@ def search_hf_models(
             repo_id = _repo_id_from_model(model)
             if not repo_id:
                 raise ValueError("missing model repository id")
+
             publisher = repo_id.split("/")[0]
             provider = publisher[:15]
             name = repo_id.split("/")[-1]
@@ -280,6 +340,7 @@ def search_hf_models(
             size = estimate_model_size_gb(name)
             siblings = getattr(model, "siblings", None) or []
             target = _select_preferred_gguf(siblings)
+
             if target:
                 quant = target.split(".")[-2] if len(target.split(".")) > 2 else "GGUF"
                 if "gguf" in quant.lower():
@@ -287,7 +348,9 @@ def search_hf_models(
 
             fit_str, mode_str, _ = calculate_fit(size, specs)
             result_dict = {
-                "inst": "[grey37]-[/grey37]" if hf_lists_installed else "[grey37]N/A[/grey37]",
+                "inst": "[grey37]-[/grey37]"
+                if hf_lists_installed
+                else "[grey37]N/A[/grey37]",
                 "source": "Hugging Face",
                 "provider": provider,
                 "publisher": publisher,
@@ -326,10 +389,21 @@ def search_hf_models(
 
 
 def enrich_hf_model_details(model, specs, model_info_cache):
-    """Enrich a Hugging Face model result with exact GGUF file details."""
+    """
+    Enrich a Hugging Face model result with exact GGUF file details.
+
+    Parameters:
+        model (dict): Model result to update in place.
+        specs: Hardware specifications used to calculate fit and operating mode.
+        model_info_cache: Optional cache for Hugging Face repository metadata.
+
+    Returns:
+        dict: The updated model result, or the original result when repository or file metadata is unavailable.
+    """
     repo_id = model.get("id")
     if not repo_id:
         return model
+
     target = model.get("target_file")
 
     cached = cache_db.get_model_cache("huggingface", repo_id)
@@ -356,6 +430,7 @@ def enrich_hf_model_details(model, specs, model_info_cache):
         info = api.model_info(repo_id, files_metadata=True)
         if model_info_cache is not None:
             model_info_cache[repo_id] = info
+
         siblings = info.siblings or []
         target = target or _select_preferred_gguf(siblings)
         if not target:
@@ -376,6 +451,7 @@ def enrich_hf_model_details(model, specs, model_info_cache):
             quant = "GGUF"
         model["quant"] = quant
         model["target_file"] = target
+
         cache_db.set_model_cache(
             "huggingface",
             repo_id,
@@ -383,4 +459,5 @@ def enrich_hf_model_details(model, specs, model_info_cache):
         )
     except (HfHubHTTPError, RequestException, OSError, ValueError, TypeError):
         return model
+
     return model

--- a/providers/hf_provider.py
+++ b/providers/hf_provider.py
@@ -5,6 +5,7 @@ from huggingface_hub.errors import HfHubHTTPError
 from requests.exceptions import RequestException
 
 from core import cache_db
+from core.errors import ProviderError
 from core.scoring import enrich_result_with_scores
 from core.utils import (
     calculate_fit,
@@ -25,14 +26,7 @@ _HF_BACKOFF_MAX_SECONDS = 4.0
 
 
 class HuggingFaceProvider:
-    """Class adapter wrapping the module-level :func:`search_hf_models`.
-
-    The free function is preserved for backward compatibility; the
-    class form lets the orchestrator treat HF the same as every other
-    :class:`BaseProvider` subclass. ``refresh_installed()`` is a no-op
-    since HF has no local-install concept; ``enrich()`` is the
-    :func:`enrich_hf_model_details` function.
-    """
+    """Class adapter wrapping the module-level :func:`search_hf_models`."""
 
     slug = "huggingface"
     display_name = "Hugging Face"
@@ -53,16 +47,9 @@ class HuggingFaceProvider:
         hf_token: str | None = None,
         **kwargs,
     ) -> SearchResult:
-        """
-        Search Hugging Face models matching the query and hardware specifications.
-
-        Parameters:
-            page (int): Zero-based result page to retrieve.
-
-        Returns:
-            SearchResult: Matching models, any search errors, and pagination information.
-        """
+        """Search Hugging Face models and return legacy plus structured diagnostics."""
         offset = page * limit
+        structured_errors: list[ProviderError] = []
         results, errors, has_more_pages = search_hf_models(
             query,
             specs,
@@ -72,11 +59,13 @@ class HuggingFaceProvider:
             hf_token=hf_token,
             lookahead=1,
             return_page_info=True,
+            _structured_error_sink=structured_errors.append,
         )
         return SearchResult(
             results=results[:limit],
             errors=list(errors),
             has_more_pages=has_more_pages,
+            structured_errors=structured_errors,
         )
 
     def list_installed(self) -> list[str]:
@@ -92,32 +81,18 @@ def _repo_id_from_model(model):
 
 
 def _select_preferred_gguf(siblings):
-    """Choose the preferred GGUF file from a list of repo sibling objects.
-
-    Preference order: Q4_K_M → Q4_0 → Q5_K_M → any ``.gguf``.
-    Returns ``None`` if no GGUF file is found.
-    """
+    """Choose the preferred GGUF file from a list of repo sibling objects."""
     filenames = [item.rfilename for item in siblings if getattr(item, "rfilename", None)]
     priorities = ["Q4_K_M.gguf", "Q4_0.gguf", "Q5_K_M.gguf"]
-
     for suffix in priorities:
         target = next((name for name in filenames if suffix in name), None)
         if target:
             return target
-
     return next((name for name in filenames if name.endswith(".gguf")), None)
 
 
 def classify_hidden_gem(downloads, likes):
-    """Classify a model as a hidden gem based on its download and like counts.
-
-    A hidden gem has significant downloads but low public visibility (few
-    likes relative to download volume).
-
-    Returns:
-        ``(is_gem: bool, gem_score: float)`` — score is higher for more
-        gem-like models.
-    """
+    """Classify a model as a hidden gem based on its download and like counts."""
     if downloads < 5000:
         return False, 0.0
     if likes > 200:
@@ -190,7 +165,6 @@ def _list_hf_models_with_retry(api, **kwargs):
             if attempt >= _HF_MAX_ATTEMPTS:
                 raise
             time.sleep(_hf_retry_delay_seconds(exc, attempt))
-
     raise RuntimeError("Hugging Face retry loop exhausted unexpectedly")
 
 
@@ -203,40 +177,38 @@ def search_hf_models(
     hf_token=None,
     lookahead=0,
     return_page_info=False,
+    _structured_error_sink=None,
 ):
-    """
-    Search Hugging Face for GGUF models matching a query.
-
-    Args:
-        query: Free-text search string.
-        specs: Hardware specification dictionary used to determine model fit.
-        model_info_cache: Shared cache for Hugging Face repository metadata.
-        limit: Maximum number of models to process.
-        offset: Number of raw search results to skip.
-        hf_token: Optional Hugging Face API token.
-        lookahead: Number of additional raw results to fetch for page-boundary detection.
-        return_page_info: Whether to include the page-availability flag in the return value.
-
-    Returns:
-        A tuple containing the parsed model results and parsing or request errors.
-        When `return_page_info` is true, includes a third boolean indicating whether
-        additional raw results are available.
-    """
+    """Search Hugging Face while preserving the legacy public tuple contract."""
     results = []
     errors = []
     found_keys = set()
     window_size = limit + max(int(lookahead), 0)
 
+    def _record_error(
+        message,
+        *,
+        code,
+        retryable=False,
+        status_code=None,
+        retry_after_seconds=None,
+    ):
+        """Append the legacy string and optionally emit a structured diagnostic."""
+        errors.append(message)
+        if _structured_error_sink is not None:
+            _structured_error_sink(
+                ProviderError(
+                    provider=HuggingFaceProvider.slug,
+                    code=code,
+                    message=message,
+                    retryable=retryable,
+                    status_code=status_code,
+                    retry_after_seconds=retry_after_seconds,
+                )
+            )
+
     def _return(has_more_pages=False):
-        """
-        Package search results with optional pagination information.
-
-        Parameters:
-            has_more_pages (bool): Whether additional result pages are available.
-
-        Returns:
-            tuple: Search results and errors, optionally followed by a pagination flag.
-        """
+        """Package results using the established two- or three-item tuple contract."""
         if return_page_info:
             return results, errors, has_more_pages
         return results, errors
@@ -253,18 +225,32 @@ def search_hf_models(
         )
         raw_window = raw_models[offset : offset + window_size]
     except HfHubHTTPError as exc:
-        errors.append(_format_hf_http_error(exc))
+        status = _get_status_code(exc)
+        retry_after = _get_retry_after_seconds(exc)
+        message = _format_hf_http_error(exc)
+        _record_error(
+            message,
+            code="rate_limited" if status == 429 else "http_error",
+            retryable=_is_retryable_hf_http_error(exc),
+            status_code=status,
+            retry_after_seconds=float(retry_after) if retry_after is not None else None,
+        )
         return _return()
     except RequestException as exc:
-        errors.append(f"Hugging Face search failed: {exc}")
+        message = f"Hugging Face search failed: {exc}"
+        _record_error(message, code="transport_error", retryable=True)
         return _return()
-    except (ValueError, OSError) as exc:
-        errors.append(f"Hugging Face search failed: {exc}")
+    except ValueError as exc:
+        message = f"Hugging Face search failed: {exc}"
+        _record_error(message, code="search_error", retryable=False)
+        return _return()
+    except OSError as exc:
+        message = f"Hugging Face search failed: {exc}"
+        _record_error(message, code="transport_error", retryable=True)
         return _return()
 
     has_more_pages = len(raw_window) > limit
     page_models = raw_window[:limit]
-
     hf_lists_installed = get_provider_capabilities(HuggingFaceProvider.slug).lists_installed
 
     for model in page_models:
@@ -272,7 +258,6 @@ def search_hf_models(
             repo_id = _repo_id_from_model(model)
             if not repo_id:
                 raise ValueError("missing model repository id")
-
             publisher = repo_id.split("/")[0]
             provider = publisher[:15]
             name = repo_id.split("/")[-1]
@@ -295,7 +280,6 @@ def search_hf_models(
             size = estimate_model_size_gb(name)
             siblings = getattr(model, "siblings", None) or []
             target = _select_preferred_gguf(siblings)
-
             if target:
                 quant = target.split(".")[-2] if len(target.split(".")) > 2 else "GGUF"
                 if "gguf" in quant.lower():
@@ -303,9 +287,7 @@ def search_hf_models(
 
             fit_str, mode_str, _ = calculate_fit(size, specs)
             result_dict = {
-                "inst": "[grey37]-[/grey37]"
-                if hf_lists_installed
-                else "[grey37]N/A[/grey37]",
+                "inst": "[grey37]-[/grey37]" if hf_lists_installed else "[grey37]N/A[/grey37]",
                 "source": "Hugging Face",
                 "provider": provider,
                 "publisher": publisher,
@@ -337,27 +319,17 @@ def search_hf_models(
             RequestException,
             OSError,
         ) as exc:
-            errors.append(f"Hugging Face model parse failed: {exc}")
+            message = f"Hugging Face model parse failed: {exc}"
+            _record_error(message, code="parse_error", retryable=False)
 
     return _return(has_more_pages)
 
 
 def enrich_hf_model_details(model, specs, model_info_cache):
-    """
-    Enrich a Hugging Face model result with exact GGUF file details.
-
-    Parameters:
-        model (dict): Model result to update in place.
-        specs: Hardware specifications used to calculate fit and operating mode.
-        model_info_cache: Optional cache for Hugging Face repository metadata.
-
-    Returns:
-        dict: The updated model result, or the original result when repository or file metadata is unavailable.
-    """
+    """Enrich a Hugging Face model result with exact GGUF file details."""
     repo_id = model.get("id")
     if not repo_id:
         return model
-
     target = model.get("target_file")
 
     cached = cache_db.get_model_cache("huggingface", repo_id)
@@ -384,7 +356,6 @@ def enrich_hf_model_details(model, specs, model_info_cache):
         info = api.model_info(repo_id, files_metadata=True)
         if model_info_cache is not None:
             model_info_cache[repo_id] = info
-
         siblings = info.siblings or []
         target = target or _select_preferred_gguf(siblings)
         if not target:
@@ -405,7 +376,6 @@ def enrich_hf_model_details(model, specs, model_info_cache):
             quant = "GGUF"
         model["quant"] = quant
         model["target_file"] = target
-
         cache_db.set_model_cache(
             "huggingface",
             repo_id,
@@ -413,5 +383,4 @@ def enrich_hf_model_details(model, specs, model_info_cache):
         )
     except (HfHubHTTPError, RequestException, OSError, ValueError, TypeError):
         return model
-
     return model

--- a/tests/test_hf_structured_errors.py
+++ b/tests/test_hf_structured_errors.py
@@ -101,7 +101,10 @@ def test_provider_marks_model_parse_failure_structured():
 
         likes = 0
         downloads = 0
-        siblings = []
+
+        def __init__(self):
+            """Initialize mutable sibling metadata per fixture instance."""
+            self.siblings = []
 
     provider = HuggingFaceProvider(model_info_cache={})
     with patch("providers.hf_provider.HfApi.list_models", return_value=[BrokenModel()]):

--- a/tests/test_hf_structured_errors.py
+++ b/tests/test_hf_structured_errors.py
@@ -1,0 +1,114 @@
+from unittest.mock import patch
+
+from huggingface_hub.errors import HfHubHTTPError
+from requests import Response
+
+from providers.hf_provider import HuggingFaceProvider, search_hf_models
+
+
+def _specs():
+    """Return minimal hardware specs for deterministic provider tests."""
+    return {
+        "has_gpu": False,
+        "vram_total": 0.0,
+        "vram_free": 0.0,
+        "ram_total": 16.0,
+        "ram_free": 16.0,
+    }
+
+
+def _http_error(status_code, retry_after=None):
+    """Build an HTTP error with controlled response metadata."""
+    response = Response()
+    response.status_code = status_code
+    if retry_after is not None:
+        response.headers["Retry-After"] = str(retry_after)
+    return HfHubHTTPError(f"HTTP {status_code}", response=response)
+
+
+def test_direct_search_keeps_legacy_two_item_tuple():
+    """Direct non-page-info callers must keep receiving exactly two values."""
+    with (
+        patch("providers.hf_provider.HfApi.list_models", side_effect=_http_error(404)),
+        patch("providers.hf_provider.time.sleep"),
+    ):
+        result = search_hf_models("test", _specs(), {})
+
+    assert len(result) == 2
+    assert result == ([], ["Hugging Face request failed (HTTP 404)."])
+
+
+def test_direct_search_keeps_legacy_three_item_page_info_tuple():
+    """Page-info callers must keep receiving exactly three values."""
+    with (
+        patch("providers.hf_provider.HfApi.list_models", side_effect=_http_error(404)),
+        patch("providers.hf_provider.time.sleep"),
+    ):
+        result = search_hf_models("test", _specs(), {}, return_page_info=True)
+
+    assert len(result) == 3
+    assert result == ([], ["Hugging Face request failed (HTTP 404)."], False)
+
+
+def test_provider_exposes_rate_limit_structured_error_with_legacy_message():
+    """The class adapter should add metadata without changing the legacy message."""
+    provider = HuggingFaceProvider(model_info_cache={})
+    error = _http_error(429, retry_after=7)
+
+    with (
+        patch(
+            "providers.hf_provider.HfApi.list_models",
+            side_effect=[error, error, error],
+        ),
+        patch("providers.hf_provider.time.sleep"),
+    ):
+        result = provider.search("test", _specs(), limit=5)
+
+    assert result.errors == ["Hugging Face rate-limited (429). Retry in 7s."]
+    assert len(result.structured_errors) == 1
+    structured = result.structured_errors[0]
+    assert structured.provider == "huggingface"
+    assert structured.code == "rate_limited"
+    assert structured.message == result.errors[0]
+    assert structured.retryable is True
+    assert structured.status_code == 429
+    assert structured.retry_after_seconds == 7.0
+
+
+def test_provider_marks_permanent_http_error_non_retryable():
+    """Permanent HTTP failures should remain non-retryable in structured metadata."""
+    provider = HuggingFaceProvider(model_info_cache={})
+
+    with patch(
+        "providers.hf_provider.HfApi.list_models",
+        side_effect=_http_error(404),
+    ):
+        result = provider.search("test", _specs(), limit=5)
+
+    assert result.errors == ["Hugging Face request failed (HTTP 404)."]
+    structured = result.structured_errors[0]
+    assert structured.code == "http_error"
+    assert structured.retryable is False
+    assert structured.status_code == 404
+    assert structured.retry_after_seconds is None
+
+
+def test_provider_marks_model_parse_failure_structured():
+    """Model parsing failures should add a non-retryable parse diagnostic."""
+
+    class BrokenModel:
+        """Model fixture without a repository id."""
+
+        likes = 0
+        downloads = 0
+        siblings = []
+
+    provider = HuggingFaceProvider(model_info_cache={})
+    with patch("providers.hf_provider.HfApi.list_models", return_value=[BrokenModel()]):
+        result = provider.search("test", _specs(), limit=5)
+
+    assert result.errors == ["Hugging Face model parse failed: missing model repository id"]
+    structured = result.structured_errors[0]
+    assert structured.code == "parse_error"
+    assert structured.retryable is False
+    assert structured.status_code is None


### PR DESCRIPTION
Closes #36

## Scope

- populate `SearchResult.structured_errors` for Hugging Face failures
- preserve every existing legacy error string
- preserve the public `search_hf_models()` two/three-item tuple contract
- add only an optional internal structured-error sink to the free function
- keep pagination, retry/backoff, token forwarding, and result parsing behavior unchanged

## Structured mappings

- HTTP 429 -> `rate_limited`, retryable, status 429, optional retry-after
- HTTP 5xx -> `http_error`, retryable
- permanent HTTP 4xx -> `http_error`, non-retryable
- requests transport failure -> `transport_error`, retryable
- value/search failure -> `search_error`, non-retryable
- OS-level failure -> `transport_error`, retryable
- model parse failure -> `parse_error`, non-retryable

## Self-review

- rejected a wider internal return-shape refactor in favor of an additive diagnostic sink
- restored existing provider docstrings after detecting unnecessary documentation churn
- final production diff is limited to structured diagnostic emission; direct callers retain exact tuple arity
- focused regressions pin two-item and three-item tuple compatibility plus structured metadata

## Acceptance

- legacy direct callers remain behaviorally unchanged
- `HuggingFaceProvider.search()` exposes structured diagnostics
- #31 page-info fail-fast contract remains unchanged
- #33 retry policy remains unchanged
- CI and Package must pass before merge