### PR TITLE
fix: contain Docker installed-model parse failures

### DIFF
--- a/providers/docker_provider.py
+++ b/providers/docker_provider.py
@@ -201,18 +201,10 @@ class DockerProvider(BaseProvider):
         """List installed Docker models."""
         try:
             resp = get_session().get(f"{self.host}/models", timeout=2)
-            if resp.status_code == 200:
-                data = resp.json()
-                models = (
-                    data if isinstance(data, list) else data.get("models", data.get("data", []))
-                )
-                ids = []
-                for m in models:
-                    if isinstance(m, str):
-                        ids.append(m.lower())
-                    else:
-                        ids.append(m.get("id", m.get("name", "")).lower())
-                return ids
-        except (RequestException, ValueError):
-            pass
-        return []
+            if resp.status_code != 200:
+                return []
+            model_ids = self._parse_model_ids(resp.json())
+        except (RequestException, ValueError, TypeError, AttributeError):
+            return []
+
+        return [model_id.lower() for model_id in model_ids]

--- a/tests/test_docker_parse_errors.py
+++ b/tests/test_docker_parse_errors.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from requests.exceptions import JSONDecodeError
+from requests.exceptions import JSONDecodeError, RequestException
 
 from providers.docker_provider import DockerProvider
 
@@ -11,8 +11,8 @@ from providers.docker_provider import DockerProvider
 class FakeResponse:
     """Minimal Docker response fixture with configurable JSON behavior."""
 
-    def __init__(self, *, data=None, json_error=None):
-        self.status_code = 200
+    def __init__(self, *, data=None, json_error=None, status_code=200):
+        self.status_code = status_code
         self._data = [] if data is None else data
         self._json_error = json_error
         self.headers = {}
@@ -35,6 +35,17 @@ class FakeSession:
         return self.response
 
 
+class FailingSession:
+    """Session fixture raising one configured request failure."""
+
+    def __init__(self, exc):
+        self.exc = exc
+
+    def get(self, *_args, **_kwargs):
+        """Raise the configured request failure."""
+        raise self.exc
+
+
 def _specs():
     """Return minimal deterministic hardware specs."""
     return {
@@ -53,6 +64,15 @@ def _search(monkeypatch, response):
         lambda: FakeSession(response),
     )
     return DockerProvider().search("qwen", _specs())
+
+
+def _installed(monkeypatch, response):
+    """Run Docker installed-model discovery against one fake response."""
+    monkeypatch.setattr(
+        "providers.docker_provider.get_session",
+        lambda: FakeSession(response),
+    )
+    return DockerProvider().list_installed()
 
 
 def test_invalid_json_is_parse_error_not_transport(monkeypatch):
@@ -134,3 +154,53 @@ def test_supported_response_shapes_remain_compatible(monkeypatch, payload):
     assert [model["id"] for model in result.results] == ["acme/qwen-coder"]
     assert result.errors == []
     assert result.structured_errors == []
+
+
+def test_installed_invalid_json_fails_closed(monkeypatch):
+    """Installed-model discovery should contain JSON decode failures."""
+    response = FakeResponse(json_error=JSONDecodeError("invalid JSON", "{", 0))
+
+    assert _installed(monkeypatch, response) == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "unexpected",
+        {"models": {"id": "acme/qwen"}},
+        [123],
+        [{"id": 123}],
+    ],
+)
+def test_installed_malformed_shapes_fail_closed(monkeypatch, payload):
+    """Installed-model discovery should contain every invalid parser shape."""
+    assert _installed(monkeypatch, FakeResponse(data=payload)) == []
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (["ACME/Qwen"], ["acme/qwen"]),
+        ({"models": [{"id": "ACME/Qwen"}]}, ["acme/qwen"]),
+        ({"data": [{"name": "ACME/Qwen"}]}, ["acme/qwen"]),
+        ([""], [""]),
+    ],
+)
+def test_installed_supported_shapes_remain_compatible(monkeypatch, payload, expected):
+    """Installed-model discovery should preserve valid envelopes and lowercase ids."""
+    assert _installed(monkeypatch, FakeResponse(data=payload)) == expected
+
+
+def test_installed_non_200_response_remains_empty(monkeypatch):
+    """Non-success installed-model responses should remain fail-closed."""
+    assert _installed(monkeypatch, FakeResponse(status_code=503)) == []
+
+
+def test_installed_request_failure_remains_empty(monkeypatch):
+    """Transport failures should remain contained during installed discovery."""
+    monkeypatch.setattr(
+        "providers.docker_provider.get_session",
+        lambda: FailingSession(RequestException("connection failed")),
+    )
+
+    assert DockerProvider().list_installed() == []


### PR DESCRIPTION
Closes #58

## Problem

`DockerProvider.search()` validates `/models` responses through `_parse_model_ids()`, but `list_installed()` still used an older ad-hoc parser. Malformed 200 responses could therefore raise `AttributeError`/`TypeError` instead of degrading to an empty installed-model list.

## Scope

- reuse `_parse_model_ids()` in `DockerProvider.list_installed()`
- preserve fail-closed `[]` behavior for malformed JSON/shapes, non-200 responses, and request failures
- preserve lowercase installed identifiers and empty-id compatibility
- leave `DockerProvider.search()`, pagination, and capabilities unchanged

## Self-review

- branch is based on exact post-#57 `main` commit `5cd9654f47b9e5eb0d78a5f410e1fcccc5cee6c2`
- production diff is +7/-15 and removes duplicate response parsing
- search-path parse behavior is untouched
- valid list, `{models:[...]}`, and `{data:[...]}` envelopes remain compatible
- malformed top-level/container/entry/id shapes now fail closed instead of raising
- regression also preserves non-200, request-failure, lowercase, and empty-string behavior

## Acceptance

- malformed installed-model payloads never raise
- invalid JSON and transport failures return `[]`
- valid supported envelopes return lowercase identifiers
- CI and Package must pass before merge