### PR TITLE
feat: populate LM Studio structured errors

### DIFF
--- a/providers/lmstudio_provider.py
+++ b/providers/lmstudio_provider.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from requests.exceptions import RequestException
+from requests.exceptions import RequestException, Timeout
 
+from core.errors import ProviderError
 from core.http_client import get_session
 from core.scoring import enrich_result_with_scores
+from core.utils import parse_retry_after_seconds
 from providers import BaseProvider
 from providers.base import SearchResult
 
@@ -77,11 +79,43 @@ class LMStudioProvider(BaseProvider):
         try:
             resp = get_session().get(f"{self.host}/v1/models", timeout=5)
             if resp.status_code != 200:
-                return SearchResult(errors=[f"LM Studio API returned status {resp.status_code}"])
+                message = f"LM Studio API returned status {resp.status_code}"
+                status_code = resp.status_code
+                retryable = status_code == 429 or status_code >= 500
+                code = "rate_limited" if status_code == 429 else "http_error"
+                retry_after = None
+                if status_code == 429:
+                    headers = getattr(resp, "headers", None) or {}
+                    retry_after = parse_retry_after_seconds(headers.get("Retry-After"))
+                return SearchResult(
+                    errors=[message],
+                    structured_errors=[
+                        ProviderError(
+                            provider=self.slug,
+                            code=code,
+                            message=message,
+                            retryable=retryable,
+                            status_code=status_code,
+                            retry_after_seconds=retry_after,
+                        )
+                    ],
+                )
 
             data = resp.json()
         except RequestException as exc:
-            return SearchResult(errors=[f"LM Studio search failed: {exc}"])
+            message = f"LM Studio search failed: {exc}"
+            code = "timeout" if isinstance(exc, Timeout) else "transport_error"
+            return SearchResult(
+                errors=[message],
+                structured_errors=[
+                    ProviderError(
+                        provider=self.slug,
+                        code=code,
+                        message=message,
+                        retryable=True,
+                    )
+                ],
+            )
 
         results = self._parse_models(data)
 

--- a/providers/lmstudio_provider.py
+++ b/providers/lmstudio_provider.py
@@ -81,7 +81,7 @@ class LMStudioProvider(BaseProvider):
             if resp.status_code != 200:
                 message = f"LM Studio API returned status {resp.status_code}"
                 status_code = resp.status_code
-                retryable = status_code == 429 or status_code >= 500
+                retryable = status_code == 429 or 500 <= status_code <= 599
                 code = "rate_limited" if status_code == 429 else "http_error"
                 retry_after = None
                 if status_code == 429:

--- a/tests/test_lmstudio_structured_errors.py
+++ b/tests/test_lmstudio_structured_errors.py
@@ -1,0 +1,154 @@
+from requests.exceptions import RequestException, Timeout
+
+from providers.lmstudio_provider import LMStudioProvider
+
+
+class FakeResponse:
+    """Minimal LM Studio response fixture with instance-owned state."""
+
+    def __init__(self, status_code=200, data=None, headers=None):
+        self.status_code = status_code
+        self._data = data if data is not None else {"data": []}
+        self.headers = dict(headers or {})
+
+    def json(self):
+        """Return the configured JSON payload."""
+        return self._data
+
+
+class FakeSession:
+    """Session fixture returning or raising a configured outcome."""
+
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def get(self, *_args, **_kwargs):
+        """Return the configured response or raise the configured exception."""
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+def _specs():
+    """Return minimal deterministic hardware specs."""
+    return {
+        "has_gpu": False,
+        "vram_total": 0.0,
+        "vram_free": 0.0,
+        "ram_total": 16.0,
+        "ram_free": 16.0,
+    }
+
+
+def test_rate_limit_adds_retryable_structured_error(monkeypatch):
+    """HTTP 429 should preserve the legacy string and expose retry metadata."""
+    response = FakeResponse(status_code=429, headers={"Retry-After": "7"})
+    monkeypatch.setattr(
+        "providers.lmstudio_provider.get_session",
+        lambda: FakeSession(response),
+    )
+
+    result = LMStudioProvider().search("model", _specs())
+
+    assert result.errors == ["LM Studio API returned status 429"]
+    assert len(result.structured_errors) == 1
+    error = result.structured_errors[0]
+    assert error.provider == "lmstudio"
+    assert error.code == "rate_limited"
+    assert error.message == result.errors[0]
+    assert error.retryable is True
+    assert error.status_code == 429
+    assert error.retry_after_seconds == 7.0
+
+
+def test_server_error_is_retryable(monkeypatch):
+    """HTTP 5xx should be represented as a retryable HTTP error."""
+    monkeypatch.setattr(
+        "providers.lmstudio_provider.get_session",
+        lambda: FakeSession(FakeResponse(status_code=503)),
+    )
+
+    result = LMStudioProvider().search("model", _specs())
+
+    assert result.errors == ["LM Studio API returned status 503"]
+    error = result.structured_errors[0]
+    assert error.code == "http_error"
+    assert error.retryable is True
+    assert error.status_code == 503
+    assert error.retry_after_seconds is None
+
+
+def test_permanent_http_error_is_not_retryable(monkeypatch):
+    """Permanent 4xx responses should retain their legacy message without retryability."""
+    monkeypatch.setattr(
+        "providers.lmstudio_provider.get_session",
+        lambda: FakeSession(FakeResponse(status_code=404)),
+    )
+
+    result = LMStudioProvider().search("model", _specs())
+
+    assert result.errors == ["LM Studio API returned status 404"]
+    error = result.structured_errors[0]
+    assert error.code == "http_error"
+    assert error.retryable is False
+    assert error.status_code == 404
+
+
+def test_timeout_is_classified_separately(monkeypatch):
+    """Timeout failures should remain legacy-compatible while exposing timeout metadata."""
+    monkeypatch.setattr(
+        "providers.lmstudio_provider.get_session",
+        lambda: FakeSession(Timeout("slow response")),
+    )
+
+    result = LMStudioProvider().search("model", _specs())
+
+    assert result.errors == ["LM Studio search failed: slow response"]
+    error = result.structured_errors[0]
+    assert error.code == "timeout"
+    assert error.retryable is True
+    assert error.status_code is None
+
+
+def test_request_failure_is_transport_error(monkeypatch):
+    """Other requests failures should be represented as retryable transport errors."""
+    monkeypatch.setattr(
+        "providers.lmstudio_provider.get_session",
+        lambda: FakeSession(RequestException("connection failed")),
+    )
+
+    result = LMStudioProvider().search("model", _specs())
+
+    assert result.errors == ["LM Studio search failed: connection failed"]
+    error = result.structured_errors[0]
+    assert error.code == "transport_error"
+    assert error.retryable is True
+    assert error.status_code is None
+
+
+def test_successful_search_remains_compatible(monkeypatch):
+    """Successful search should keep filtering and pagination behavior unchanged."""
+    response = FakeResponse(
+        data={
+            "data": [
+                {"id": "qwen-coder"},
+                {"id": "qwen-chat"},
+                {"id": "llama"},
+            ]
+        }
+    )
+    monkeypatch.setattr(
+        "providers.lmstudio_provider.get_session",
+        lambda: FakeSession(response),
+    )
+    monkeypatch.setattr(
+        "providers.lmstudio_provider.enrich_result_with_scores",
+        lambda model, _specs: model,
+    )
+
+    result = LMStudioProvider().search("qwen", _specs(), limit=1)
+
+    assert [model["name"] for model in result.results] == ["qwen-coder"]
+    assert result.errors == []
+    assert result.structured_errors == []
+    assert result.has_more_pages is True


### PR DESCRIPTION
Closes #40

## Scope

- populate `SearchResult.structured_errors` for LM Studio search failures
- preserve every existing legacy error string exactly
- keep successful search, filtering, scoring, installed-model, metadata, and pagination behavior unchanged
- keep the shared HTTP retry/backoff policy unchanged
- intentionally leave malformed JSON / parse behavior unchanged in this PR

## Structured mappings

- HTTP 429 -> `rate_limited`, retryable, status 429, optional retry-after
- HTTP 5xx -> `http_error`, retryable
- permanent non-200 HTTP -> `http_error`, non-retryable
- timeout -> `timeout`, retryable
- other requests failures -> `transport_error`, retryable

## Self-review

- branch is based on exact post-#39 `main` commit `3682db87cae204609701fe32f2ff31eac1d0a3c2`
- legacy messages remain byte-for-byte unchanged
- retryable HTTP range is bounded to 429 or 500..599
- no retry implementation is duplicated
- parse behavior is deliberately out of scope
- final diff is limited to `providers/lmstudio_provider.py` plus one focused regression file

## Acceptance

- 429 exposes retry-after metadata without changing the legacy string
- 5xx is retryable; permanent 4xx is not
- timeout is classified separately from generic transport failures
- successful filtering and `has_more_pages` behavior remain unchanged
- CI and Package must pass before merge