### PR TITLE
fix: preserve provider pagination authority

### DIFF
--- a/search/search_orchestration.py
+++ b/search/search_orchestration.py
@@ -80,17 +80,10 @@ def validate_page_request(page_num: int, max_pages: int) -> tuple[bool, str | No
 
 
 def has_more_pages_for_results(
-    providers: Sequence[str],
-    hf_result_count: int,
-    ollama_result_count: int,
-    page_size: int,
+    providers: Sequence[str], provider_has_more_pages: bool
 ) -> bool:
-    """Compute whether next-page navigation should be enabled."""
-    if is_hf_provider_selection(providers) and hf_result_count > 0:
-        return hf_result_count == page_size
-    if "ollama" in providers and ollama_result_count > 0:
-        return False
-    return False
+    """Gate a provider-reported continuation flag through pagination capabilities."""
+    return selection_supports_pagination(providers) and provider_has_more_pages
 
 
 def provider_result_count(

--- a/search/search_orchestrator.py
+++ b/search/search_orchestrator.py
@@ -141,6 +141,7 @@ class SearchOrchestrator:
         hf_errors: list[str] = []
         extra_results: list[dict] = []
         extra_errors: list[str] = []
+        provider_page_flags: dict[str, bool] = {}
 
         def _cancelled_outcome() -> SearchOutcome:
             partial_results = ollama_results + hf_results + extra_results
@@ -218,6 +219,7 @@ class SearchOrchestrator:
                             extra_errors.append(f"{label} search failed")
                         continue
 
+                    provider_page_flags[label] = result.has_more_pages
                     if label == "ollama":
                         ollama_results = result.results
                         ollama_errors = result.errors
@@ -235,12 +237,10 @@ class SearchOrchestrator:
 
         results = ollama_results + hf_results + extra_results
         errors = ollama_errors + hf_errors + extra_errors
-        has_more_pages = has_more_pages_for_results(
-            providers,
-            hf_result_count=len(hf_results),
-            ollama_result_count=len(ollama_results),
-            page_size=page_size,
+        provider_has_more_pages = (
+            provider_page_flags.get(providers[0], False) if len(providers) == 1 else False
         )
+        has_more_pages = has_more_pages_for_results(providers, provider_has_more_pages)
         result_count = len(results)
 
         return SearchOutcome(

--- a/tests/test_provider_pagination_authority.py
+++ b/tests/test_provider_pagination_authority.py
@@ -1,0 +1,111 @@
+"""Regression tests for provider-owned pagination continuation state."""
+
+from providers import SearchResult
+from search.search_orchestrator import SearchOrchestrator
+
+
+class StubProvider:
+    """Provider test double returning one configured SearchResult."""
+
+    def __init__(self, slug: str, result: SearchResult):
+        self.slug = slug
+        self.display_name = slug.title()
+        self.result = result
+
+    def detect(self) -> bool:
+        """Return available for deterministic orchestration tests."""
+        return True
+
+    def search(self, *_args, **_kwargs) -> SearchResult:
+        """Return the configured search result."""
+        return self.result
+
+    def search_with_installed(self, *_args, **_kwargs) -> SearchResult:
+        """Return the configured search result for installed-aware calls."""
+        return self.result
+
+
+class StubMonitor:
+    """Hardware monitor test double."""
+
+    def get_specs(self) -> dict:
+        """Return minimal deterministic specs."""
+        return {"has_gpu": False, "ram_total": 16.0}
+
+
+def _orchestrator(hf_result: SearchResult, ollama_result: SearchResult | None = None):
+    """Build an orchestrator with deterministic provider results."""
+    return SearchOrchestrator(
+        monitor=StubMonitor(),
+        hf_provider=StubProvider("huggingface", hf_result),
+        ollama_provider=StubProvider("ollama", ollama_result or SearchResult.empty()),
+        on_progress=lambda *_args: None,
+        cancel_check=lambda: False,
+    )
+
+
+def test_hf_terminal_full_page_keeps_next_disabled():
+    """A full terminal HF page must trust the provider's False continuation flag."""
+    hf_result = SearchResult(
+        results=[{"id": "hf-1"}, {"id": "hf-2"}],
+        has_more_pages=False,
+    )
+    outcome = _orchestrator(hf_result).search(
+        search_id=1,
+        query="qwen",
+        providers=["huggingface"],
+        page=0,
+        page_size=2,
+    )
+
+    assert len(outcome.results) == 2
+    assert outcome.has_more_pages is False
+
+
+def test_hf_provider_true_continuation_enables_next():
+    """A paginated provider's True continuation flag must reach the outcome."""
+    hf_result = SearchResult(
+        results=[{"id": "hf-1"}],
+        has_more_pages=True,
+    )
+    outcome = _orchestrator(hf_result).search(
+        search_id=1,
+        query="qwen",
+        providers=["huggingface"],
+        page=0,
+        page_size=2,
+    )
+
+    assert outcome.has_more_pages is True
+
+
+def test_nonpaginated_provider_cannot_enable_next():
+    """Capability gating must reject continuation flags from non-paginated providers."""
+    ollama_result = SearchResult(
+        results=[{"id": "ollama-1"}],
+        has_more_pages=True,
+    )
+    outcome = _orchestrator(SearchResult.empty(), ollama_result).search(
+        search_id=1,
+        query="llama",
+        providers=["ollama"],
+        page=0,
+        page_size=1,
+    )
+
+    assert outcome.has_more_pages is False
+
+
+def test_multi_provider_search_remains_nonpaginated():
+    """Multi-provider fan-in must remain non-paginated even when providers report more pages."""
+    hf_result = SearchResult(results=[{"id": "hf-1"}], has_more_pages=True)
+    ollama_result = SearchResult(results=[{"id": "ollama-1"}], has_more_pages=True)
+    outcome = _orchestrator(hf_result, ollama_result).search(
+        search_id=1,
+        query="model",
+        providers=["ollama", "huggingface"],
+        page=0,
+        page_size=1,
+    )
+
+    assert outcome.has_more_pages is False

--- a/tests/test_search_orchestration.py
+++ b/tests/test_search_orchestration.py
@@ -34,16 +34,14 @@ def test_validate_page_request_rejects_out_of_bounds():
     assert message == "Reached page limit (10)."
 
 
-def test_has_more_pages_for_hf_when_page_full():
-    assert has_more_pages_for_results(
-        ["huggingface"], hf_result_count=15, ollama_result_count=0, page_size=15
-    )
+def test_has_more_pages_trusts_paginated_provider_flag():
+    assert has_more_pages_for_results(["huggingface"], True) is True
+    assert has_more_pages_for_results(["huggingface"], False) is False
 
 
-def test_has_more_pages_for_ollama_always_false():
-    assert not has_more_pages_for_results(
-        ["ollama"], hf_result_count=0, ollama_result_count=20, page_size=15
-    )
+def test_has_more_pages_rejects_nonpaginated_and_multi_provider_flags():
+    assert has_more_pages_for_results(["ollama"], True) is False
+    assert has_more_pages_for_results(["huggingface", "ollama"], True) is False
 
 
 def test_provider_result_count_tracks_selected_provider():


### PR DESCRIPTION
Closes #46

## Problem

`HuggingFaceProvider.search()` already returns authoritative `has_more_pages` state computed with lookahead, but `SearchOrchestrator` discarded it and guessed continuation from `hf_result_count == page_size`. A terminal page containing exactly `page_size` results could therefore incorrectly re-enable Next.

## Scope

- preserve each provider result's `has_more_pages` flag during fan-in
- make `has_more_pages_for_results()` a capability gate instead of a count heuristic
- allow pagination only for a single provider whose canonical capability is `paginated=True`
- keep multi-provider and non-paginated provider behavior unchanged
- do not change HF search, lookahead, retry, token, or tuple semantics

## Self-review

- branch is based on exact post-#45 `main` commit `63e1fb79707c5c1aef05d05618809088c78d8178`
- the old count heuristic is removed rather than retained as a fallback
- provider continuation state is now authoritative; orchestration only applies capability policy
- regression proves the old failure case: exactly `page_size` HF results with `has_more_pages=False`
- regression also proves provider `True` is preserved, while Ollama and multi-provider searches remain non-paginated
- no provider implementation or UI code is changed

## Acceptance

- terminal full HF page keeps Next disabled when provider reports no continuation
- provider-reported HF continuation enables Next
- non-paginated providers cannot enable Next
- multi-provider searches remain non-paginated
- CI and Package must pass before merge