### PR TITLE
feat: preserve structured errors through search orchestration

### DIFF
--- a/search/search_orchestrator.py
+++ b/search/search_orchestrator.py
@@ -32,6 +32,7 @@ from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 
+from core.errors import ProviderError
 from providers import SearchResult, get_all_provider_classes
 from search.search_orchestration import has_more_pages_for_results
 
@@ -56,6 +57,9 @@ class SearchOutcome:
             providers returned. The orchestrator still returns a
             partial :class:`SearchOutcome`; the caller decides
             whether to apply it.
+        structured_errors: Machine-readable provider diagnostics preserved
+            from completed provider results. This field is additive; legacy
+            UI callers may continue using :attr:`errors` only.
     """
 
     results: list[dict] = field(default_factory=list)
@@ -64,6 +68,7 @@ class SearchOutcome:
     result_count: int = 0
     providers: list[str] = field(default_factory=list)
     cancelled: bool = False
+    structured_errors: list[ProviderError] = field(default_factory=list)
 
 
 class SearchOrchestrator:
@@ -137,10 +142,13 @@ class SearchOrchestrator:
 
         ollama_results: list[dict] = []
         ollama_errors: list[str] = []
+        ollama_structured_errors: list[ProviderError] = []
         hf_results: list[dict] = []
         hf_errors: list[str] = []
+        hf_structured_errors: list[ProviderError] = []
         extra_results: list[dict] = []
         extra_errors: list[str] = []
+        extra_structured_errors: list[ProviderError] = []
         provider_page_flags: dict[str, bool] = {}
 
         def _cancelled_outcome() -> SearchOutcome:
@@ -151,6 +159,11 @@ class SearchOrchestrator:
                 result_count=len(partial_results),
                 providers=list(providers),
                 cancelled=True,
+                structured_errors=(
+                    ollama_structured_errors
+                    + hf_structured_errors
+                    + extra_structured_errors
+                ),
             )
 
         def _search_ollama():
@@ -223,12 +236,15 @@ class SearchOrchestrator:
                     if label == "ollama":
                         ollama_results = result.results
                         ollama_errors = result.errors
+                        ollama_structured_errors = result.structured_errors
                     elif label == "huggingface":
                         hf_results = result.results
                         hf_errors = result.errors
+                        hf_structured_errors = result.structured_errors
                     else:
                         extra_results.extend(result.results)
                         extra_errors.extend(result.errors)
+                        extra_structured_errors.extend(result.structured_errors)
         finally:
             pool.shutdown(wait=wait_for_workers, cancel_futures=not wait_for_workers)
 
@@ -237,6 +253,9 @@ class SearchOrchestrator:
 
         results = ollama_results + hf_results + extra_results
         errors = ollama_errors + hf_errors + extra_errors
+        structured_errors = (
+            ollama_structured_errors + hf_structured_errors + extra_structured_errors
+        )
         provider_has_more_pages = (
             provider_page_flags.get(providers[0], False) if len(providers) == 1 else False
         )
@@ -249,4 +268,5 @@ class SearchOrchestrator:
             has_more_pages=has_more_pages,
             result_count=result_count,
             providers=list(providers),
+            structured_errors=structured_errors,
         )

--- a/tests/test_orchestrator_structured_errors.py
+++ b/tests/test_orchestrator_structured_errors.py
@@ -1,0 +1,220 @@
+from core.errors import ProviderError
+from providers import SearchResult
+from search import search_orchestrator
+from search.search_orchestrator import SearchOrchestrator, SearchOutcome
+
+
+class StubMonitor:
+    """Return deterministic hardware specs for orchestration tests."""
+
+    def get_specs(self):
+        """Return minimal hardware data."""
+        return {"has_gpu": False, "ram_total": 16.0}
+
+
+class StubProvider:
+    """Provider double returning one configured SearchResult."""
+
+    def __init__(self, slug, result):
+        self.slug = slug
+        self.display_name = slug.title()
+        self.result = result
+
+    def detect(self):
+        """Report the provider as available."""
+        return True
+
+    def search(self, *_args, **_kwargs):
+        """Return the configured search result."""
+        return self.result
+
+    def search_with_installed(self, *_args, **_kwargs):
+        """Return the configured installed-aware search result."""
+        return self.result
+
+
+class ImmediateFuture:
+    """Small future double whose result is already available."""
+
+    def __init__(self, result):
+        self._result = result
+
+    def result(self):
+        """Return the precomputed result."""
+        return self._result
+
+
+class ImmediatePool:
+    """Synchronous executor used to make cancellation ordering deterministic."""
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def submit(self, fn, *args):
+        """Execute immediately and wrap the return value as a future."""
+        return ImmediateFuture(fn(*args))
+
+    def shutdown(self, **_kwargs):
+        """Match the executor shutdown surface without side effects."""
+        return None
+
+
+def _error(provider, code):
+    """Build one deterministic structured provider error."""
+    return ProviderError(
+        provider=provider,
+        code=code,
+        message=f"{provider}:{code}",
+        retryable=False,
+    )
+
+
+def _orchestrator(hf_result=None, ollama_result=None, cancel_check=lambda: False):
+    """Build an orchestrator with configurable built-in provider results."""
+    hf = StubProvider("huggingface", hf_result or SearchResult.empty())
+    ollama = StubProvider("ollama", ollama_result or SearchResult.empty())
+    return SearchOrchestrator(
+        monitor=StubMonitor(),
+        hf_provider=hf,
+        ollama_provider=ollama,
+        on_progress=lambda *_args: None,
+        cancel_check=cancel_check,
+    )
+
+
+def test_search_outcome_defaults_structured_errors_independently():
+    """The additive field should default to an independent empty list."""
+    first = SearchOutcome()
+    second = SearchOutcome()
+
+    first.structured_errors.append(_error("test", "first"))
+
+    assert len(first.structured_errors) == 1
+    assert second.structured_errors == []
+
+
+def test_single_provider_preserves_legacy_and_structured_errors():
+    """HF diagnostics should survive fan-in without changing legacy errors."""
+    structured = _error("huggingface", "rate_limited")
+    orch = _orchestrator(
+        hf_result=SearchResult(
+            errors=["legacy hf error"],
+            structured_errors=[structured],
+        )
+    )
+
+    outcome = orch.search(
+        search_id=1,
+        query="qwen",
+        providers=["huggingface"],
+        page=0,
+        page_size=10,
+    )
+
+    assert outcome.errors == ["legacy hf error"]
+    assert outcome.structured_errors == [structured]
+
+
+def test_builtin_provider_structured_errors_keep_legacy_group_order():
+    """Ollama diagnostics should remain before Hugging Face diagnostics."""
+    ollama_error = _error("ollama", "timeout")
+    hf_error = _error("huggingface", "http_error")
+    orch = _orchestrator(
+        ollama_result=SearchResult(
+            errors=["ollama legacy"],
+            structured_errors=[ollama_error],
+        ),
+        hf_result=SearchResult(
+            errors=["hf legacy"],
+            structured_errors=[hf_error],
+        ),
+    )
+
+    outcome = orch.search(
+        search_id=1,
+        query="model",
+        providers=["ollama", "huggingface"],
+        page=0,
+        page_size=10,
+    )
+
+    assert outcome.errors == ["ollama legacy", "hf legacy"]
+    assert outcome.structured_errors == [ollama_error, hf_error]
+
+
+def test_extra_provider_structured_errors_survive_fan_in(monkeypatch):
+    """Class-registry providers should contribute structured diagnostics too."""
+    docker_error = _error("docker", "parse_error")
+
+    class ExtraProvider:
+        """Docker-like registry provider used only for this test."""
+
+        slug = "docker"
+        display_name = "Docker"
+
+        def detect(self):
+            """Report the provider as available."""
+            return True
+
+        def search(self, *_args, **_kwargs):
+            """Return one structured parse diagnostic."""
+            return SearchResult(
+                errors=["docker legacy"],
+                structured_errors=[docker_error],
+            )
+
+    monkeypatch.setattr(
+        search_orchestrator,
+        "get_all_provider_classes",
+        lambda: [ExtraProvider],
+    )
+    orch = _orchestrator()
+
+    outcome = orch.search(
+        search_id=1,
+        query="model",
+        providers=["docker"],
+        page=0,
+        page_size=10,
+    )
+
+    assert outcome.errors == ["docker legacy"]
+    assert outcome.structured_errors == [docker_error]
+
+
+def test_cancelled_outcome_keeps_completed_structured_errors(monkeypatch):
+    """Final cancellation should retain diagnostics already returned by providers."""
+    structured = _error("huggingface", "timeout")
+    calls = 0
+
+    def cancel_check():
+        """Cancel only on the final post-fan-in cancellation check."""
+        nonlocal calls
+        calls += 1
+        return calls >= 4
+
+    def immediate_wait(pending, **_kwargs):
+        """Mark every synchronous future complete in one polling cycle."""
+        return set(pending), set()
+
+    monkeypatch.setattr(search_orchestrator, "ThreadPoolExecutor", ImmediatePool)
+    monkeypatch.setattr(search_orchestrator, "wait", immediate_wait)
+    orch = _orchestrator(
+        hf_result=SearchResult(
+            errors=["legacy timeout"],
+            structured_errors=[structured],
+        ),
+        cancel_check=cancel_check,
+    )
+
+    outcome = orch.search(
+        search_id=1,
+        query="qwen",
+        providers=["huggingface"],
+        page=0,
+        page_size=10,
+    )
+
+    assert outcome.cancelled is True
+    assert outcome.errors == ["legacy timeout"]
+    assert outcome.structured_errors == [structured]


### PR DESCRIPTION
Closes #50

## Problem

Provider implementations now emit machine-readable `SearchResult.structured_errors`, but `SearchOrchestrator` discarded that metadata and `SearchOutcome` exposed only legacy string errors.

## Scope

- add additive `SearchOutcome.structured_errors` as the final dataclass field
- preserve Ollama, Hugging Face, and extra-provider structured diagnostics during fan-in
- preserve already-completed structured diagnostics in cancelled outcomes
- keep legacy `errors`, result ordering, pagination, cancellation and TUI behavior unchanged
- do not synthesize structured errors for unexpected provider exceptions
- do not change TUI rendering in this PR

## Self-review

- branch is based on exact post-#49 `main` commit `253f228e8209d3fd0c4304850ee84ef5507faa7c`
- the new field is appended after every existing `SearchOutcome` field to preserve constructor compatibility
- production diff is additive only (+20 lines)
- legacy error grouping remains Ollama, Hugging Face, then extra providers; structured diagnostics use the same grouping
- extra-provider diagnostics follow the existing extra-provider completion order, matching legacy extra errors/results
- cancelled outcomes retain diagnostics already processed before cancellation
- existing TUI still reads only `outcome.errors`, so user-visible behavior is unchanged
- no provider implementation is modified

## Acceptance

- single-provider structured diagnostics survive into `SearchOutcome`
- built-in multi-provider diagnostics preserve legacy grouping order
- registry/extra-provider diagnostics survive fan-in
- cancelled outcomes retain completed structured diagnostics
- default `SearchOutcome()` instances have independent structured-error lists
- CI and Package must pass before merge