### PR TITLE
feat: populate Ollama structured errors

### DIFF
--- a/providers/ollama_provider.py
+++ b/providers/ollama_provider.py
@@ -6,6 +6,7 @@ from requests.exceptions import ConnectionError, RequestException, Timeout
 
 import config
 from core import cache_db
+from core.errors import ProviderError
 from core.http_client import get_session
 from core.scoring import enrich_result_with_scores
 from core.utils import (
@@ -59,17 +60,20 @@ class OllamaProvider:
         page: int = 0,
         **kwargs,
     ) -> SearchResult:
+        structured_errors: list[ProviderError] = []
         results, errors, has_more = search_ollama_models(
             query,
             specs,
             self.installed,
             page=page,
             page_size=limit,
+            _structured_error_sink=structured_errors.append,
         )
         return SearchResult(
             results=results,
             errors=errors,
             has_more_pages=has_more,
+            structured_errors=structured_errors,
         )
 
     def list_installed(self) -> list[str]:
@@ -264,7 +268,14 @@ def get_ollama_model_metadata(model_name):
     return metadata
 
 
-def search_ollama_models(query, specs, local_models, page=0, page_size=15):
+def search_ollama_models(
+    query,
+    specs,
+    local_models,
+    page=0,
+    page_size=15,
+    _structured_error_sink=None,
+):
     """Search the Ollama model registry for models matching *query*.
 
     Scrapes ``ollama.com/search``.  Returns
@@ -279,11 +290,34 @@ def search_ollama_models(query, specs, local_models, page=0, page_size=15):
         local_models: List of locally installed models.
         page: Page number (ignored).
         page_size: Results per page (used for slicing).
+        _structured_error_sink: Optional internal callback receiving ``ProviderError`` values.
     """
     results = []
     errors = []
     found_keys = set()
     html_text = ""
+
+    def _record_error(
+        message,
+        *,
+        code,
+        retryable=False,
+        status_code=None,
+        retry_after_seconds=None,
+    ):
+        """Append the legacy string and optionally emit a structured diagnostic."""
+        errors.append(message)
+        if _structured_error_sink is not None:
+            _structured_error_sink(
+                ProviderError(
+                    provider=OllamaProvider.slug,
+                    code=code,
+                    message=message,
+                    retryable=retryable,
+                    status_code=status_code,
+                    retry_after_seconds=retry_after_seconds,
+                )
+            )
 
     try:
         # Ollama doesn't support page-based pagination via URL
@@ -295,15 +329,34 @@ def search_ollama_models(query, specs, local_models, page=0, page_size=15):
         if response.status_code == 429:
             retry_after = _retry_after_from_response(response)
             if retry_after is not None:
-                errors.append(f"Ollama registry rate-limited (429). Retry in {retry_after}s.")
+                message = f"Ollama registry rate-limited (429). Retry in {retry_after}s."
             else:
-                errors.append("Ollama registry rate-limited (429). Retry shortly.")
+                message = "Ollama registry rate-limited (429). Retry shortly."
+            _record_error(
+                message,
+                code="rate_limited",
+                retryable=True,
+                status_code=429,
+                retry_after_seconds=float(retry_after) if retry_after is not None else None,
+            )
             return results, errors, False
         if response.status_code >= 500:
-            errors.append(f"Ollama registry unavailable (HTTP {response.status_code}).")
+            message = f"Ollama registry unavailable (HTTP {response.status_code})."
+            _record_error(
+                message,
+                code="http_error",
+                retryable=True,
+                status_code=response.status_code,
+            )
             return results, errors, False
         if response.status_code != 200:
-            errors.append(f"Ollama registry request failed (HTTP {response.status_code}).")
+            message = f"Ollama registry request failed (HTTP {response.status_code})."
+            _record_error(
+                message,
+                code="http_error",
+                retryable=False,
+                status_code=response.status_code,
+            )
             return results, errors, False
 
         html_text = response.text
@@ -379,13 +432,17 @@ def search_ollama_models(query, specs, local_models, page=0, page_size=15):
             enrich_result_with_scores(result_dict, specs)
             results.append(result_dict)
     except Timeout:
-        errors.append("Ollama registry request timed out.")
+        _record_error("Ollama registry request timed out.", code="timeout", retryable=True)
     except ConnectionError:
-        errors.append("Ollama registry unreachable. Check network connectivity.")
+        _record_error(
+            "Ollama registry unreachable. Check network connectivity.",
+            code="transport_error",
+            retryable=True,
+        )
     except RequestException as exc:
-        errors.append(f"Ollama search failed: {exc}")
+        _record_error(f"Ollama search failed: {exc}", code="transport_error", retryable=True)
     except (ValueError, AttributeError) as exc:
-        errors.append(f"Ollama parse failed: {exc}")
+        _record_error(f"Ollama parse failed: {exc}", code="parse_error", retryable=False)
 
     # Ollama returns all results at once (no page-offset support).
     # Keep the result cap for consistency, but never advertise a next page.

--- a/tests/test_ollama_structured_errors.py
+++ b/tests/test_ollama_structured_errors.py
@@ -1,0 +1,146 @@
+from unittest.mock import patch
+
+from requests.exceptions import ConnectionError, Timeout
+
+from providers.ollama_provider import OllamaProvider, search_ollama_models
+
+
+class FakeResponse:
+    """Minimal requests-like response for deterministic provider tests."""
+
+    def __init__(self, status_code=200, text="", headers=None):
+        self.status_code = status_code
+        self.text = text
+        self.headers = dict(headers or {})
+
+
+class FakeSession:
+    """Minimal requests-like session returning a response or raising an exception."""
+
+    def __init__(self, *, response=None, exc=None):
+        self.response = response
+        self.exc = exc
+
+    def get(self, *_args, **_kwargs):
+        if self.exc is not None:
+            raise self.exc
+        return self.response
+
+
+def _specs():
+    """Return minimal hardware specs for deterministic Ollama tests."""
+    return {
+        "has_gpu": False,
+        "vram_total": 0.0,
+        "vram_free": 0.0,
+        "ram_total": 16.0,
+        "ram_free": 16.0,
+    }
+
+
+def test_direct_search_keeps_legacy_three_item_tuple():
+    """Direct callers must keep receiving the established three-item tuple."""
+    response = FakeResponse(status_code=404)
+    with patch(
+        "providers.ollama_provider.get_session",
+        return_value=FakeSession(response=response),
+    ):
+        result = search_ollama_models("test", _specs(), [])
+
+    assert len(result) == 3
+    assert result == ([], ["Ollama registry request failed (HTTP 404)."], False)
+
+
+def test_provider_exposes_rate_limit_structured_error_with_legacy_message():
+    """A 429 should expose retry metadata without changing the legacy message."""
+    response = FakeResponse(status_code=429, headers={"Retry-After": "7"})
+    provider = OllamaProvider()
+
+    with patch(
+        "providers.ollama_provider.get_session",
+        return_value=FakeSession(response=response),
+    ):
+        result = provider.search("test", _specs(), limit=5)
+
+    assert result.errors == ["Ollama registry rate-limited (429). Retry in 7s."]
+    assert len(result.structured_errors) == 1
+    structured = result.structured_errors[0]
+    assert structured.provider == "ollama"
+    assert structured.code == "rate_limited"
+    assert structured.message == result.errors[0]
+    assert structured.retryable is True
+    assert structured.status_code == 429
+    assert structured.retry_after_seconds == 7.0
+
+
+def test_provider_marks_server_error_retryable():
+    """A final 5xx response should be classified as a retryable HTTP error."""
+    response = FakeResponse(status_code=503)
+    provider = OllamaProvider()
+
+    with patch(
+        "providers.ollama_provider.get_session",
+        return_value=FakeSession(response=response),
+    ):
+        result = provider.search("test", _specs(), limit=5)
+
+    assert result.errors == ["Ollama registry unavailable (HTTP 503)."]
+    structured = result.structured_errors[0]
+    assert structured.code == "http_error"
+    assert structured.retryable is True
+    assert structured.status_code == 503
+
+
+def test_provider_marks_timeout_retryable():
+    """Timeout failures should use the stable timeout code and remain retryable."""
+    provider = OllamaProvider()
+
+    with patch(
+        "providers.ollama_provider.get_session",
+        return_value=FakeSession(exc=Timeout("slow")),
+    ):
+        result = provider.search("test", _specs(), limit=5)
+
+    assert result.errors == ["Ollama registry request timed out."]
+    structured = result.structured_errors[0]
+    assert structured.code == "timeout"
+    assert structured.retryable is True
+    assert structured.status_code is None
+
+
+def test_provider_marks_connection_failure_transport_error():
+    """Connection failures should be classified as retryable transport errors."""
+    provider = OllamaProvider()
+
+    with patch(
+        "providers.ollama_provider.get_session",
+        return_value=FakeSession(exc=ConnectionError("offline")),
+    ):
+        result = provider.search("test", _specs(), limit=5)
+
+    assert result.errors == ["Ollama registry unreachable. Check network connectivity."]
+    structured = result.structured_errors[0]
+    assert structured.code == "transport_error"
+    assert structured.retryable is True
+    assert structured.status_code is None
+
+
+def test_provider_marks_parse_failure_non_retryable():
+    """HTML parse failures should produce a non-retryable parse diagnostic."""
+    response = FakeResponse(status_code=200, text="<html></html>")
+    provider = OllamaProvider()
+
+    with (
+        patch(
+            "providers.ollama_provider.get_session",
+            return_value=FakeSession(response=response),
+        ),
+        patch("providers.ollama_provider.BeautifulSoup", side_effect=ValueError("bad html")),
+    ):
+        result = provider.search("test", _specs(), limit=5)
+
+    assert result.errors == ["Ollama parse failed: bad html"]
+    structured = result.structured_errors[0]
+    assert structured.code == "parse_error"
+    assert structured.retryable is False
+    assert structured.status_code is None


### PR DESCRIPTION
Closes #38

## Scope

- populate `SearchResult.structured_errors` for Ollama registry search failures
- preserve every existing legacy error string
- preserve the public `search_ollama_models()` three-item tuple contract
- add only an optional internal structured-error sink to the free function
- keep shared retry/backoff behavior in `core/http_client.py` unchanged
- keep scraping, installed-model detection, metadata enrichment, and pagination semantics unchanged

## Structured mappings

- HTTP 429 -> `rate_limited`, retryable, status 429, optional retry-after
- HTTP 5xx -> `http_error`, retryable
- permanent non-200 HTTP -> `http_error`, non-retryable
- timeout -> `timeout`, retryable
- connection/request failure -> `transport_error`, retryable
- parse/value failure -> `parse_error`, non-retryable

## Self-review

- branch is based on the exact post-#37 main commit
- direct `search_ollama_models()` callers retain the exact `(results, errors, has_more_pages)` shape
- repository scan found no narrow-signature test double that rejects the internal keyword sink
- existing retry policy is not duplicated or changed
- new fixtures keep mutable state on instances to avoid the RUF012 failure pattern seen in #37
- final diff is limited to `providers/ollama_provider.py` plus one focused regression file

## Acceptance

- legacy direct callers remain behaviorally unchanged
- `OllamaProvider.search()` exposes structured diagnostics
- rate limit, 5xx, timeout, transport, and parse classifications are covered
- CI and Package must pass before merge