### PR TITLE
fix: surface provider diagnostics in CLI model discovery

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -41,6 +41,12 @@ def _search_hf_models(query: str, specs: dict, model_info_cache: dict, *, limit:
     )
 
 
+def _emit_provider_errors(errors: list[str]) -> None:
+    """Emit provider diagnostics on stderr without contaminating command stdout."""
+    for error in errors:
+        click.echo(f"Warning: {error}", err=True)
+
+
 def get_version() -> str:
     """Return the installed AI Model Explorer package version."""
     try:
@@ -128,16 +134,23 @@ def search(query, provider, limit, sort):
     monitor = HardwareMonitor()
     specs = monitor.get_specs()
     results = []
+    errors: list[str] = []
 
     with console.status(f"Searching for '{query}'..."):
         if provider in ("all", "ollama"):
             local = get_installed_ollama_models()
-            ollama_results, _, _ = search_ollama_models(query, specs, local, page_size=limit)
+            ollama_results, ollama_errors, _ = search_ollama_models(
+                query, specs, local, page_size=limit
+            )
             results.extend(ollama_results)
+            errors.extend(ollama_errors)
 
         if provider in ("all", "huggingface"):
-            hf_results, _ = _search_hf_models(query, specs, {}, limit=limit)
+            hf_results, hf_errors = _search_hf_models(query, specs, {}, limit=limit)
             results.extend(hf_results)
+            errors.extend(hf_errors)
+
+    _emit_provider_errors(errors)
 
     if sort == "composite":
         results.sort(key=lambda r: r.get("score_composite", 0), reverse=True)
@@ -190,15 +203,21 @@ def fit(perfect, limit):
     monitor = HardwareMonitor()
     specs = monitor.get_specs()
     results = []
+    errors: list[str] = []
 
     with console.status("Scanning models for hardware fit..."):
         local = get_installed_ollama_models()
-        ollama_results, _, _ = search_ollama_models("*", specs, local, page_size=50)
+        ollama_results, ollama_errors, _ = search_ollama_models(
+            "*", specs, local, page_size=50
+        )
         results.extend(ollama_results)
+        errors.extend(ollama_errors)
 
-        hf_results, _ = _search_hf_models("*", specs, {}, limit=50)
+        hf_results, hf_errors = _search_hf_models("*", specs, {}, limit=50)
         results.extend(hf_results)
+        errors.extend(hf_errors)
 
+    _emit_provider_errors(errors)
     results.sort(key=lambda r: r.get("score_composite", 0), reverse=True)
 
     if perfect:
@@ -242,15 +261,21 @@ def recommend(limit, use_case, output_json):
     monitor = HardwareMonitor()
     specs = monitor.get_specs()
     results = []
+    errors: list[str] = []
 
     with console.status(f"Finding best {use_case} models..."):
         local = get_installed_ollama_models()
-        ollama_results, _, _ = search_ollama_models("*", specs, local, page_size=50)
+        ollama_results, ollama_errors, _ = search_ollama_models(
+            "*", specs, local, page_size=50
+        )
         results.extend(ollama_results)
+        errors.extend(ollama_errors)
 
-        hf_results, _ = _search_hf_models("*", specs, {}, limit=50)
+        hf_results, hf_errors = _search_hf_models("*", specs, {}, limit=50)
         results.extend(hf_results)
+        errors.extend(hf_errors)
 
+    _emit_provider_errors(errors)
     results = [r for r in results if r.get("use_case_key") == use_case or use_case == "general"]
     results = [r for r in results if "no fit" not in r.get("fit", "").lower()]
     results.sort(key=lambda r: r.get("score_composite", 0), reverse=True)

--- a/tests/test_cli_provider_diagnostics.py
+++ b/tests/test_cli_provider_diagnostics.py
@@ -1,0 +1,156 @@
+"""Regression coverage for provider diagnostics in CLI model discovery commands."""
+
+from __future__ import annotations
+
+import json
+
+import cli as cli_module
+import providers.ollama_provider as ollama_provider
+
+
+class StubMonitor:
+    """Return deterministic hardware specs for CLI command tests."""
+
+    def get_specs(self) -> dict:
+        """Return minimal hardware data used only by provider doubles."""
+        return {"has_gpu": False, "ram_total": 16.0, "ram_free": 16.0}
+
+
+class _StatusContext:
+    """No-op context manager matching Rich Console.status()."""
+
+    def __enter__(self):
+        """Enter the no-op status context."""
+        return self
+
+    def __exit__(self, *_args):
+        """Exit the no-op status context without suppressing exceptions."""
+        return False
+
+
+class StubConsole:
+    """Avoid Rich terminal control output while preserving string stdout."""
+
+    def status(self, *_args, **_kwargs):
+        """Return a no-op status context."""
+        return _StatusContext()
+
+    def print(self, value="", *_args, **_kwargs):
+        """Print strings normally and ignore Rich table objects."""
+        if isinstance(value, str):
+            print(value)
+        elif value == "":
+            print()
+
+
+def _patch_common(monkeypatch) -> None:
+    """Install deterministic hardware, console, and installed-model doubles."""
+    monkeypatch.setattr(cli_module, "HardwareMonitor", StubMonitor)
+    monkeypatch.setattr(cli_module, "console", StubConsole())
+    monkeypatch.setattr(ollama_provider, "get_installed_ollama_models", lambda: [])
+
+
+def test_search_success_emits_no_provider_warning(monkeypatch, capsys):
+    """A successful selected-provider search should leave stderr empty."""
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        ollama_provider,
+        "search_ollama_models",
+        lambda *_args, **_kwargs: ([], [], False),
+    )
+
+    cli_module.search.callback("qwen", "ollama", 5, "composite")
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_search_surfaces_selected_provider_error_and_keeps_partial_results(
+    monkeypatch, capsys
+):
+    """Search should warn on stderr without discarding partial provider results."""
+    _patch_common(monkeypatch)
+
+    def ollama_search(*_args, **_kwargs):
+        return [
+            {
+                "name": "local-model",
+                "source": "Ollama",
+                "score_composite": 50,
+            }
+        ], ["Ollama registry timeout"], False
+
+    def unexpected_hf(*_args, **_kwargs):
+        raise AssertionError("Hugging Face should not run for provider=ollama")
+
+    monkeypatch.setattr(ollama_provider, "search_ollama_models", ollama_search)
+    monkeypatch.setattr(cli_module, "_search_hf_models", unexpected_hf)
+
+    cli_module.search.callback("qwen", "ollama", 5, "composite")
+
+    captured = capsys.readouterr()
+    assert captured.err == "Warning: Ollama registry timeout\n"
+    assert "1 results found" in captured.out
+
+
+def test_fit_preserves_ollama_then_hf_warning_order(monkeypatch, capsys):
+    """Multi-provider fit diagnostics should keep the existing provider order."""
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        ollama_provider,
+        "search_ollama_models",
+        lambda *_args, **_kwargs: ([], ["Ollama unavailable"], False),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "_search_hf_models",
+        lambda *_args, **_kwargs: ([], ["Hugging Face rate-limited"]),
+    )
+
+    cli_module.fit.callback(False, 5)
+
+    captured = capsys.readouterr()
+    assert captured.err.splitlines() == [
+        "Warning: Ollama unavailable",
+        "Warning: Hugging Face rate-limited",
+    ]
+
+
+def test_recommend_json_keeps_stdout_valid_and_warnings_on_stderr(monkeypatch, capsys):
+    """JSON recommendations must remain parseable when a provider reports failure."""
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        ollama_provider,
+        "search_ollama_models",
+        lambda *_args, **_kwargs: ([], ["Ollama transport failed"], False),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "_search_hf_models",
+        lambda *_args, **_kwargs: (
+            [
+                {
+                    "name": "hf-model",
+                    "source": "Hugging Face",
+                    "use_case_key": "general",
+                    "fit": "Perfect",
+                    "score_quality": 70,
+                    "score_speed": 60,
+                    "score_fit": 80,
+                    "score_context": 50,
+                    "score_composite": 65,
+                }
+            ],
+            ["Hugging Face request degraded"],
+        ),
+    )
+
+    cli_module.recommend.callback(5, "general", True)
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert [model["name"] for model in payload] == ["hf-model"]
+    assert captured.err.splitlines() == [
+        "Warning: Ollama transport failed",
+        "Warning: Hugging Face request degraded",
+    ]


### PR DESCRIPTION
Closes #62

## Problem

The CLI `search`, `fit`, and `recommend` commands discarded provider error lists, so rate limits, timeouts, HTTP failures, and similar provider failures could look like ordinary zero/partial-result output.

## Scope

- collect existing Ollama and Hugging Face error strings in `search`, `fit`, and `recommend`
- emit those diagnostics as `Warning: ...` lines on stderr
- preserve Ollama -> Hugging Face diagnostic order
- preserve result aggregation, sorting, tables, partial results, and exit codes
- preserve `recommend --json` stdout as the existing JSON array contract
- do not alter provider implementations or error classifications
- do not redesign CLI JSON output in this PR

## Self-review

- branch is based on exact post-#61 `main` commit `f9496a7d6fb4affb3d23c21e4f4d5df2ea0431c6`
- production diff is limited to +31/-6 in `cli.py`
- one helper centralizes stderr warning emission through `click.echo(..., err=True)`
- successful commands emit no warning lines
- provider-specific search does not execute or surface the other provider
- partial results remain rendered while provider warnings are emitted
- focused regression stubs Rich status/table output and verifies stdout/stderr separately
- `recommend --json` remains parseable JSON even when both providers return diagnostics

## Acceptance

- provider failures are distinguishable from genuine zero-result success
- partial results remain usable
- JSON stdout remains valid and unchanged in shape
- CI and Package must pass before merge