### PR TITLE
feat: populate Docker structured errors

### DIFF
--- a/providers/docker_provider.py
+++ b/providers/docker_provider.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from requests.exceptions import RequestException
+from requests.exceptions import RequestException, Timeout
 
+from core.errors import ProviderError
 from core.http_client import get_session
 from core.scoring import enrich_result_with_scores
 from core.utils import (
@@ -20,6 +21,7 @@ from core.utils import (
     estimate_model_size_gb,
     extract_params,
     infer_quant_from_name,
+    parse_retry_after_seconds,
 )
 from providers import BaseProvider
 from providers.base import SearchResult
@@ -57,8 +59,29 @@ class DockerProvider(BaseProvider):
         try:
             resp = get_session().get(f"{self.host}/models", timeout=5)
             if resp.status_code != 200:
-                errors.append(f"Docker Model Runner API error (HTTP {resp.status_code})")
-                return SearchResult(results=results, errors=errors)
+                message = f"Docker Model Runner API error (HTTP {resp.status_code})"
+                errors.append(message)
+                status_code = resp.status_code
+                retryable = status_code == 429 or 500 <= status_code <= 599
+                code = "rate_limited" if status_code == 429 else "http_error"
+                retry_after = None
+                if status_code == 429:
+                    headers = getattr(resp, "headers", None) or {}
+                    retry_after = parse_retry_after_seconds(headers.get("Retry-After"))
+                return SearchResult(
+                    results=results,
+                    errors=errors,
+                    structured_errors=[
+                        ProviderError(
+                            provider=self.slug,
+                            code=code,
+                            message=message,
+                            retryable=retryable,
+                            status_code=status_code,
+                            retry_after_seconds=retry_after,
+                        )
+                    ],
+                )
 
             data = resp.json()
             # Docker Model Runner returns a list or {"models": [...]}
@@ -114,7 +137,21 @@ class DockerProvider(BaseProvider):
                     break
 
         except RequestException as exc:
-            errors.append(f"Docker Model Runner request failed: {exc}")
+            message = f"Docker Model Runner request failed: {exc}"
+            errors.append(message)
+            code = "timeout" if isinstance(exc, Timeout) else "transport_error"
+            return SearchResult(
+                results=results,
+                errors=errors,
+                structured_errors=[
+                    ProviderError(
+                        provider=self.slug,
+                        code=code,
+                        message=message,
+                        retryable=True,
+                    )
+                ],
+            )
 
         return SearchResult(results=results, errors=errors, has_more_pages=len(results) > limit)
 

--- a/tests/test_docker_structured_errors.py
+++ b/tests/test_docker_structured_errors.py
@@ -1,0 +1,152 @@
+from requests.exceptions import RequestException, Timeout
+
+from providers.docker_provider import DockerProvider
+
+
+class FakeResponse:
+    """Minimal Docker Model Runner response fixture with instance-owned state."""
+
+    def __init__(self, status_code=200, data=None, headers=None):
+        self.status_code = status_code
+        self._data = data if data is not None else []
+        self.headers = dict(headers or {})
+
+    def json(self):
+        """Return the configured JSON payload."""
+        return self._data
+
+
+class FakeSession:
+    """Session fixture returning or raising a configured outcome."""
+
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def get(self, *_args, **_kwargs):
+        """Return the configured response or raise the configured exception."""
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+def _specs():
+    """Return minimal deterministic hardware specs."""
+    return {
+        "has_gpu": False,
+        "vram_total": 0.0,
+        "vram_free": 0.0,
+        "ram_total": 16.0,
+        "ram_free": 16.0,
+    }
+
+
+def test_rate_limit_adds_retryable_structured_error(monkeypatch):
+    """HTTP 429 should preserve the legacy string and expose retry metadata."""
+    response = FakeResponse(status_code=429, headers={"Retry-After": "7"})
+    monkeypatch.setattr(
+        "providers.docker_provider.get_session",
+        lambda: FakeSession(response),
+    )
+
+    result = DockerProvider().search("model", _specs())
+
+    assert result.errors == ["Docker Model Runner API error (HTTP 429)"]
+    assert len(result.structured_errors) == 1
+    error = result.structured_errors[0]
+    assert error.provider == "docker"
+    assert error.code == "rate_limited"
+    assert error.message == result.errors[0]
+    assert error.retryable is True
+    assert error.status_code == 429
+    assert error.retry_after_seconds == 7.0
+
+
+def test_server_error_is_retryable(monkeypatch):
+    """HTTP 5xx should be represented as a retryable HTTP error."""
+    monkeypatch.setattr(
+        "providers.docker_provider.get_session",
+        lambda: FakeSession(FakeResponse(status_code=503)),
+    )
+
+    result = DockerProvider().search("model", _specs())
+
+    assert result.errors == ["Docker Model Runner API error (HTTP 503)"]
+    error = result.structured_errors[0]
+    assert error.code == "http_error"
+    assert error.retryable is True
+    assert error.status_code == 503
+    assert error.retry_after_seconds is None
+
+
+def test_permanent_http_error_is_not_retryable(monkeypatch):
+    """Permanent 4xx responses should retain their legacy message without retryability."""
+    monkeypatch.setattr(
+        "providers.docker_provider.get_session",
+        lambda: FakeSession(FakeResponse(status_code=404)),
+    )
+
+    result = DockerProvider().search("model", _specs())
+
+    assert result.errors == ["Docker Model Runner API error (HTTP 404)"]
+    error = result.structured_errors[0]
+    assert error.code == "http_error"
+    assert error.retryable is False
+    assert error.status_code == 404
+
+
+def test_timeout_is_classified_separately(monkeypatch):
+    """Timeout failures should remain legacy-compatible while exposing timeout metadata."""
+    monkeypatch.setattr(
+        "providers.docker_provider.get_session",
+        lambda: FakeSession(Timeout("slow response")),
+    )
+
+    result = DockerProvider().search("model", _specs())
+
+    assert result.errors == ["Docker Model Runner request failed: slow response"]
+    error = result.structured_errors[0]
+    assert error.code == "timeout"
+    assert error.retryable is True
+    assert error.status_code is None
+
+
+def test_request_failure_is_transport_error(monkeypatch):
+    """Other requests failures should be represented as retryable transport errors."""
+    monkeypatch.setattr(
+        "providers.docker_provider.get_session",
+        lambda: FakeSession(RequestException("connection failed")),
+    )
+
+    result = DockerProvider().search("model", _specs())
+
+    assert result.errors == ["Docker Model Runner request failed: connection failed"]
+    error = result.structured_errors[0]
+    assert error.code == "transport_error"
+    assert error.retryable is True
+    assert error.status_code is None
+
+
+def test_successful_search_remains_compatible(monkeypatch):
+    """Successful search should keep filtering and result behavior unchanged."""
+    response = FakeResponse(
+        data=[
+            "acme/qwen-coder",
+            {"id": "acme/qwen-chat"},
+            {"name": "acme/llama"},
+        ]
+    )
+    monkeypatch.setattr(
+        "providers.docker_provider.get_session",
+        lambda: FakeSession(response),
+    )
+    monkeypatch.setattr(
+        "providers.docker_provider.enrich_result_with_scores",
+        lambda model, _specs: model,
+    )
+
+    result = DockerProvider().search("qwen", _specs(), limit=5)
+
+    assert [model["id"] for model in result.results] == ["acme/qwen-coder", "acme/qwen-chat"]
+    assert result.errors == []
+    assert result.structured_errors == []
+    assert result.has_more_pages is False


### PR DESCRIPTION
Closes #42

## Scope

- populate `SearchResult.structured_errors` for Docker Model Runner search failures
- preserve every existing legacy error string exactly
- keep successful search, filtering, scoring, installed-model, host, and pagination behavior unchanged
- keep the shared HTTP retry/backoff policy unchanged
- intentionally leave malformed JSON behavior unchanged in this PR

## Structured mappings

- HTTP 429 -> `rate_limited`, retryable, status 429, optional retry-after
- HTTP 5xx -> `http_error`, retryable
- permanent non-200 HTTP -> `http_error`, non-retryable
- timeout -> `timeout`, retryable
- other request failures -> `transport_error`, retryable

## Self-review

- branch is based on exact post-#41 `main` commit `081efa9883b66f9e0aad3f9dc246d2d6fd19c040`
- legacy messages remain byte-for-byte unchanged
- retryable HTTP range is bounded to 429 or 500..599
- no retry implementation is duplicated
- parse and pagination behavior are deliberately out of scope
- new fixtures keep mutable state on instances
- final diff is limited to `providers/docker_provider.py` plus one focused regression file

## Acceptance

- 429 exposes retry-after metadata without changing the legacy string
- 5xx is retryable; permanent 4xx is not
- timeout is classified separately from generic transport failures
- successful filtering/result behavior remains unchanged
- CI and Package must pass before merge