### PR TITLE
fix: contain Docker response parse failures

### DIFF
--- a/providers/docker_provider.py
+++ b/providers/docker_provider.py
@@ -37,6 +37,39 @@ class DockerProvider(BaseProvider):
     def __init__(self):
         self.host = os.environ.get("DOCKER_MODEL_RUNNER_HOST", self.default_host)
 
+    @staticmethod
+    def _parse_model_ids(data: Any) -> list[str]:
+        """Validate a Docker Model Runner response and return model identifiers."""
+        if isinstance(data, list):
+            models = data
+        elif isinstance(data, dict):
+            if "models" in data:
+                models = data["models"]
+            elif "data" in data:
+                models = data["data"]
+            else:
+                models = []
+        else:
+            raise ValueError("expected response to be a list or object")
+
+        if not isinstance(models, list):
+            raise ValueError("expected model collection to be a list")
+
+        model_ids: list[str] = []
+        for model in models:
+            if isinstance(model, str):
+                model_id = model
+            elif isinstance(model, dict):
+                model_id = model.get("id", model.get("name", ""))
+            else:
+                raise ValueError("expected model entry to be a string or object")
+
+            if not isinstance(model_id, str):
+                raise ValueError("expected model id or name to be a string")
+            model_ids.append(model_id)
+
+        return model_ids
+
     def detect(self) -> bool:
         """Check if Docker Model Runner is available."""
         try:
@@ -82,60 +115,6 @@ class DockerProvider(BaseProvider):
                         )
                     ],
                 )
-
-            data = resp.json()
-            # Docker Model Runner returns a list or {"models": [...]}
-            models = data if isinstance(data, list) else data.get("models", data.get("data", []))
-
-            for model in models:
-                if isinstance(model, str):
-                    model_id = model
-                else:
-                    model_id = model.get("id", model.get("name", ""))
-
-                if not model_id:
-                    continue
-                if query and query != "*" and query.lower() not in model_id.lower():
-                    continue
-
-                name = model_id.split("/")[-1] if "/" in model_id else model_id
-                publisher = model_id.split("/")[0] if "/" in model_id else "docker"
-                params = extract_params(name)
-                use_case = determine_use_case(name)
-                use_case_key = determine_use_case_key(name)
-                quant = infer_quant_from_name(name, default="GGUF")
-                size_gb = estimate_model_size_gb(name)
-
-                fit_str, mode_str, _ = calculate_fit(size_gb, specs)
-
-                result = {
-                    "inst": "[green]✔[/green]",
-                    "source": "Docker",
-                    "provider": "Docker",
-                    "publisher": publisher,
-                    "id": model_id,
-                    "name": name,
-                    "params": params,
-                    "use_case": use_case,
-                    "use_case_key": use_case_key,
-                    "score": "[grey50]-[/grey50]",
-                    "likes": 0,
-                    "downloads": 0,
-                    "is_hidden_gem": False,
-                    "gem_score": 0.0,
-                    "quant": quant,
-                    "size_source": "estimated",
-                    "mode": mode_str,
-                    "fit": fit_str,
-                    "size": f"~{size_gb:.1f} GB",
-                    "_size_gb": size_gb,
-                }
-                enrich_result_with_scores(result, specs)
-                results.append(result)
-
-                if len(results) >= limit:
-                    break
-
         except RequestException as exc:
             message = f"Docker Model Runner request failed: {exc}"
             errors.append(message)
@@ -152,6 +131,68 @@ class DockerProvider(BaseProvider):
                     )
                 ],
             )
+
+        try:
+            model_ids = self._parse_model_ids(resp.json())
+        except (ValueError, TypeError, AttributeError) as exc:
+            message = f"Docker Model Runner response parse failed: {exc}"
+            errors.append(message)
+            return SearchResult(
+                results=results,
+                errors=errors,
+                structured_errors=[
+                    ProviderError(
+                        provider=self.slug,
+                        code="parse_error",
+                        message=message,
+                        retryable=False,
+                    )
+                ],
+            )
+
+        for model_id in model_ids:
+            if not model_id:
+                continue
+            if query and query != "*" and query.lower() not in model_id.lower():
+                continue
+
+            name = model_id.split("/")[-1] if "/" in model_id else model_id
+            publisher = model_id.split("/")[0] if "/" in model_id else "docker"
+            params = extract_params(name)
+            use_case = determine_use_case(name)
+            use_case_key = determine_use_case_key(name)
+            quant = infer_quant_from_name(name, default="GGUF")
+            size_gb = estimate_model_size_gb(name)
+
+            fit_str, mode_str, _ = calculate_fit(size_gb, specs)
+
+            result = {
+                "inst": "[green]✔[/green]",
+                "source": "Docker",
+                "provider": "Docker",
+                "publisher": publisher,
+                "id": model_id,
+                "name": name,
+                "params": params,
+                "use_case": use_case,
+                "use_case_key": use_case_key,
+                "score": "[grey50]-[/grey50]",
+                "likes": 0,
+                "downloads": 0,
+                "is_hidden_gem": False,
+                "gem_score": 0.0,
+                "quant": quant,
+                "size_source": "estimated",
+                "mode": mode_str,
+                "fit": fit_str,
+                "size": f"~{size_gb:.1f} GB",
+                "_size_gb": size_gb,
+            }
+            enrich_result_with_scores(result, specs)
+            results.append(result)
+
+            if len(results) >= limit:
+                break
 
         return SearchResult(results=results, errors=errors, has_more_pages=len(results) > limit)
 

--- a/providers/docker_provider.py
+++ b/providers/docker_provider.py
@@ -115,6 +115,69 @@ class DockerProvider(BaseProvider):
                         )
                     ],
                 )
+
+            try:
+                model_ids = self._parse_model_ids(resp.json())
+            except (ValueError, TypeError, AttributeError) as exc:
+                message = f"Docker Model Runner response parse failed: {exc}"
+                errors.append(message)
+                return SearchResult(
+                    results=results,
+                    errors=errors,
+                    structured_errors=[
+                        ProviderError(
+                            provider=self.slug,
+                            code="parse_error",
+                            message=message,
+                            retryable=False,
+                        )
+                    ],
+                )
+
+            for model_id in model_ids:
+                if not model_id:
+                    continue
+                if query and query != "*" and query.lower() not in model_id.lower():
+                    continue
+
+                name = model_id.split("/")[-1] if "/" in model_id else model_id
+                publisher = model_id.split("/")[0] if "/" in model_id else "docker"
+                params = extract_params(name)
+                use_case = determine_use_case(name)
+                use_case_key = determine_use_case_key(name)
+                quant = infer_quant_from_name(name, default="GGUF")
+                size_gb = estimate_model_size_gb(name)
+
+                fit_str, mode_str, _ = calculate_fit(size_gb, specs)
+
+                result = {
+                    "inst": "[green]✔[/green]",
+                    "source": "Docker",
+                    "provider": "Docker",
+                    "publisher": publisher,
+                    "id": model_id,
+                    "name": name,
+                    "params": params,
+                    "use_case": use_case,
+                    "use_case_key": use_case_key,
+                    "score": "[grey50]-[/grey50]",
+                    "likes": 0,
+                    "downloads": 0,
+                    "is_hidden_gem": False,
+                    "gem_score": 0.0,
+                    "quant": quant,
+                    "size_source": "estimated",
+                    "mode": mode_str,
+                    "fit": fit_str,
+                    "size": f"~{size_gb:.1f} GB",
+                    "_size_gb": size_gb,
+                }
+                enrich_result_with_scores(result, specs)
+                results.append(result)
+
+                if len(results) >= limit:
+                    break
+
         except RequestException as exc:
             message = f"Docker Model Runner request failed: {exc}"
             errors.append(message)
@@ -131,68 +194,6 @@ class DockerProvider(BaseProvider):
                     )
                 ],
             )
-
-        try:
-            model_ids = self._parse_model_ids(resp.json())
-        except (ValueError, TypeError, AttributeError) as exc:
-            message = f"Docker Model Runner response parse failed: {exc}"
-            errors.append(message)
-            return SearchResult(
-                results=results,
-                errors=errors,
-                structured_errors=[
-                    ProviderError(
-                        provider=self.slug,
-                        code="parse_error",
-                        message=message,
-                        retryable=False,
-                    )
-                ],
-            )
-
-        for model_id in model_ids:
-            if not model_id:
-                continue
-            if query and query != "*" and query.lower() not in model_id.lower():
-                continue
-
-            name = model_id.split("/")[-1] if "/" in model_id else model_id
-            publisher = model_id.split("/")[0] if "/" in model_id else "docker"
-            params = extract_params(name)
-            use_case = determine_use_case(name)
-            use_case_key = determine_use_case_key(name)
-            quant = infer_quant_from_name(name, default="GGUF")
-            size_gb = estimate_model_size_gb(name)
-
-            fit_str, mode_str, _ = calculate_fit(size_gb, specs)
-
-            result = {
-                "inst": "[green]✔[/green]",
-                "source": "Docker",
-                "provider": "Docker",
-                "publisher": publisher,
-                "id": model_id,
-                "name": name,
-                "params": params,
-                "use_case": use_case,
-                "use_case_key": use_case_key,
-                "score": "[grey50]-[/grey50]",
-                "likes": 0,
-                "downloads": 0,
-                "is_hidden_gem": False,
-                "gem_score": 0.0,
-                "quant": quant,
-                "size_source": "estimated",
-                "mode": mode_str,
-                "fit": fit_str,
-                "size": f"~{size_gb:.1f} GB",
-                "_size_gb": size_gb,
-            }
-            enrich_result_with_scores(result, specs)
-            results.append(result)
-
-            if len(results) >= limit:
-                break
 
         return SearchResult(results=results, errors=errors, has_more_pages=len(results) > limit)
 

--- a/tests/test_docker_parse_errors.py
+++ b/tests/test_docker_parse_errors.py
@@ -1,0 +1,136 @@
+"""Regression coverage for Docker Model Runner response parse containment."""
+
+from __future__ import annotations
+
+import pytest
+from requests.exceptions import JSONDecodeError
+
+from providers.docker_provider import DockerProvider
+
+
+class FakeResponse:
+    """Minimal Docker response fixture with configurable JSON behavior."""
+
+    def __init__(self, *, data=None, json_error=None):
+        self.status_code = 200
+        self._data = [] if data is None else data
+        self._json_error = json_error
+        self.headers = {}
+
+    def json(self):
+        """Return configured data or raise the configured JSON failure."""
+        if self._json_error is not None:
+            raise self._json_error
+        return self._data
+
+
+class FakeSession:
+    """Session fixture returning one configured response."""
+
+    def __init__(self, response):
+        self.response = response
+
+    def get(self, *_args, **_kwargs):
+        """Return the configured response."""
+        return self.response
+
+
+def _specs():
+    """Return minimal deterministic hardware specs."""
+    return {
+        "has_gpu": False,
+        "vram_total": 0.0,
+        "vram_free": 0.0,
+        "ram_total": 16.0,
+        "ram_free": 16.0,
+    }
+
+
+def _search(monkeypatch, response):
+    """Run Docker search against one fake response."""
+    monkeypatch.setattr(
+        "providers.docker_provider.get_session",
+        lambda: FakeSession(response),
+    )
+    return DockerProvider().search("qwen", _specs())
+
+
+def test_invalid_json_is_parse_error_not_transport(monkeypatch):
+    """Requests JSON decode failures should remain inside the parse boundary."""
+    response = FakeResponse(
+        json_error=JSONDecodeError("invalid JSON", "{", 0),
+    )
+
+    result = _search(monkeypatch, response)
+
+    assert result.results == []
+    assert result.errors[0].startswith("Docker Model Runner response parse failed: invalid JSON")
+    assert len(result.structured_errors) == 1
+    error = result.structured_errors[0]
+    assert error.provider == "docker"
+    assert error.code == "parse_error"
+    assert error.message == result.errors[0]
+    assert error.retryable is False
+    assert error.status_code is None
+
+
+def test_scalar_payload_is_contained(monkeypatch):
+    """A scalar top-level payload should return a deterministic parse diagnostic."""
+    result = _search(monkeypatch, FakeResponse(data="unexpected"))
+
+    assert result.errors == [
+        "Docker Model Runner response parse failed: expected response to be a list or object"
+    ]
+    assert result.structured_errors[0].code == "parse_error"
+
+
+def test_non_list_model_collection_is_contained(monkeypatch):
+    """Object wrappers must expose a list-valued model collection."""
+    result = _search(monkeypatch, FakeResponse(data={"models": {"id": "acme/qwen"}}))
+
+    assert result.errors == [
+        "Docker Model Runner response parse failed: expected model collection to be a list"
+    ]
+    assert result.structured_errors[0].code == "parse_error"
+
+
+def test_invalid_model_entry_is_contained(monkeypatch):
+    """Each model entry must be either a string id or an object."""
+    result = _search(monkeypatch, FakeResponse(data=[123]))
+
+    assert result.errors == [
+        "Docker Model Runner response parse failed: expected model entry to be a string or object"
+    ]
+    assert result.structured_errors[0].code == "parse_error"
+
+
+def test_non_string_model_id_is_contained(monkeypatch):
+    """Object model ids/names must resolve to strings before filtering."""
+    result = _search(monkeypatch, FakeResponse(data=[{"id": 123}]))
+
+    assert result.errors == [
+        "Docker Model Runner response parse failed: expected model id or name to be a string"
+    ]
+    assert result.structured_errors[0].code == "parse_error"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        ["acme/qwen-coder"],
+        {"models": [{"id": "acme/qwen-coder"}]},
+        {"data": [{"name": "acme/qwen-coder"}]},
+    ],
+)
+def test_supported_response_shapes_remain_compatible(monkeypatch, payload):
+    """All currently supported Docker response envelopes should still search normally."""
+    monkeypatch.setattr(
+        "providers.docker_provider.enrich_result_with_scores",
+        lambda model, _specs: model,
+    )
+
+    result = _search(monkeypatch, FakeResponse(data=payload))
+
+    assert [model["id"] for model in result.results] == ["acme/qwen-coder"]
+    assert result.errors == []
+    assert result.structured_errors == []


### PR DESCRIPTION
Closes #48

## Problem

`DockerProvider.search()` contained HTTP/transport failures but malformed `/models` responses could still leak exceptions or be misclassified. In particular, requests JSON decode errors are also `RequestException` instances, so invalid JSON could be surfaced as `transport_error` instead of a parse failure.

## Scope

- validate Docker search response envelopes before filtering/scoring
- contain malformed JSON/response shapes as non-retryable `parse_error`
- preserve supported list, `{models: [...]}`, and `{data: [...]}` response shapes
- keep HTTP status, timeout, transport, filtering, scoring, host, installed-model and non-pagination behavior unchanged
- leave `list_installed()` unchanged

## Self-review

- branch is based on exact post-#47 `main` commit `148b6a50809f05752d4cbd72e007530bed810ef8`
- parse handling is an inner boundary inside the existing request `try`, so JSON decode errors are classified before the outer `RequestException` handler
- response dictionaries without `models`/`data` still behave as an empty result, preserving the prior fallback
- empty string model ids are still skipped
- success loop semantics are unchanged
- an initial wider dedent was refactored away; final production diff is limited to the parser helper and parse containment path
- final diff is limited to `providers/docker_provider.py` plus one focused regression file

## Acceptance

- invalid JSON is `parse_error`, not `transport_error`
- scalar and non-list model collections are contained
- invalid model entries and non-string ids are contained
- all supported response envelopes still search normally
- existing Docker structured HTTP/transport tests remain green
- CI and Package must pass before merge