### PR TITLE
docs: refresh project baseline and active roadmap

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,193 +1,239 @@
 # Architecture
 
-**Analysis Date:** 2026-06-09
+**Baseline date:** 2026-09-07  
+**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`
 
-## Pattern Overview
+## Overview
 
-**Overall:** Monolithic TUI application with layering via internal packages + background subprocess service
+AI Model Explorer is a terminal-first local application with three user-facing surfaces over shared core logic:
 
-The application runs as a single Textual-based TUI process (`app.py:673`, class `AIModelViewer`) that orchestrates the entire user experience. A separate background process (`downloads/download_service.py`) handles model downloads asynchronously, communicating over HTTP on `127.0.0.1:8765`.
+- Textual TUI (`main.py` → `app.viewer.AIModelViewer`),
+- Click CLI (`cli.py`),
+- localhost REST API (`api_server.py`).
 
-**Key Characteristics:**
-- Provider plugin model via `BaseProvider` ABC (`providers/__init__.py:16`) — Ollama, HuggingFace, LM Studio, Docker, MLX
-- 4-dimension scoring engine (`core/scoring.py`) — Quality, Speed, Fit, Context metrics
-- Dual-mode UI: "comfortable" (full) and "compact" (minimal) views
-- Dual-cache strategy: SQLite for persistent metadata + in-memory for search results
-- CLI alternative via Click (`cli.py`) and REST API via `http.server` (`api_server.py:8787`)
+Model discovery is provider-based. Download execution is isolated in a separate localhost HTTP service so jobs can continue independently of TUI lifecycle.
 
-## Layers
+The architecture is no longer the old single-file `app.py` monolith described by the 2026-06-09 mapper output. The main Textual implementation still lives in `tui_app.py`, but provider selection, modals, widgets, search state, and download-management concerns have been extracted into focused modules under `app/`; search fan-out is isolated in `search/search_orchestrator.py`.
 
-**1. TUI Presentation (Heaviest Layer):**
-- Purpose: Render the terminal UI, handle keyboard/mouse input, manage widgets
-- Location: `app.py` (2466 lines — the monolith)
-- Contains: `AIModelViewer(App)` main class, 4 modal screens (`ModelDetailModal`, `DownloadJobModal`, `PlanModeModal`, `ComparisonModal`), `SystemInfoWidget`
-- Depends on: All other layers (core, providers, downloads, search, results)
-- Used by: `main.py` entry point
+## Major Components
 
-**2. CLI Layer:**
-- Purpose: Command-line access to search, scoring, hardware info, cache management
-- Location: `cli.py` (398 lines)
-- Contains: 8 Click commands (`info`, `system`, `search`, `fit`, `recommend`, `plan`, `scores`, `cache-clear`, `cache-stats`, `version`)
-- Depends on: `core`, `providers`
-- Used by: `pyproject.toml` entry point `ai-model-explorer-cli = "cli:cli"`
+### 1. Runtime TUI
 
-**3. REST API Layer:**
-- Purpose: Machine-readable HTTP API for programmatic access
-- Location: `api_server.py` (339 lines)
-- Contains: `ModelAPIHandler`, `create_server()`, `run_server()`, `start_server_background()`
-- Depends on: `core`, `providers`
-- Endpoints: `/health`, `/api/v1/system`, `/api/v1/models`, `/api/v1/models/{name}/plan`, `/api/v1/scores/{name}`, `/api/v1/providers`
+Entry path:
 
-**4. Core Domain:**
-- Purpose: Business logic — hardware detection, model scoring, caching, utilities
-- Location: `core/` (1627 total lines across 8 files)
-- Sub-modules:
-  - `hardware.py` — `HardwareMonitor`, GPU vendor detection, Ollama process check (389 lines)
-  - `scoring.py` — 4-dimension scoring engine, GPU bandwidth lookup, use-case weights (475 lines)
-  - `model_intelligence.py` — MoE detection, quantization selection, size estimation (334 lines)
-  - `models.py` — `ModelResult` TypedDict type definition (54 lines)
-  - `utils.py` — Model name parsing, fit calculation, helpers (183 lines)
-  - `cache_db.py` — SQLite-backed cache for model metadata + hardware snapshots (158 lines)
-  - `logging_.py` — loguru setup with file rotation (33 lines)
-- Used by: All other layers
+```text
+main.py
+  -> app/viewer.py
+       -> tui_app.AIModelViewer
+```
 
-**5. Provider Layer:**
-- Purpose: Abstracted search backends for different model sources
-- Location: `providers/` (1162 total lines across 6 files)
-- Contains:
-  - `__init__.py` — `BaseProvider` ABC, provider registry with lazy imports (154 lines)
-  - `hf_provider.py` — HuggingFace Hub search + metadata enrichment (272 lines)
-  - `ollama_provider.py` — Ollama registry scraping + local API (325 lines)
-  - `lmstudio_provider.py` — LM Studio local API search (123 lines)
-  - `docker_provider.py` — Docker Model Runner search (139 lines)
-  - `mlx_provider.py` — Apple Silicon MLX local scan (149 lines)
+Responsibilities:
 
-**6. Search Layer:**
-- Purpose: Search orchestration, caching, query building
-- Location: `search/` (212 total lines across 2 files)
-- Contains:
-  - `search_orchestration.py` — Provider-aware pagination, query key building, status messages (123 lines)
-  - `search_cache.py` — In-memory cache with hardware-aware invalidation (89 lines)
+- Textual layout and event handling,
+- user search/filter/sort actions,
+- cache/stale-cache use,
+- result rendering,
+- hardware status presentation,
+- coordination with download manager and search orchestrator.
 
-**7. Results Layer:**
-- Purpose: Table layout, cell formatting, filtering/sorting
-- Location: `results/` (589 total lines across 4 files)
-- Contains:
-  - `results_layout.py` — Responsive column computation for DataTable (167 lines)
-  - `results_presenter.py` — Color-coded cell markup for all columns (241 lines)
-  - `results_text.py` — Text truncation, alignment, header formatting (62 lines)
-  - `results_view.py` — Filter and sort logic for model results (119 lines)
+Supporting modules under `app/`:
 
-**8. Downloads Layer:**
-- Purpose: Manage model downloads asynchronously
-- Location: `downloads/` (1376 total lines across 8 files)
-- This layer has TWO components:
-  - **In-process client code:** `download_history.py`, `download_lifecycle.py`, `download_manager.py`, `download_status.py`, `service_client.py`, `hf_downloader.py`
-  - **Background service:** `download_service.py` (796 lines) — Separate subprocess with its own HTTP server
+- `viewer.py` — runtime subclass/provider-selector integration,
+- `modals.py` — model detail, download, plan, and comparison modal screens,
+- `widgets.py` — focused Textual widgets,
+- `download_manager.py` — TUI-side download coordination,
+- `search_results_state.py` — search-result state/invariants,
+- `search_constants.py` — filter/sort/use-case UI constants.
 
-**9. Configuration:**
-- Purpose: Centralized settings with env var overrides
-- Location: `config.py` (62 lines)
-- Contains: `Settings` dataclass via `pydantic_settings.BaseSettings`
+`tui_app.py` remains the largest presentation module and is still a performance/refactor sensitivity area, but it is no longer responsible for every concern in the application.
 
-## Data Flow
+### 2. Search Layer
 
-**Primary Flow — Search:**
+Key modules:
 
-1. User types query in Input widget -> `on_input_submitted` (`app.py:1582`)
-2. `start_search()` debounces (120ms), builds cache key -> `_dispatch_debounced_search()` (`app.py:1613`)
-3. Checks `SearchCache` (in-memory, hardware-aware) — if hit, returns cached results
-4. Cache miss -> `run_search_worker()` in background thread (`app.py:2204`)
-5. Worker queries configured providers (Ollama, HF, LM Studio, Docker, MLX)
-6. Each result is scored via `enrich_result_with_scores()` from `core/scoring.py`
-7. Results combined -> cached -> `on_search_completed()` -> `refresh_table()`
-8. `filter_results_for_view()` applies provider/use-case/hidden-gem/fit/sort filters (`app.py:2378`)
+- `search/search_orchestrator.py` — parallel provider fan-out/fan-in, cancellation polling, deterministic grouping, structured diagnostics,
+- `search/search_orchestration.py` — provider selection, pagination/capability rules, query/status helpers,
+- `search/search_cache.py` — in-memory hardware-aware search cache with stale-entry access for TUI offline fallback.
 
-**Secondary Flow — Model Download:**
+`SearchOrchestrator` uses a bounded `ThreadPoolExecutor` and keeps provider result grouping deterministic:
 
-1. User clicks "Download" in `ModelDetailModal` -> `start_model_download()` (`app.py:1890`)
-2. `service_client.create_job()` sends HTTP POST to download service on port 8765
-3. Download service receives job -> `DownloadStore.upsert_job()` writes to SQLite queue
-4. Worker loop picks up queued job -> spawns `subprocess.Popen` (ollama pull or HF snapshot_download)
-5. `_run_stream_download_job()` / `_run_hf_api_download_job()` monitor progress via stdout parsing
-6. Status polling: `app.py` polls `GET /jobs` every 1.5s via `_run_download_poll_worker()` (thread)
-7. Results table updates download state column in real-time
+1. Ollama,
+2. Hugging Face,
+3. extra providers.
 
-**Tertiary Flow — Hardware Monitoring:**
+Cancellation is polled while futures are pending so the caller can return without waiting for still-running provider workers.
 
-1. `on_mount()` starts polling timers (`app.py:1220`):
-   - `system_metrics_timer`: every 3s -> `request_system_info_refresh()`
-   - `download_status_timer`: every 1.5s -> `request_download_poll()`
-2. `_run_system_info_refresh_worker()` (thread) -> `monitor.get_specs()` + `check_ollama_running()`
-3. Results update `SystemInfoWidget` header and cached `latest_specs`
-4. Hardware changes automatically invalidate search cache
+### 3. Provider Layer
 
-**State Management:**
-- UI state: Stored as instance attributes on `AIModelViewer` (no reactive state management beyond Textual's built-in)
-- Search results: `self.all_results` — a flat list of `ModelResult` dicts
-- Comparison set: `self.comparison_set` — list of up to 4 model dicts
-- Download registry: `self.download_registry` — dict keyed by `target_id`
-- Configuration: Singleton `config.settings` object (Pydantic Settings)
-- Persistent state: SQLite databases (cache + download queue)
+Providers:
 
-## Key Abstractions
+- Ollama,
+- Hugging Face,
+- LM Studio,
+- Docker Model Runner,
+- MLX.
 
-**BaseProvider (`providers/__init__.py:16`):**
-- Purpose: Pluggable search backend interface
-- Methods: `detect()`, `search()`, `list_installed()`, `search_with_installed()`
-- Implementations: Ollama, HuggingFace, LM Studio, Docker, MLX (only Ollama + HF are used in primary search path)
+Provider capabilities are defined centrally in `providers/capabilities.py`. Capability metadata is used to decide searchability, pagination, installed-list support, downloadability, and provider-selection behavior.
 
-**Scores dataclass (`core/scoring.py:136`):**
-- Purpose: Immutable container for 4-dimension + composite scores
-- Fields: `quality`, `speed`, `fit`, `context`, `composite`, `estimated_tok_s`
-- Computed by `score_model()` with use-case-weighted aggregation
+The provider contract uses `SearchResult` (`providers/base.py`) with:
 
-**ModelResult TypedDict (`core/models.py:4`):**
-- Purpose: Canonical shape for all model result dicts across providers
-- All fields optional (`total=False`) — providers populate different subsets
+- `results`,
+- legacy human-readable `errors`,
+- `has_more_pages`,
+- machine-readable `structured_errors` (`ProviderError`).
 
-**HardwareMonitor (`core/hardware.py:100`):**
-- Purpose: Detect and snapshot local hardware
-- Detects: NVIDIA (pynvml/nvidia_smi), AMD (rocm-smi), Apple Silicon (system_profiler), Intel Arc (lspci)
-- Output: CPU name/cores, RAM total/free, VRAM total/free, GPU name, vendor, backend
-- Graceful fallback at every level
+Transient/search/parse/I/O failures should normally be contained inside provider results instead of escaping as uncaught exceptions.
 
-**DownloadService / DownloadStore (`downloads/download_service.py`):**
-- Purpose: Background HTTP service for asynchronous model downloads
-- Threading: Worker thread + locking for SQLite access + process tracking
+### 4. Error and Diagnostic Flow
 
-## Entry Points
+`core/errors.py` defines `ProviderError` metadata such as:
 
-| Entry Point | File | How Invoked | Purpose |
-|-------------|------|-------------|---------|
-| `main()` | `main.py:23` | `ai-model-explorer` console script | Starts Textual TUI |
-| `cli()` | `cli.py:14` | `ai-model-explorer-cli` console script | CLI commands |
-| `api_server.main()` | `api_server.py:326` | `python -m api_server` | REST API server (port 8787) |
-| `download_service.main()` | `downloads/download_service.py:742` | Auto-launched by `ensure_service_running()` | Background download worker (port 8765) |
+- provider slug,
+- stable code,
+- message,
+- retryability,
+- optional HTTP status,
+- optional retry-after duration.
 
-## Error Handling
+Diagnostic flow:
 
-**Strategy:** Defensive logging with broad exception catches. Most error recovery is silent (log or status bar message). Providers return diagnostics as a `list[str]` carried inside a `SearchResult` (see `providers/base.py`); downstream code never sees a typed exception.
+```text
+provider
+  -> SearchResult.errors + SearchResult.structured_errors
+  -> SearchOrchestrator SearchOutcome
+  -> TUI status/error handling
+```
 
-**Patterns:**
-- Broad `except Exception: pass` — used extensively across the codebase (e.g., `app.py:967`, `app.py:1237`, `app.py:1318`, etc.)
-- HTTP error recovery: `service_client.py` retries once with `ensure_service_running()` on 404
-- Graceful degradation: Hardware detection fails -> returns empty specs; Search fails -> shows error in results table
-- Status bar updates via `self.update_status()` are the primary user-facing error channel
-- Error messages are plain strings. The earlier `core/errors.py` typed hierarchy (added in commit 923f3d6, 2026-06-09) was removed: only one of five providers used it, and the receiving TUI flattened the types to strings anyway, so the type information did not survive the seam.
+Other surfaces preserve diagnostics independently:
 
-## Cross-Cutting Concerns
+- REST `/api/v1/models` returns additive `errors` and `structured_errors` arrays while preserving HTTP-200 partial-result semantics.
+- CLI `search`, `fit`, and `recommend` emit provider warnings on stderr. `recommend --json` keeps stdout as the existing JSON array contract.
 
-**Logging:** loguru configured in `core/logging_.py` — stderr (INFO) + file rotation (DEBUG). Used sparsely across provider and service code.
+The remaining goal is not to remove all broad catches, but to ensure user-impacting failures are observable and correctly classified.
 
-**Validation:** Minimal — Pydantic validates config only. Search queries are raw strings. No schema validation for API endpoints.
+### 5. HTTP Client Layer
 
-**Threading:**
-- Textual's `@work(thread=True)` decorator for non-blocking operations
-- Manual `call_from_thread()` for cross-thread UI updates
-- `threading.Lock` for SQLite in `cache_db.py` and `DownloadStore`
-- `threading.Event` for graceful shutdown in download service
+`core/http_client.py` owns the shared `requests.Session` used by requests-based providers. It provides:
 
----
+- connection reuse,
+- retry/backoff for retryable GET failures,
+- handling for 429 and common 5xx responses.
 
-*Architecture analysis: 2026-06-09*
+Hugging Face also uses `huggingface_hub` APIs for search/download-specific operations.
+
+### 6. Core Domain
+
+`core/` contains UI-independent domain services:
+
+- hardware detection and snapshots,
+- scoring and GPU-bandwidth lookup,
+- MoE/model-size/quantization intelligence,
+- metadata/hardware SQLite cache,
+- shared utilities,
+- logging,
+- typed provider errors.
+
+`core/cache_db.py` uses a shared SQLite connection guarded by an `RLock`, reopens when the configured path changes, and retries after SQLite connection errors.
+
+### 7. Results Layer
+
+`results/` contains mostly pure presentation helpers:
+
+- responsive column layout,
+- cell markup,
+- text alignment/truncation,
+- filtering/sorting/view selection.
+
+The main TUI still performs full DataTable rebuilds in important refresh paths. Incremental updates are a planned performance improvement, not a correctness requirement.
+
+### 8. Download Layer
+
+The download system has two sides:
+
+**TUI/client side**
+
+- `app/download_manager.py`,
+- `downloads/service_client.py`,
+- lifecycle/history/status helpers.
+
+**Background service side**
+
+- `downloads/download_service.py`,
+- `downloads/api.py`,
+- `downloads/store.py`,
+- `downloads/runner.py`.
+
+The service runs on loopback (default `127.0.0.1:8765`) and persists jobs in SQLite. Work is dispatched through a bounded `ThreadPoolExecutor`; default concurrency is 2 and is configurable with `AIMODEL_DOWNLOAD_MAX_WORKERS`.
+
+The service supports an optional bearer token for non-health endpoints. Non-loopback bind/client hosts are rejected until authenticated TLS transport is implemented.
+
+### 9. REST API
+
+`api_server.py` exposes localhost programmatic access on `127.0.0.1:8787` by default.
+
+Current model-search providers exposed through `/api/v1/models` are Ollama and Hugging Face. The provider descriptor endpoint exposes the canonical provider registry and identifies which providers are supported by the REST model endpoint.
+
+Request validation returns 400 for invalid provider/limit/context/sort inputs rather than relying on outer 500 handling.
+
+### 10. CLI
+
+`cli.py` provides:
+
+- hardware/system info,
+- model search,
+- hardware-fit listing,
+- recommendations,
+- hardware planning,
+- scoring,
+- cache helpers.
+
+Provider errors are surfaced on stderr. JSON recommendation output remains stdout-only JSON for scripting compatibility.
+
+## Primary Search Flow
+
+```text
+query/filter action
+  -> build provider selection + query key
+  -> SearchCache lookup
+       -> fresh hit: use cached result
+       -> stale hit may be used as TUI offline fallback
+  -> background SearchOrchestrator
+       -> providers run in parallel
+       -> SearchResult diagnostics collected
+       -> cancellation observed between future completions
+  -> SearchOutcome
+  -> cache/update state
+  -> filter/sort/render DataTable
+```
+
+Only the selected single paginated provider may authorize a next page. Multi-provider search does not synthesize continuation from result counts.
+
+## Primary Download Flow
+
+```text
+TUI action
+  -> service_client HTTP request
+  -> download-service API
+  -> DownloadStore SQLite state
+  -> bounded worker pool
+  -> runner (Ollama pull or HF download path)
+  -> persisted state/progress
+  -> TUI polling snapshot
+  -> row/history update
+```
+
+## State and Storage
+
+- Search result state: `SearchResultsState` + in-memory `SearchCache`.
+- Persistent model/hardware metadata: SQLite cache DB.
+- Download job state/history: download-service SQLite DB.
+- Default DB/model directories: OS-specific user-data paths via configuration/platformdirs.
+- Runtime configuration: singleton Pydantic Settings object (`config.settings`).
+
+## Cross-Cutting Rules
+
+- Public behavior is shared conceptually, but TUI/CLI/REST are not forced through one abstraction when that would break surface-specific contracts.
+- Provider capabilities are authoritative; UI heuristics should not invent capabilities.
+- Diagnostic metadata is additive and must not require string parsing for machine-readable callers.
+- Correctness fixes should preserve partial-success behavior when one provider fails and another succeeds.
+- Documentation must be re-reviewed after architecture-affecting merges; see `docs/maintenance.md`.

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,219 +1,190 @@
 # Codebase Concerns
 
-**Analysis Date:** 2026-06-09
+**Baseline date:** 2026-09-07  
+**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`
 
-## Tech Debt
+This file lists **current, verified concerns**. It intentionally removes old mapper findings that have already been addressed, including the root `app.py` monolith claim, missing connection pooling, sequential provider search, single-worker downloads, missing search cancellation, missing REST validation, and missing structured errors.
 
-### 1. `app.py` Monolith — Extreme Size (2466 LOC)
-- **Issue:** The main TUI application in `app.py` is a massive single-file monolith containing the `AIModelViewer` App class plus 4 modal screen classes. It simultaneously manages: UI layout, keyboard bindings, search orchestration, download lifecycle, hardware polling, pagination, comparison logic, theme management, and status updates.
-- **Files:** `app.py` (lines 1-2466)
-- **Impact:**
-  - Single-responsibility violations — `AIModelViewer` has ~50+ instance attributes and ~60+ methods
-  - Extremely difficult to test — only 3 test files target TUI behavior
-  - High cognitive load for any modification
-  - Long methods like `run_search_worker` (~120 lines), `refresh_table` (~100 lines), `_apply_ui_mode` (~68 lines)
-  - All four modals (`ModelDetailModal`, `DownloadJobModal`, `PlanModeModal`, `ComparisonModal`) are mixed into the same file
-- **Fix approach:** Extract modal screens to `app/modals.py`, extract search orchestration from `AIModelViewer` to a `SearchCoordinator` delegate, extract download management to a `DownloadManager` delegate
+## Priority 1
 
-### 2. Broad `except Exception: pass` Pattern
-- **Issue:** The codebase uses silent exception swallowing as its primary error handling strategy. Errors in hardware polling, cache access, UI refresh, and search are silently dropped.
-- **Files:** `app.py` (lines ~967, 1101, 1237, 1318, 1505, 1532, 1605, 2284, 2285), `core/cache_db.py` (pass on ~72, 86, 124, 144, 158), `downloads/download_service.py` (pass on ~573-574), and many more
-- **Impact:** Silent failures hide real issues. A broken GPU detection, failed search, or stale cache produces no visible error — the UI just shows empty results or defaults.
-- **Fix approach:** Replace with structured logging via loguru, add warning-level log statements, use specific exception types where possible
+### 1. Ollama remote registry depends on HTML structure
 
-### 3. Duplicated Model-Size Estimation Logic
-- **Issue:** Two separate functions estimate model size from name tokens: `estimate_model_size_gb()` in `core/utils.py:81` (11 branches, plain if/elif chain) and `estimate_model_size_gb_v2()` in `core/model_intelligence.py:213` (table-driven approach with `_PARAM_SIZE_MAP`). Both are used in different code paths.
-- **Files:** `core/utils.py:81-110`, `core/model_intelligence.py:167-255`
-- **Impact:** Inconsistent results. `utils.estimate_model_size_gb` uses a flat if/elif chain with hardcoded values; `model_intelligence.estimate_model_size_gb_v2` uses a dict table with MoE awareness. When a model name doesn't match, they return different results.
-- **Fix approach:** Deprecate `utils.estimate_model_size_gb`, make `model_intelligence.estimate_model_size_gb_v2` the single source of truth, update all callers
+**Area:** `providers/ollama_provider.py`
 
-### 4. HTML Screen-Scraping for Ollama Registry
-- **Issue:** The Ollama provider scrapes `ollama.com/search` and `ollama.com/library/{name}` using BeautifulSoup with fragile HTML structure assumptions.
-- **Files:** `providers/ollama_provider.py:70-127` (`_extract_models_table_rows`), `providers/ollama_provider.py:239-260` (search page anchor parsing)
-- **Impact:** Brittle — any HTML structure change on ollama.com breaks search. No pagination support despite Ollama using htmx infinite scroll (currently ignored).
-- **Fix approach:** Request an official Ollama search API, or use a more robust scraping strategy with structured data extraction
+Remote Ollama discovery still fetches `ollama.com/search`/library HTML and parses it with BeautifulSoup.
 
-### 5. Import-Within-Function Pattern Throughout `app.py`
-- **Issue:** `app.py` uses late/conditional imports scattered within method bodies (e.g., `from providers import get_provider_filter_labels` inside `action_cycle_provider`, `from core.model_intelligence import plan_hardware_for_model` inside `action_open_plan_mode`).
-- **Files:** `app.py` (lines 1267, 1314, 1293, 2266)
-- **Impact:** Unnecessary overhead on each action invocation, obscured dependency graph, can mask circular import issues
-- **Fix approach:** Move all imports to module top level; resolve any circular dependency issues
+**Risk:**
 
-### 6. No Retry/Rate-Limiting Logic on Provider HTTP Calls
-- **Issue:** Provider search calls have no retry or exponential backoff. An HTTP 429 (rate limit) or transient failure immediately surfaces as an error to the user.
-- **Files:** `providers/hf_provider.py:118-130`, `providers/ollama_provider.py:216-235`
-- **Impact:** Rate-limited requests fail immediately even though the user could wait and retry. No caching of failed responses.
-- **Fix approach:** Add `tenacity` or custom retry decorator with exponential backoff for provider HTTP calls
+- third-party page structure can change without a versioned API contract,
+- valid “no results” and parser-structure breakage can be difficult to distinguish,
+- metadata/pagination behavior is constrained by page representation.
 
-### 7. No Formal Error Types — Errors as Strings
-- **Issue:** Errors are passed around as plain strings in `(results, errors)` tuples. There is no error hierarchy, no structured error metadata, and no machine-readable error codes.
-- **Files:** All provider `search()` methods, `app.py` error handling paths
-- **Impact:** Callers cannot differentiate error types (rate limit vs. network vs. auth vs. parse error) without string parsing
-- **Fix approach:** Define a lightweight error class hierarchy (`RateLimitError`, `NetworkError`, `ParseError`, etc.) with codes and user-friendly messages
+**Current mitigation:**
 
-## Known Bugs
+- retry/backoff and provider diagnostics exist,
+- parsing has helper coverage.
 
-### 1. Smoke Mode Race Condition
-- **Issue:** `_finish_smoke_mode()` in `app.py:1165` calls `self.exit()` which may be invoked before the app is fully mounted. The `set_timer(1, _finish_smoke_mode)` backup fires simultaneously with `call_after_refresh(self._finish_smoke_mode)`.
-- **Files:** `app.py:1190-1193`
-- **Trigger:** Running with `AIMODEL_SMOKE=1`
-- **Workaround:** Not user-facing (dev-only smoke test mode)
+**Next work:**
 
-### 2. ComparisonModal Duplicate Key Handling
-- **Issue:** `ComparisonModal.compose()` iterates rows with accessor lambdas. If two models in the comparison set share the same `name` prefix, the `Strip_markup` call can produce zero-length text that breaks the pipeline rendering.
-- **Files:** `app.py:627-655`
-- **Trigger:** Selecting two models with identical names but different sources
+1. fixture-backed parser contracts for supported shapes,
+2. structural-failure detection/diagnostics,
+3. research a supported structured registry/search source before considering migration.
 
-### 3. Download History Table Sort Key Edge Case
-- **Issue:** `refresh_download_history_table()` sorts by `created_at` then `target_id`. If `created_at` is missing from an entry, `str(entry.get("created_at", 0))` produces `"0"` for the sort, which may interleave incorrectly with entries that have real timestamps.
-- **Files:** `app.py:1990-1997`
-- **Trigger:** Download entries where `created_at` field was not set during upsert
+### 2. Coverage policy is configured but not enforced by the normal verify lane
 
-## Security Considerations
+**Area:** `pyproject.toml`, `scripts/dev.py`, CI
 
-### 1. HuggingFace Token Leaked to Subprocess Environment
-- **Issue:** The download service passes the HuggingFace token to subprocesses via environment variables: `env["HF_TOKEN"]` and `env["AIMODEL_HF_TOKEN"]` (in `downloads/download_service.py:348-349`). Any child process inherits these.
-- **Files:** `downloads/download_service.py:344-349`
-- **Risk:** If a subprocess is compromised or leaks, the HF token is exposed
-- **Current mitigation:** Subprocess runs locally only
-- **Recommendations:** Use stdin pipe instead of env vars for token passing; or scope token permissions to read-only
+`fail_under = 45` exists, but `scripts/dev.py verify` currently runs pytest/import smoke/Ruff without a coverage-enforced pytest invocation.
 
-### 2. No Input Validation on API Server
-- **Issue:** `api_server.py` takes raw query parameters (`search`, `provider`, `limit`, etc.) without validation. Integer casts (`int(params.get("limit", ["20"])[0])`) can raise `ValueError` on malformed input.
-- **Files:** `api_server.py:118-124`
-- **Risk:** Malformed requests cause 500 errors instead of graceful 400 responses
-- **Recommendations:** Add parameter validation with try/except, return structured 400 errors
+**Risk:**
 
-### 3. Subprocess Shell Execution
-- **Issue:** `terminal_ui/app.py:106-124` (`run_shell_command`) uses `shell=True` with user-provided input (command text from the Input widget). While `run_shell_command` receives already-typed commands, the `subprocess.run(cmd, shell=True)` pattern is dangerous for any untrusted input.
-- **Files:** `terminal_ui/app.py:109-110`
-- **Risk:** If this code path is ever exposed to external input, shell injection is trivial
-- **Current mitigation:** Only runs in the legacy `ObsidianConsole` which isn't the primary entry point
-- **Recommendations:** Replace `shell=True` with argument list in the legacy widget, or document as deprecated
+- the configured threshold can be mistaken for a real CI gate,
+- large changes can reduce coverage without the merge gate noticing,
+- the existing 600+ tests are broad but do not guarantee high-risk application boundaries are sufficiently covered.
 
-## Performance Bottlenecks
+**Next work:**
 
-### 1. Synchronous HTTP Calls in Provider Search
-- **Issue:** Search across multiple providers (Ollama + HF + LM Studio + Docker + MLX) runs sequentially, not in parallel. Each provider's HTTP call blocks the search worker thread.
-- **Files:** `app.py:2204-2291` (`run_search_worker`)
-- **Cause:** Sequential provider search. Ollama finishes first, then HF starts.
-- **Improvement path:** Use `concurrent.futures.ThreadPoolExecutor` to run provider searches in parallel with a timeout
+- measure a reproducible baseline,
+- add focused high-risk tests,
+- enforce staged CI thresholds 50 → 55 → 60.
 
-### 2. GPU Bandwidth Linear Search
-- **Issue:** `find_gpu_bandwidth()` in `core/scoring.py:153` does a linear scan over ~95 GPU entries twice (first for substring match, then for parts match). Called once per model result during search.
-- **Files:** `core/scoring.py:153-176`
-- **Cause:** Simple dict iteration on every call
-- **Improvement path:** Build a trie or normalized lookup table at module load time, or reduce to single pass with combined matching
+### 3. TUI result refresh still performs full table rebuilds in important paths
 
-### 3. SQLite Cache Writes on Every Search
-- **Issue:** `cache_db.set_model_cache()` and `set_hardware_snapshot()` each open a new SQLite connection (`_connect()` called inside get/set), write, then close. This is called 15+ times per search result.
-- **Files:** `core/cache_db.py:75-86`, `core/cache_db.py:147-158`
-- **Cause:** Connection-per-operation pattern instead of connection pooling
-- **Improvement path:** Use a module-level connection pool or long-lived connection with reconnection logic
+**Area:** `tui_app.py`, `results/`
 
-### 4. UI Refresh Causes Full Table Rebuild
-- **Issue:** `refresh_table()` in `app.py:2366` clears and rebuilds the entire DataTable from scratch on every filter/sort change, hardware poll, or download status update.
-- **Files:** `app.py:2366-2466`
-- **Cause:** No incremental row update — full DOM rebuild
-- **Improvement path:** Use Textual's `DataTable.update_cell()` for incremental updates where possible
+Result refresh still uses `DataTable.clear()` in normal/structural refresh paths.
 
-## Fragile Areas
+**Risk:**
 
-### 1. `app.py` — The Monolith (2466 lines)
-- **Files:** `app.py`
-- **Why fragile:** Huge single file with implicit dependencies between methods. A change to `refresh_table()` can break `_ensure_download_fields()` which can break `sync_download_jobs_from_service()`.
-- **Safe modification:** Isolate changes to individual modal screens first; add tests for any behavior change; extract search/download logic before modifying
-- **Test coverage:** 3 test files (~246 lines) for a 2466-line file — ~10% coverage
+- unnecessary work for larger result sets,
+- cursor/scroll/update churn,
+- download/progress state changes may trigger more rendering than necessary.
 
-### 2. Hardware Detection Chain
-- **Files:** `core/hardware.py:100-350`
-- **Why fragile:** Depends on platform-specific subprocesses (`rocm-smi`, `system_profiler`, `lspci`, `nvidia_smi`) and optional imports (`nvidia_smi`, `pynvml`). Any one of these can fail silently, leaving other detection paths to compensate.
-- **Safe modification:** Add logging to each detection path; verify on target platforms; maintain the graceful fallback pattern
-- **Test coverage:** `test_hardware_expanded.py` (79 lines) — tests vendor detection functions, not actual hardware interaction
+**Current mitigation:**
 
-### 3. Download Service Version Compatibility
-- **Files:** `downloads/download_service.py:25` (`SERVICE_VERSION = "1.7"`), `downloads/service_client.py:16` (`MIN_SERVICE_VERSION = "1.7"`)
-- **Why fragile:** Version mismatch between UI process and background service can silently break downloads. The service client polls `/health` and checks version compatibility, but if the service is outdated, it gets restarted (which kills in-flight downloads).
-- **Safe modification:** Add version negotiation on startup; warn user if restart kills active downloads
-- **Test coverage:** `test_service_client.py` (13 lines)
+- resize/search progress is already debounced/throttled,
+- cursor/scroll behavior has dedicated handling,
+- pure layout/presentation logic is extracted and tested.
 
-### 4. Ollama HTML Scraping
-- **Files:** `providers/ollama_provider.py:70-127, 239-260`
-- **Why fragile:** Relies on specific HTML table structure, anchor href patterns, and CSS class names on ollama.com
-- **Safe modification:** Add integration test with cached HTML samples; monitor for structural changes
-- **Test coverage:** `test_ollama_provider_helpers.py` (59 lines)
+**Next work:**
 
-## Scaling Limits
+- measure representative refresh cost,
+- use stable row keys and incremental cell/row updates where ordering/layout does not change,
+- keep full rebuilds where they are simpler/correct for structural changes.
 
-### 1. In-Memory Search Result Storage
-- **Current capacity:** Stores all `all_results` in a single Python list (dict objects for every model)
-- **Limit:** With 1000+ models (5 pages of HF results + Ollama results), memory could reach 50-100MB for the results list alone
-- **Scaling path:** Implement lazy loading — only hold visible page in memory, fetch on demand
+## Priority 2
 
-### 2. Download Service Single Worker
-- **Current capacity:** One worker thread processes one download at a time (FIFO queue)
-- **Limit:** Multiple queued downloads block behind the current one. No concurrency limit for parallel downloads
-- **Scaling path:** Add configurable `max_workers` parameter, use `ThreadPoolExecutor` for parallel downloads
+### 4. Residual broad exception/suppression boundaries remain
 
-### 3. SQLite Concurrency
-- **Current capacity:** SQLite connection per operation with thread lock
-- **Limit:** Under heavy polling (1.5s interval), download status + hardware metrics + cache DB access could create contention
-- **Scaling path:** Use connection pooling with timeout retry
+Broad catches are no longer the system-wide default, but some best-effort paths still use them, for example:
 
-## Dependencies at Risk
+- provider registry import/detection suppression,
+- provider-selector widget synchronization fallback,
+- some polling/UI update boundaries,
+- platform hardware probes.
 
-### 1. Textual 0.x (>=0.86,<1.0)
-- **Risk:** Textual is pre-1.0 software. API breaking changes between minor versions are common. The version pin `>=0.86,<1.0` is already specific, suggesting known compatibility concerns.
-- **Impact:** Cannot freely upgrade Textual. New feature adoption requires careful testing.
-- **Migration plan:** Pin to working version, monitor Textual changelog before upgrades, run smoke tests after upgrades
+**Risk:** a broad catch can become a silent false-success path if its context changes.
 
-### 2. Ollama.com HTML Scraping
-- **Risk:** Not an API dependency per se, but the codebase critically depends on Ollama.com's HTML structure remaining stable. No API alternative exists.
-- **Impact:** Complete loss of Ollama search if the website redesigns
-- **Migration plan:** Add comprehensive error handling, cached HTML test fixtures, and monitoring for search failure rates
+**Required audit rule:** classify each boundary as:
 
-## Missing Critical Features
+- expected fail-closed + logged,
+- user-visible diagnostic required,
+- narrower exception types required,
+- intentional best-effort behavior with a comment/test.
 
-### 1. No HTTP Connection Pooling
-- **Problem:** Every provider API call opens a new HTTP connection. HuggingFace's `HfApi` manages its own session, but Ollama, LM Studio, Docker, and MLX providers create new `requests.get()` calls each time.
-- **Files:** All provider `search()` methods
-- **Blocks:** Efficient multi-query workflows, reduced latency on repeated calls
+Do not mechanically replace broad catches that protect platform/UI teardown behavior; audit observable semantics instead.
 
-### 2. No Search Cancellation
-- **Problem:** Running a new search while one is in-flight queues behind the current one. The `_search_inflight_signature` check only prevents duplicate searches, not cancellation.
-- **Files:** `app.py:1596-1600`
-- **Blocks:** Responsive UI during slow searches
+### 5. Platform acceptance is broader than hosted CI evidence
 
-### 3. No Offline/Disconnected Mode
-- **Problem:** The entire application requires network connectivity. No read-from-cache mode exists for offline operation.
-- **Files:** Entire provider layer
-- **Blocks:** Usage in air-gapped environments or during network outages
+Project metadata supports Python 3.10-3.14 and integrations span Windows/Linux/macOS/Apple Silicon, but hosted CI currently verifies only:
 
-## Test Coverage Gaps
+- Ubuntu + Windows,
+- Python 3.12 + 3.14,
+- offline-safe verify/smoke behavior.
 
-### 1. TUI/Monolith (`app.py`)
-- **What's not tested:** 95% of `AIModelViewer` behavior — keyboard actions, search flow, download lifecycle, modal screens, pagination, theme cycling, comparison, compact mode transitions
-- **Files:** `app.py` (2466 lines)
-- **Risk:** Any change to `app.py` can break core functionality without detection
-- **Priority:** High
+Hosted CI does not prove:
 
-### 2. Ollama Provider HTML Scraping
-- **What's not tested:** The actual HTML parsing logic — only helper functions have tests (`test_ollama_provider_helpers.py`). `search_ollama_models()` and `get_ollama_model_metadata()` have no tests with real or mocked HTML.
-- **Files:** `providers/ollama_provider.py:70-127, 195-325`
-- **Risk:** Ollama.com HTML changes silently break search
-- **Priority:** Medium
+- WSL-specific behavior,
+- real NVIDIA/AMD/Intel GPU tooling,
+- actual Ollama/LM Studio/Docker Model Runner services,
+- macOS Apple Silicon/MLX filesystem behavior.
 
-### 3. Download Service
-- **What's not tested:** `download_service.py` worker loop, cancellation flow, HF API download, subprocess management, version compatibility
-- **Files:** `downloads/download_service.py:569-610` (worker loop), `385-483` (HF download), `486-566` (stream download)
-- **Risk:** Background download failures go undetected until user reports issues
-- **Priority:** Medium
+**Next work:** explicit automated/manual platform acceptance matrix.
 
-### 4. Error Handling Paths
-- **What's not tested:** All the `except Exception: pass` code paths — what happens when hardware detection fails, when HF API is down, when cache DB is corrupted
-- **Files:** All error-handling blocks across the codebase
-- **Priority:** Medium
+### 6. Main TUI base module remains large
 
----
+The old “single root `app.py` monolith” concern is obsolete: provider selector, modals, widgets, download manager, search state, search orchestration, result helpers, and download internals have been extracted.
 
-*Concerns audit: 2026-06-09*
+However, `tui_app.py` still owns the base Textual layout/event lifecycle and remains a high-coupling presentation module.
+
+**Risk:** broad UI changes can still have regression surface across search, table rendering, polling and downloads.
+
+**Guidance:**
+
+- prefer pure helpers/delegates for new deterministic logic,
+- avoid extraction solely to reduce line count,
+- require focused Textual tests for behavior-changing edits.
+
+## Priority 3
+
+### 7. Local-provider helper parity has minor remaining edge cases
+
+Known lower-priority examples:
+
+- MLX `list_installed()` does not yet have the same explicit filesystem-I/O containment contract as MLX search,
+- LM Studio metadata helper parsing is less hardened than the production search/list paths, but currently lacks a significant production caller,
+- some zero/negative limit edge cases are unreachable through normal validated user surfaces.
+
+These should be handled when a concrete caller/bug justifies them rather than bundled into speculative refactors.
+
+### 8. Textual 0.x dependency pin
+
+The project intentionally pins `textual>=0.86,<1.0`.
+
+**Risk:** upgrading Textual can affect widget/layout/event behavior and requires TUI smoke/regression evidence.
+
+**Guidance:** treat Textual upgrades as compatibility changes, not routine dependency bumps.
+
+## Security Boundaries
+
+### Download service
+
+Current boundary is intentionally local:
+
+- loopback-only host,
+- optional bearer token on non-health endpoints,
+- non-loopback hosts rejected until TLS exists.
+
+Do not weaken this restriction as a convenience change. Any LAN/remote mode requires an explicit transport/auth threat model.
+
+### REST API
+
+The REST API binds to loopback by default and is intended for local programmatic use. It does not provide a public-network authentication model.
+
+If remote binding ever becomes a product requirement, add auth/TLS/origin/rate-limit design before exposing it.
+
+### Hugging Face credentials
+
+Use least-privilege/read-only tokens. Credential propagation changes should be reviewed separately from unrelated provider correctness work.
+
+## Resolved Historical Concerns
+
+The following old concerns are retained here only to prevent accidental re-planning:
+
+- **Root `app.py` 2466-line monolith:** obsolete; runtime is `main.py` → `app/viewer.py` → `tui_app.py` with extracted modules.
+- **No HTTP pooling:** resolved by `core/http_client.py` shared session.
+- **No provider retry/backoff:** resolved for retryable provider HTTP paths.
+- **No formal provider errors:** resolved by `ProviderError` + `SearchResult.structured_errors`.
+- **Sequential provider search:** resolved by `SearchOrchestrator` parallel fan-out.
+- **No search cancellation:** resolved by orchestrator cancellation polling/UI search IDs.
+- **SQLite connection per operation:** resolved for metadata cache by shared locked connection.
+- **Download service single worker:** resolved by bounded configurable worker pool.
+- **Duplicate model-size estimator:** `core.utils` delegates to canonical MoE-aware estimator.
+- **GPU bandwidth repeated linear scan:** resolved by pre-built lookup maps.
+- **No REST input validation:** core model-search/plan inputs now validate to 400 responses.
+- **Provider failures hidden in REST/CLI:** resolved with REST diagnostics and CLI stderr warnings.
+- **Legacy `shell=True` finding:** no active source match; old planning reference removed from current concerns.
+
+## Maintenance Rule
+
+A concern should remain in this file only while it is materially true. When a merge resolves or substantially changes a concern, update/remove it in that PR when practical. See `docs/maintenance.md`.

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,122 +1,174 @@
 # External Integrations
 
-**Analysis Date:** 2026-06-09
+**Baseline date:** 2026-09-07  
+**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`
 
-## APIs & External Services
+## Provider Integrations
 
-**Model Search Providers (3rd-party APIs):**
-| Service | Usage | Client | Auth |
-|---------|-------|--------|------|
-| HuggingFace API | Search GGUF models, fetch metadata, download | `huggingface_hub.HfApi` (`providers/hf_provider.py:118`) | `AIMODEL_HF_TOKEN` env var (optional, for rate limits) |
-| Ollama Registry | Scrape model library pages for search results | `requests` + BeautifulSoup (`providers/ollama_provider.py:219-238`) | None (anonymous web scraping) |
-| Ollama Local API | List installed models (`GET /api/tags`) | `requests` (`providers/ollama_provider.py:37`) | None (localhost only) |
+| Provider | Remote/local source | Client | Authentication | Notes |
+|---|---|---|---|---|
+| Hugging Face | Hub API/search/download | `huggingface_hub` + requests paths | `AIMODEL_HF_TOKEN` (with `HF_TOKEN` fallback) | Hosted provider; retry/structured errors supported |
+| Ollama registry | `ollama.com` search/library HTML | shared `requests.Session` + BeautifulSoup | None | Main external-format fragility; HTML structure is not versioned API |
+| Ollama local runtime | `/api/tags` on configured Ollama base | shared `requests.Session` | None by default | Installed-model/runtime detection |
+| LM Studio | local `/v1/models` | shared `requests.Session` | None by default | Local provider, parse/error containment |
+| Docker Model Runner | local `/models` | shared `requests.Session` | None by default | Local provider, parse/error containment |
+| MLX | local platform/cache filesystem | stdlib/platform/filesystem | N/A | macOS Apple Silicon + cache scanning |
 
-**Local Runtime Detection:**
-| Service | Port | Detection Method |
-|---------|------|-----------------|
-| Ollama | 11434 (default) | psutil process scan + HTTP `/api/tags` |
-| LM Studio | 1234 (default) | HTTP `GET /v1/models` (`providers/lmstudio_provider.py:39`) |
-| Docker Model Runner | 12434 (default) | HTTP `GET /models` (`providers/docker_provider.py:39`) |
-| MLX | Local filesystem | `sysctl hw.optional.arm64` + cache dir scan (`providers/mlx_provider.py:47-54`) |
+## Shared Provider HTTP Behavior
+
+Requests-based providers use `core/http_client.py` rather than opening a new connection for every call.
+
+The shared session provides:
+
+- HTTP connection reuse,
+- bounded retry/backoff for retryable GET failures,
+- retry support for 429 and selected 5xx responses.
+
+Providers still own semantic parsing and stable error classification. A transport retry is not a substitute for provider-level parse/contract handling.
+
+## Search Integration Model
+
+The Textual search path uses `SearchOrchestrator` to fan out selected providers in parallel and fan results back in deterministic order.
+
+Provider diagnostics are preserved as:
+
+- human-readable `errors`,
+- machine-readable `ProviderError` values in `structured_errors`.
+
+The TUI may use stale `SearchCache` entries when a live search fails and a matching stale entry exists, providing a limited offline/disconnected fallback.
+
+## REST API
+
+Default address: `127.0.0.1:8787`.
+
+Endpoints include:
+
+- `GET /health`,
+- `GET /api/v1/system`,
+- `GET /api/v1/models`,
+- `GET /api/v1/models/top`,
+- `GET /api/v1/models/{name}/plan`,
+- `GET /api/v1/scores/{name}`,
+- `GET /api/v1/providers`.
+
+### REST model provider scope
+
+`/api/v1/models` currently supports:
+
+- Ollama,
+- Hugging Face.
+
+LM Studio, Docker Model Runner and MLX remain visible in canonical provider descriptors but are not automatically exposed as REST model-search providers.
+
+### Diagnostics
+
+Successful REST model responses include additive:
+
+- `errors`,
+- `structured_errors`.
+
+Provider failures can coexist with partial models in a 200 response. This lets callers distinguish “zero matching models” from “one provider failed” without breaking existing partial-success behavior.
+
+`structured_errors` preserves provider, stable code, message, retryability, optional HTTP status and optional retry-after metadata.
+
+## Download Service
+
+Default address: `127.0.0.1:8765`.
+
+The background service is intentionally separate from the TUI process so queued/running download state can survive UI restarts.
+
+Primary responsibilities:
+
+- persistent download job store,
+- create/list/cancel/delete lifecycle,
+- bounded worker dispatch,
+- Ollama and Hugging Face execution paths,
+- debug/health/version compatibility surfaces.
+
+### Concurrency
+
+`AIMODEL_DOWNLOAD_MAX_WORKERS` controls the bounded worker pool. Default: `2`.
+
+### Transport boundary
+
+The service is loopback-only. Non-loopback bind/client hosts are rejected until authenticated TLS transport is implemented.
+
+`AIMODEL_DOWNLOAD_SERVICE_TOKEN` optionally protects non-health endpoints with a bearer token. `/health` remains unauthenticated for local probes/version checks.
 
 ## Data Storage
 
-**SQLite Databases:**
-| Database | Location | Tables | Purpose |
-|----------|----------|--------|---------|
-| `cache.db` | `data/cache.db` | `model_cache`, `hardware_snapshot` | Caching HF/Ollama metadata, hardware snapshots |
-| `downloads.db` | `data/downloads.db` | `jobs` | Download job queue (created by download service) |
+Runtime data uses OS-specific user-data locations by default rather than repository-local `data/` paths.
 
-**Client:**
-- `sqlite3` (stdlib) — Direct SQL access in `core/cache_db.py` and `downloads/download_service.py`
+Important configurable destinations include:
 
-**File Storage:**
-- Local filesystem only — Downloaded models stored in `models/` directory (GGUF files)
-- MLX models discovered from `~/.cache/huggingface/hub/` and `~/.cache/lm-studio/models/`
+- metadata/cache SQLite DB,
+- download-service SQLite DB,
+- Hugging Face model output directory.
 
-**Caching:**
-- **Persistent:** SQLite-based (24h TTL for model metadata, 90s TTL for search results)
-- **In-memory:** `SearchCache` class in `search/search_cache.py` — 20 entries max, hardware-aware invalidation (checks RAM/VRAM drift)
+`platformdirs` is used to resolve portable default locations.
 
-## Authentication & Identity
+### Metadata cache
 
-**Auth Provider:**
-- None built-in. HuggingFace token is optional and used only for higher API rate limits
-- Passed via `AIMODEL_HF_TOKEN` -> `HF_TOKEN` env var for download processes
-- Download service runs on localhost only (no auth required)
+`core/cache_db.py` maintains a shared SQLite connection inside the application process, guarded by an `RLock` and reopened on path/connection failure.
 
-## Background Services
+### Download store
 
-**Download Service:**
-- Implementation: `downloads/download_service.py` (796 LOC)
-- Protocol: HTTP REST on `127.0.0.1:8765`
-- Endpoints:
-  - `GET /health` — Health check with version
-  - `GET /jobs` — List download jobs
-  - `GET /debug/active` — Active download diagnostics
-  - `POST /jobs` — Create/upsert download job
-  - `POST /jobs/cancel` — Cancel download
-  - `POST /jobs/delete` — Delete job record
-  - `POST /shutdown` — Graceful shutdown
-- Lifecycle: Auto-started by `service_client.ensure_service_running()` on UI mount (`app.py:1195`)
-- Architecture: Threaded worker loop polling a SQLite queue
+The download service owns a separate SQLite store and its own concurrency controls.
 
-**REST API Server:**
-- Implementation: `api_server.py` (339 LOC)
-- Protocol: HTTP on `127.0.0.1:8787`
-- Endpoints:
-  - `GET /health` — Health check
-  - `GET /api/v1/system` — Hardware specs
-  - `GET /api/v1/models` — Search models (query, provider, limit, sort params)
-  - `GET /api/v1/models/top` — Top models
-  - `GET /api/v1/models/{name}/plan` — Hardware plan
-  - `GET /api/v1/scores/{name}` — Model scores
-  - `GET /api/v1/providers` — Available providers
+## Authentication and Secrets
 
-## Monitoring & Observability
+### Hugging Face
 
-**Error Tracking:**
-- None (no Sentry, no external logging service)
+Canonical application setting:
 
-**Logs:**
-- **loguru** — Console output (INFO level) + file rotation at `data/logs/app_{time}.log` (DEBUG level, 10MB rotation, 7-day retention)
-- `core/logging_.py` — Logger setup, used sparsely across the codebase
+- `AIMODEL_HF_TOKEN`.
 
-## CI/CD & Deployment
+Standard `HF_TOKEN` is accepted as a compatibility fallback where documented.
 
-**Hosting:**
-- Not applicable (terminal application, runs locally)
+The token should be read-only and scoped to the minimum required Hugging Face access.
 
-**CI Pipeline:**
-- Not detected (no `.github/workflows/` contents related to CI)
+### Download service
 
-## Environment Configuration
+Optional local bearer token:
 
-**Required env vars:**
-- None strictly required (all have defaults)
+- `AIMODEL_DOWNLOAD_SERVICE_TOKEN`.
 
-**Critical optional env vars:**
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `AIMODEL_HF_TOKEN` | None | HuggingFace API token for higher rate limits |
-| `AIMODEL_HF_SEARCH_LIMIT` | `15` | Results per page |
-| `AIMODEL_HF_SEARCH_MAX_PAGES` | `10` | Max pagination pages |
-| `AIMODEL_OLLAMA_API_BASE` | `http://localhost:11434` | Ollama local API endpoint |
-| `AIMODEL_OLLAMA_TIMEOUT` | `5` | Ollama request timeout (seconds) |
-| `AIMODEL_SMOKE` | Not set | Enable smoke-test mode (`"1"` to enable) |
+The download service is not designed as a LAN/public HTTP API.
 
-**Secrets location:**
-- `.env` file at project root (not committed) — contains `AIMODEL_HF_TOKEN`
-- Token forwarded to subprocess via `HF_TOKEN` env var (`downloads/download_service.py:348`)
+## CI and Packaging Integrations
 
-## Webhooks & Callbacks
+GitHub Actions currently contains active CI rather than “no CI” as stated by the old mapper output.
 
-**Incoming:**
-- None
+`CI` workflow:
 
-**Outgoing:**
-- None
+- verify matrix,
+- smoke matrix,
+- Ubuntu + Windows,
+- Python 3.12 + 3.14.
 
----
+A separate `Package` workflow verifies packaging/install behavior and is part of the project's normal exact-head merge gate.
 
-*Integration audit: 2026-06-09*
+## Observability
+
+- Local logging: loguru.
+- Provider diagnostics: legacy strings + structured provider metadata.
+- Download service: health/debug/job state endpoints.
+- No external hosted error-tracking service is required by the project.
+
+## Current Integration Risks
+
+### 1. Ollama registry HTML dependency — high priority
+
+Remote Ollama discovery relies on third-party HTML. Fixture-backed parser contracts and structural-failure detection are active roadmap work.
+
+### 2. Local runtime availability — expected degradation
+
+LM Studio, Docker Model Runner, Ollama runtime and MLX may not exist on a machine. Detection/search paths should fail closed or report provider diagnostics without breaking other providers.
+
+### 3. Platform-specific hardware/runtime evidence — medium priority
+
+Hosted CI proves install/verify/smoke on Ubuntu and Windows, but does not fully represent WSL, real GPU drivers, local model runtimes, or macOS Apple Silicon. A documented platform acceptance matrix is active roadmap work.
+
+## Documentation Rule
+
+Changes to ports, auth, provider scopes, endpoints, env variables, storage locations or third-party sources require updates to this document and README configuration where user-facing. See `docs/maintenance.md`.

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,115 +1,134 @@
 # Technology Stack
 
-**Analysis Date:** 2026-06-09
-
-## Languages
-
-**Primary:**
-- Python >=3.10 — All application code, from TUI to download service to API server
-
-**Secondary:**
-- CSS (Textual TCSS) — `terminal_ui/theme.tcss` for styling the legacy Obsidian Console widget
+**Baseline date:** 2026-09-07  
+**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`
 
 ## Runtime
 
-**Environment:**
-- CPython 3.10+ (required by `pyproject.toml`)
+- **Language:** Python 3.10-3.14 supported by project metadata.
+- **CI verification:** Ubuntu + Windows on Python 3.12 and 3.14.
+- **Primary UI:** Textual.
+- **CLI:** Click + Rich.
+- **Configuration:** Pydantic Settings.
+- **Packaging:** setuptools via `pyproject.toml`.
 
-**Package Manager:**
-- pip (via `requirements.in` / `requirements.txt`)
-- pip-compile (via `requirements/*.in` -> `requirements/*.txt`)
-- Lockfile: `requirements.txt`, `requirements-dev.txt`, plus platform-specific variants in `requirements/`
-- Virtual envs detected: `.venv/`, `.venv314/`, `.venv.py313-broken/`
+## Core Runtime Dependencies
 
-## Frameworks
+| Package | Declared range | Purpose |
+|---|---|---|
+| `textual` | `>=0.86,<1.0` | Textual TUI |
+| `rich` | `>=13.9,<14.0` | CLI/table/markup rendering |
+| `click` | `>=8.0,<9.0` | CLI framework |
+| `pydantic-settings` | `>=2.0,<3.0` | Environment/config loading |
+| `requests` | `>=2.32,<3.0` | Requests-based provider HTTP traffic |
+| `huggingface_hub` | `>=0.27,<1.0` | Hugging Face search/download APIs |
+| `beautifulsoup4` | `>=4.12,<5.0` | Ollama registry HTML parsing |
+| `psutil` | `>=5.9,<7.0` | CPU/RAM/process inspection |
+| `nvidia-ml-py` | `>=12.560,<13.0` | NVIDIA GPU/VRAM detection |
+| `loguru` | `>=0.7,<1.0` | Local logging |
+| `pyperclip` | `>=1.8,<2.0` | Clipboard integration |
+| `platformdirs` | `>=4.0,<5.0` | OS-specific user-data paths |
 
-**Core:**
-- **Textual** `>=0.86,<1.0` — Terminal UI framework powering the main `AIModelViewer` app in `app.py` (2466 LOC)
-- **Rich** `>=13.9,<14.0` — Terminal formatting, used in `cli.py` for tables and markup
-- **Click** `>=8.0,<9.0` — CLI framework in `cli.py` (8 commands: info, system, search, fit, recommend, plan, scores, cache-clear, cache-stats, version)
-- **Pydantic Settings** `>=2.0,<3.0` — `config.py` `Settings` class with `.env` support via `AIMODEL_` prefix
+Exact development/runtime lock versions live in committed platform lock files under `requirements/` and may be narrower than the project dependency ranges above.
 
-**Web/HTTP:**
-- **requests** `>=2.32,<3.0` — HTTP client for HuggingFace API, Ollama registry scraping, LM Studio/Docker APIs
-- **urllib** (stdlib) — HTTP client for download service (`service_client.py`) and API server
-- **http.server** (stdlib) — HTTP server for download service (`downloads/download_service.py`) and REST API (`api_server.py`)
+## HTTP and Service Stack
 
-**Scraping:**
-- **BeautifulSoup4** `>=4.12,<5.0` — HTML parsing for `ollama.com` library page scraping
+### Provider HTTP
 
-**Data & ML Integration:**
-- **huggingface_hub** `>=0.27,<1.0` — HuggingFace API for model search and download
-- **nvidia-ml-py** `>=12.560,<13.0` — NVIDIA GPU detection (VRAM, GPU name)
+`core/http_client.py` owns a shared `requests.Session` for requests-based providers. It supplies connection reuse plus retry/backoff for retryable GET failures such as 429 and common 5xx responses.
 
-**System/Hardware:**
-- **psutil** `>=5.9,<7.0` — CPU, RAM, process monitoring with graceful fallback
+Hugging Face integration also uses `huggingface_hub.HfApi`/Hub tooling where appropriate.
 
-**Other:**
-- **loguru** `>=0.7,<1.0` — Structured logging (`core/logging_.py`)
-- **pyperclip** `>=1.8,<2.0` — Clipboard integration for copy-command feature
+### Local HTTP Services
 
-**Testing:**
-- **pytest** (via `[tool.pytest.ini_options]`) — 34 test files, 3172 lines
-- **coverage** — `fail_under = 40`
+The project deliberately uses stdlib HTTP servers rather than a web framework:
 
-**Linting/Formatting:**
-- **Ruff** — Linter + formatter, target `py310`, line-length `100`
-  - Rules: E, W, F, I, UP, B, C4, SIM, RUF
-  - Isort: known-first-party for app modules
-- **Mypy** — Static type checking, `strict = false`, `ignore_missing_imports = true`
+- download service: `http.server` on loopback, default port 8765,
+- REST API: `http.server` on loopback, default port 8787.
 
-## Key Dependencies
+The download service can require a bearer token for non-health endpoints and rejects non-loopback hosts until TLS transport exists.
 
-**Critical:**
-| Package | Version | Why It Matters |
-|---------|---------|----------------|
-| `textual` | >=0.86,<1.0 | Entire TUI depends on it. 0.x maturity — API churn risk |
-| `huggingface_hub` | >=0.27,<1.0 | Primary model source. Search + download both depend on it |
-| `requests` | >=2.32,<3.0 | Ubiquitous HTTP client across all providers and web scraping |
+## Persistence
 
-**Infrastructure:**
-| Package | Version | Purpose |
-|---------|---------|---------|
-| `psutil` | >=5.9,<7.0 | Hardware monitoring with graceful `ImportError` fallback |
-| `nvidia-ml-py` | >=12.560 | NVIDIA VRAM / GPU detection |
-| `beautifulsoup4` | >=4.12 | Ollama.com HTML scraping |
-| `pydantic-settings` | >=2.0 | Type-safe configuration |
-| `loguru` | >=0.7 | Structured logging with rotation |
-| `pyperclip` | >=1.8 | Model command copy to clipboard |
-| `click` | >=8.0 | CLI framework |
+### Metadata Cache
 
-## Configuration
+- SQLite (`core/cache_db.py`).
+- Shared process-level connection guarded by an `RLock`.
+- Reopens when configured path changes or after SQLite connection errors.
+- Stores model metadata and hardware snapshots.
 
-**Environment:**
-- `.env` file with `AIMODEL_` prefix (managed by Pydantic Settings in `config.py`)
-- `AIMODEL_HF_TOKEN` — HuggingFace API token (optional, increases rate limits)
-- `AIMODEL_HF_SEARCH_LIMIT` — Results per page (default 15)
-- `AIMODEL_HF_SEARCH_MAX_PAGES` — Max pages to fetch (default 10)
-- `AIMODEL_OLLAMA_API_BASE` — Ollama server URL (default `http://localhost:11434`)
-- `AIMODEL_OLLAMA_TIMEOUT` — Ollama request timeout (default 5s)
-- `AIMODEL_SEARCH_CACHE_TTL_SECONDS` — Cache TTL (default 90s)
-- `AIMODEL_SEARCH_CACHE_MAX_ENTRIES` — Max cache entries (default 20)
+### Download State
 
-**Build:**
-- `pyproject.toml` — Build config, ruff, mypy, pytest, coverage all configured here
-- `requirements/requirements.in` — Base deps
-- `requirements/requirements-dev.in` — Dev deps
-- Platform-specific `requirements-linux.txt` and `requirements-windows.txt`
+- SQLite store owned by the background download service.
+- Persists queued/running/completed/cancelled/failed job state independently of TUI lifetime.
 
-## Platform Requirements
+### Search Cache
 
-**Development:**
-- Python >= 3.10
-- pip + virtualenv
-- A HuggingFace token (optional, but recommended for rate limits)
-- Ollama (optional, for local model runtime features)
-- NVIDIA GPU with CUDA (optional, for accelerated inference)
+- In-memory `SearchCache`.
+- Hardware-aware invalidation.
+- Supports stale-entry lookup used by the TUI as an offline/disconnected fallback.
 
-**Production:**
-- Run as a terminal application (TUI) or CLI
-- Background download service process (launched automatically)
-- Can be accessed programmatically via REST API on port 8787
+Default persistent paths use OS-specific per-user application-data directories.
 
----
+## Concurrency
 
-*Stack analysis: 2026-06-09*
+- Textual background workers for UI-safe long-running operations.
+- `SearchOrchestrator` uses a bounded `ThreadPoolExecutor` for parallel provider search.
+- Download service uses a bounded `ThreadPoolExecutor`; default max workers: 2.
+- SQLite cache access is serialized with locks.
+- Download-store/process state has its own locking/coordination.
+
+## Development Tooling
+
+### Bootstrap and Locks
+
+Canonical workflow:
+
+```bash
+python scripts/dev.py bootstrap
+python scripts/dev.py verify
+python scripts/dev.py smoke
+```
+
+`bootstrap` installs from committed platform-specific development locks. Dependency intent belongs in `requirements/requirements.in` and `requirements/requirements-dev.in`; lock regeneration is an explicit maintenance operation rather than part of normal bootstrap.
+
+### Verification
+
+- **pytest** — main test runner.
+- **Ruff** — lint/import/static style checks.
+- **Mypy** — configured, non-strict static typing; not the primary merge gate.
+- **coverage / pytest-cov** — available in dev locks.
+
+The current verify lane contains **600+ tests** (603 observed on the 2026-09-07 PR #63 Ubuntu/Python 3.12 verify job).
+
+`pyproject.toml` currently sets `fail_under = 45`, but `scripts/dev.py verify` does not run a coverage-enforced lane. Establishing and enforcing a measured staged coverage target is active P1 roadmap work.
+
+## CI
+
+GitHub Actions `CI` workflow runs two independent matrices:
+
+- verify,
+- smoke.
+
+Each matrix covers:
+
+- `ubuntu-latest`,
+- `windows-latest`,
+- Python 3.12,
+- Python 3.14.
+
+The separate `Package` workflow is also required before the project's normal merge process considers a PR green.
+
+## Platform Integrations
+
+- **Ollama:** local API plus remote HTML registry search.
+- **Hugging Face:** hosted API/Hub plus local downloads.
+- **LM Studio:** local `/v1/models` API.
+- **Docker Model Runner:** local `/models` API.
+- **MLX:** macOS/Apple-Silicon detection plus local cache scanning.
+
+The active roadmap includes a clearer acceptance matrix for Windows, WSL/Linux, Linux native, and macOS Apple Silicon.
+
+## Known Stack Risk
+
+The most important external-format risk is Ollama registry HTML scraping. BeautifulSoup itself is not the problem; the contract depends on a third-party page structure that can change without API-version guarantees. Parser fixture coverage and structural-failure detection are P1 roadmap work.

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -117,7 +117,7 @@ Each matrix covers:
 - Python 3.12,
 - Python 3.14.
 
-The separate `Package` workflow is also required before the project's normal merge process considers a PR green.
+A separate `Package` workflow validates wheel build/install/entry points for package-relevant changes. It is path-filtered, so documentation-only PRs do not trigger it. When Package is applicable and triggered, it must be green on the exact PR head before merge.
 
 ## Platform Integrations
 

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,210 +1,192 @@
 # Codebase Structure
 
-**Analysis Date:** 2026-06-09
+**Baseline date:** 2026-09-07  
+**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`
 
-## Directory Layout
+This document describes the current repository layout. It replaces the older mapper output that referenced a root `app.py` monolith and outdated file/test counts.
 
-```
-ai-model-explorer/
-├── app.py              # Main TUI application (2466 lines — monolith)
-├── main.py             # Entry point — runs AIModelViewer
-├── cli.py              # Click CLI with 8 commands (398 lines)
-├── api_server.py       # REST API on port 8787 (339 lines)
-├── config.py           # Pydantic Settings with env overrides (62 lines)
-├── pyproject.toml      # Build, lint, test, coverage config
+## Top-Level Layout
+
+```text
+llm-terminal/
+├── main.py                  # Primary TUI entry point
+├── tui_app.py               # Base Textual application implementation
+├── cli.py                   # Click CLI
+├── api_server.py            # Local REST API
+├── config.py                # Pydantic settings
+├── pyproject.toml           # Packaging/tooling config
 │
-├── core/               # Domain logic — hardware, scoring, caching (1627 lines)
-│   ├── hardware.py     #   HardwareMonitor + GPU detection (389 lines)
-│   ├── scoring.py      #   4-dimension scoring engine (475 lines)
-│   ├── model_intelligence.py  # MoE detection, quant selection (334 lines)
-│   ├── models.py       #   ModelResult TypedDict (54 lines)
-│   ├── utils.py        #   Name parsing, fit calculation (183 lines)
-│   ├── cache_db.py     #   SQLite metadata cache (158 lines)
-│   └── logging_.py     #   loguru setup (33 lines)
+├── app/                     # Runtime TUI support modules
+│   ├── viewer.py            # Runtime AIModelViewer subclass/provider selector
+│   ├── modals.py            # Detail/download/plan/comparison modals
+│   ├── widgets.py           # Focused Textual widgets
+│   ├── download_manager.py  # TUI-side download coordination
+│   ├── search_results_state.py
+│   └── search_constants.py
 │
-├── providers/          # Search backends (1162 lines)
-│   ├── __init__.py     #   BaseProvider ABC + registry (154 lines)
-│   ├── hf_provider.py  #   HuggingFace Hub search (272 lines)
-│   ├── ollama_provider.py     # Ollama registry scraping (325 lines)
-│   ├── lmstudio_provider.py   # LM Studio local API (123 lines)
-│   ├── docker_provider.py     # Docker Model Runner (139 lines)
-│   └── mlx_provider.py        # Apple Silicon MLX (149 lines)
-│
-├── downloads/          # Download management (1376 lines)
-│   ├── download_service.py    # Background HTTP service (796 lines)
-│   ├── service_client.py      # HTTP client for service (197 lines)
-│   ├── download_manager.py    # Download command builder (41 lines)
-│   ├── download_history.py    # History helpers (58 lines)
-│   ├── download_lifecycle.py  # Lifecycle management (134 lines)
-│   ├── download_status.py     # Status/state helpers (92 lines)
-│   └── hf_downloader.py       # HF-specific download logic (58 lines)
-│
-├── search/             # Search orchestration + caching (212 lines)
-│   ├── search_orchestration.py  # Provider-aware search flow (123 lines)
-│   └── search_cache.py          # In-memory cache with HW invalidation (89 lines)
-│
-├── results/            # Results table presentation (589 lines)
-│   ├── results_layout.py       # Responsive column widths (167 lines)
-│   ├── results_presenter.py    # Color-coded cell markup (241 lines)
-│   ├── results_text.py         # Truncation, alignment (62 lines)
-│   └── results_view.py         # Filter + sort engine (119 lines)
-│
-├── terminal_ui/        # Legacy Obsidian Console (769 lines)
-│   ├── app.py          #   ObsidianConsole — experimental workspace (631 lines)
-│   └── themes.py       #   Color theme definitions (137 lines)
-│
-├── scripts/            # Development/CI scripts
-│   ├── dev.py
-│   ├── release_check.py
-│   ├── release_check_helpers.py
-│   ├── reset_downloads.py
-│   └── reset_all.bat
-│
-├── tests/              # 34 test files, 3172 lines
-│   ├── conftest.py     #   Pytest config + --run-live flag
-│   ├── test_scoring.py #   303 lines — comprehensive scoring tests
-│   ├── test_model_intelligence.py  # 214 lines
-│   ├── test_providers_extended.py  # 180 lines
-│   ├── test_api_server.py          # 168 lines
-│   ├── test_download_service_store.py  # 154 lines
-│   ├── test_download_lifecycle.py  # 118 lines
-│   ├── test_scoring_ui.py          # 205 lines
-│   ├── test_dev_script.py          # 424 lines
-│   └── ... (26 more files)
-│
-├── data/               # Runtime data (git-ignored?)
-│   ├── cache.db        #   Model metadata + hardware snapshot cache
-│   └── downloads.db    #   Download job queue
-│
-├── models/             # Downloaded GGUF model files
-├── docs/               # Documentation
-│   ├── structure.md
-│   ├── archive/
-│   └── superpowers/
-│
-├── requirements/       # Pinned dependency files
-│   ├── requirements.txt
-│   ├── requirements-dev.txt
-│   ├── requirements-linux.txt
-│   ├── requirements-windows.txt
-│   └── *.in (source files)
-│
-└── .env                # Environment variables (not committed)
+├── core/                    # Domain logic and infrastructure helpers
+├── providers/               # Search/runtime providers + capabilities
+├── search/                  # Search orchestration, cache, pagination rules
+├── results/                 # Result layout/render/filter helpers
+├── downloads/               # Background download service + client/store/runner
+├── terminal_ui/             # Theme/style assets and isolated legacy internals
+├── scripts/                 # Dev/release/maintenance commands
+├── requirements/            # Intent files + committed platform locks
+├── tests/                   # Unit, contract, smoke and optional live tests
+├── docs/                    # Maintained developer/product documentation
+└── .planning/               # Active roadmap + current codebase baseline docs
 ```
 
-## Directory Purposes
+## Entry Points
 
-**`core/`** — Domain Business Logic:
-- Purpose: Hardware detection, model scoring, MoE intelligence, caching, utility functions
-- Contains: Domain services with no dependencies on UI or provider-specific code
-- Key files: `hardware.py` (hardware detection for all vendors), `scoring.py` (scoring engine + GPU bandwidth DB)
+### `main.py`
 
-**`providers/`** — Search Backends:
-- Purpose: Pluggable model search implementations following `BaseProvider` ABC
-- Contains: One file per provider, each with `detect()`, `search()`, `list_installed()`
-- Key files: `__init__.py` (registry, lazy imports), `hf_provider.py` (primary HF search)
+Installed script: `ai-model-explorer`
 
-**`downloads/`** — Download Management:
-- Purpose: Background download orchestration via subprocess HTTP service
-- Contains: HTTP server + client, state machine, SQLite job queue
-- Key files: `download_service.py` (796-line HTTP+worker server), `service_client.py` (UI-side client)
+Creates `app.viewer.AIModelViewer`. `app/viewer.py` subclasses the base `AIModelViewer` from `tui_app.py` and owns runtime provider-selector behavior.
 
-**`search/`** — Search Pipeline:
-- Purpose: Orchestrate multi-provider search, cache results
-- Contains: Cache-aware search dispatch, pagination helpers
+### `cli.py`
 
-**`results/`** — Results Presentation:
-- Purpose: Filter, sort, layout, and colorize model results for DataTable rendering
-- Contains: Pure formatting functions with no UI dependencies
+Installed script: `ai-model-explorer-cli`
 
-**`tests/`** — Test Suite:
-- Purpose: 34 test files, 3172 lines covering scoring, hardware, providers, downloads, API, UI
-- Contains: Unit tests + smoke tests; live integration tests behind `--run-live` flag
-- Key files: `conftest.py` (sys.path setup, --run-live flag, marker registration)
+Commands include system information, search, fit, recommend, plan, scores, and cache operations.
 
-## Key File Locations
+### `api_server.py`
 
-**Entry Points:**
-- `main.py` — Primary TUI entry point (`ai-model-explorer`)
-- `cli.py` — CLI entry point (`ai-model-explorer-cli`)
-- `api_server.py` — REST API (`python -m api_server`)
-- `downloads/download_service.py` — Background service (auto-launched)
+Invoked with `python -m api_server`.
 
-**Configuration:**
-- `pyproject.toml` — Project metadata, dependencies, ruff, mypy, pytest, coverage
-- `config.py` — Runtime settings via Pydantic
-- `.env` — Environment variable overrides (not committed)
-- `requirements/*.txt` — Pinned dependency versions
+Provides local machine-readable endpoints on port 8787 by default.
 
-**Core Logic:**
-- `app.py` — Main TUI application (2466 lines)
-- `core/scoring.py` — Scoring engine (475 lines)
-- `core/hardware.py` — Hardware detection (389 lines)
-- `core/model_intelligence.py` — MoE/quant intelligence (334 lines)
-- `providers/hf_provider.py` — HuggingFace search (272 lines)
-- `providers/ollama_provider.py` — Ollama search (325 lines)
+### `downloads/download_service.py`
 
-**Testing:**
-- `tests/` directory, 34 files, 3172 lines total
-- Configuration in `[tool.pytest.ini_options]` in `pyproject.toml`
+Auto-started by the client when required. Runs the persistent background download queue/service on port 8765 by default.
 
-## Naming Conventions
+## `app/` — TUI Composition
 
-**Files:**
-- `snake_case.py` — All Python files
-- Module `__init__.py` files present in all packages
+Use this package for presentation responsibilities that can be kept out of the base Textual application.
 
-**Functions:**
-- `snake_case` — All functions and methods
-- Private functions prefixed with `_` (e.g., `_select_preferred_gguf`, `_cpu_count`)
+- `viewer.py` — provider selector integration and runtime viewer extension.
+- `modals.py` — modal screens.
+- `widgets.py` — reusable Textual widgets.
+- `download_manager.py` — client-side download coordination/poll application.
+- `search_results_state.py` — search-result state and invariants.
+- `search_constants.py` — filter/sort/use-case UI constants and compact tags.
 
-**Variables:**
-- `snake_case` — All variables
-- Module-level constants: `UPPER_CASE` (e.g., `SERVICE_VERSION`, `GPU_BANDWIDTH`)
+When adding a new modal or provider-selector behavior, prefer `app/` over expanding `tui_app.py` unless the behavior fundamentally belongs to the base application event loop/layout.
 
-**Types:**
-- `PascalCase` — Classes (`AIModelViewer`, `HardwareMonitor`, `BaseProvider`)
-- `PascalCase` — TypedDicts (`ModelResult`), dataclasses (`Scores`, `Theme`)
-- `_T` suffix — TypeAlias conventions (e.g., `_TruncatePlain`, `_AlignPlain`)
+## `search/` — Search Pipeline
 
-## Where to Add New Code
+Key files:
 
-**New Feature (e.g., new provider):**
-- Add provider class in `providers/{name}_provider.py` extending `BaseProvider`
-- Register in `providers/__init__.py:get_all_provider_classes()` and `get_provider_filter_labels()`
-- Add UI filter label in `providers/__init__.py:_FILTER_TO_SLUGS` (if not in `search/search_orchestration.py`)
+- `search_orchestrator.py` — parallel provider fan-out/fan-in, cancellation, structured diagnostic aggregation.
+- `search_orchestration.py` — provider selection, capability-aware pagination and query/status helpers.
+- `search_cache.py` — in-memory search cache with hardware-aware invalidation and stale-entry access.
 
-**New Scoring Dimension:**
-- Add scoring function in `core/scoring.py`
-- Add weight in `USE_CASE_WEIGHTS` dict
-- Add field to `Scores` dataclass
-- Update `ModelResult` TypedDict in `core/models.py`
-- Add column to `results_presenter.py` markup functions
-- Add to comparison modal in `app.py:627-655`
+New provider orchestration behavior should normally be implemented here rather than directly in Textual callbacks.
 
-**New UI Modal:**
-- Create new `ModalScreen` subclass in `app.py` following `ModelDetailModal` pattern
-- Add action method to `AIModelViewer` (e.g., `action_open_plan_mode`)
-- Add keybinding in `BINDINGS` list
+## `providers/` — Provider Backends
 
-**New CLI Command:**
-- Add Click command in `cli.py` following `@cli.command()` pattern
-- Wire into `pyproject.toml` if needed
+Key files:
 
-**New API Endpoint:**
-- Add handler method to `ModelAPIHandler` in `api_server.py`
-- Register route in `do_GET()` dispatch
+- `base.py` — `SearchResult` contract.
+- `capabilities.py` — canonical provider capability metadata.
+- `__init__.py` — `BaseProvider` interface + registry/detection helpers.
+- `ollama_provider.py` — Ollama local API + remote registry HTML discovery.
+- `hf_provider.py` — Hugging Face search/metadata integration.
+- `lmstudio_provider.py` — LM Studio local API.
+- `docker_provider.py` — Docker Model Runner local API.
+- `mlx_provider.py` — Apple Silicon/local cache discovery.
 
-## Special Directories
+When adding a provider:
 
-**`data/`:** Runtime SQLite databases created on first run. Contains `cache.db` and `downloads.db`. Should be added to `.gitignore`.
+1. implement the provider module/interface,
+2. declare canonical capabilities,
+3. register discovery/detection,
+4. add focused provider contract/error tests,
+5. expose it to TUI/CLI/REST only when that surface intentionally supports it.
 
-**`models/`:** Downloaded GGUF model files. Large binary files — should be excluded from version control.
+Do not infer capabilities from display labels or result length.
 
-**`models/.cache/`:** HuggingFace Hub cache for downloaded model metadata.
+## `core/` — Shared Domain Logic
 
-**`terminal_ui/`:** Contains a legacy, unused application (`ObsidianConsole` in `app.py:329`). Not connected to the main entry point. Kept as historical reference.
+Contains:
 
----
+- hardware detection,
+- scoring and GPU bandwidth data,
+- model/MoE/quantization intelligence,
+- SQLite metadata cache,
+- shared HTTP session/retry helpers,
+- structured provider error types,
+- logging and utility functions.
 
-*Structure analysis: 2026-06-09*
+`core/` should remain independent of Textual UI details.
+
+## `results/` — View Logic
+
+Contains pure or mostly-pure helpers for:
+
+- responsive columns,
+- cell presentation,
+- text truncation/alignment,
+- filtering/sorting/result identity.
+
+Use these modules for deterministic presentation logic that can be tested without starting the TUI.
+
+## `downloads/` — Download Service
+
+The package is split between client/API/state/runner concerns instead of one service monolith.
+
+Important modules include:
+
+- `download_service.py` — service composition/startup and worker dispatch,
+- `api.py` — service HTTP API handling,
+- `store.py` — persistent download-job SQLite store,
+- `runner.py` — job execution/process handling,
+- `service_client.py` — TUI/client requests and service compatibility handling,
+- `download_history.py`, `download_lifecycle.py`, `download_status.py` — reusable state helpers,
+- `download_manager.py` — command/payload helpers,
+- `hf_downloader.py` — focused Hugging Face downloader entry path.
+
+The worker pool is bounded and configurable; download state is persisted independently of the TUI process.
+
+## `tests/` — Verification
+
+The verify lane contains more than 600 tests as of this baseline. Tests cover:
+
+- core scoring/model intelligence/hardware helpers,
+- provider parsing/retry/structured error contracts,
+- search orchestration/cancellation/pagination,
+- cache concurrency,
+- REST/CLI contracts,
+- download service/store/lifecycle,
+- TUI state/view helpers and smoke paths,
+- dev/release scripts.
+
+Live external integration tests are opt-in (`--run-live`).
+
+## Runtime Data
+
+Runtime data is not assumed to live under a repository-local `data/` directory. Defaults use OS-specific per-user application data paths. Configuration variables can override cache DB, download DB, and model destinations.
+
+Large model files, runtime DBs, logs, virtualenvs and generated state must stay out of version control.
+
+## Where to Add New Work
+
+| Change | Preferred location |
+|---|---|
+| Provider implementation | `providers/{name}_provider.py` + capabilities/registry |
+| Provider fan-out/cancel/error aggregation | `search/search_orchestrator.py` |
+| Pagination/provider selection rules | `search/search_orchestration.py` |
+| Search caching | `search/search_cache.py` |
+| Scoring/model intelligence | `core/` |
+| Result sorting/formatting/layout | `results/` |
+| New modal/widget | `app/modals.py` / `app/widgets.py` |
+| TUI download behavior | `app/download_manager.py` + `downloads/` helpers |
+| Background download execution | `downloads/` service/store/runner modules |
+| CLI behavior | `cli.py` |
+| REST behavior | `api_server.py` |
+| Documentation/process | `README.md`, `docs/`, `.planning/` |
+
+## Documentation Rule
+
+Structural changes require a review of this file and `ARCHITECTURE.md` before the implementation is considered fully documented. See `docs/maintenance.md`.

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,247 +1,203 @@
-# Testing Patterns
+# Testing and Verification
 
-**Analysis Date:** 2026-06-09
+**Baseline date:** 2026-09-07  
+**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`
 
 ## Test Framework
 
-**Runner:**
-- pytest
-- Config: `pyproject.toml` > `[tool.pytest.ini_options]`
-- Test path: `tests/`
-- Default args: `-q` (quiet mode)
+- **Runner:** pytest.
+- **Default test path:** `tests/`.
+- **Default pytest args:** `-q` via `pyproject.toml`.
+- **Live external tests:** opt-in with `--run-live`.
+- **Mocking:** pytest `monkeypatch`, `unittest.mock`, small fake response/session/provider classes, and deterministic pure-function tests.
 
-**Assertion Library:**
-- Standard `assert` statements (pytest native)
+The old 2026-06-09 document described 34 test files and little/no mocking. That is no longer representative.
 
-**Run Commands:**
+## Normal Developer Commands
+
 ```bash
-pytest                          # Run all tests (quiet mode)
-pytest -v                       # Verbose output
-pytest -x                       # Stop on first failure
-pytest --run-live               # Include live integration tests
-pytest tests/test_scoring.py    # Single test file
-pytest -k "test_perfect"        # Keyword filter
+python scripts/dev.py bootstrap
+python scripts/dev.py verify
+python scripts/dev.py smoke
 ```
 
-**Coverage:**
+### `verify`
+
+The required local verify lane currently runs:
+
+1. pytest,
+2. import smoke,
+3. Ruff checks.
+
+The latest baseline CI verify job observed **603 passing tests** on Ubuntu/Python 3.12 for PR #63.
+
+### `smoke`
+
+The smoke lane exercises bounded/offline-safe startup paths for:
+
+- CLI,
+- REST API,
+- TUI test-mode startup,
+- download service.
+
+Smoke is not a replacement for the full unit/contract suite.
+
+## CI Matrix
+
+GitHub Actions runs verify and smoke on:
+
+| OS | Python |
+|---|---|
+| Ubuntu | 3.12 |
+| Ubuntu | 3.14 |
+| Windows | 3.12 |
+| Windows | 3.14 |
+
+The normal merge process also requires the separate `Package` workflow to be green on the exact PR head.
+
+## Exact-Head Rule
+
+A green workflow result belongs to one commit SHA. If the PR head changes, prior green evidence is stale and must not be used as the merge gate.
+
+Before merge:
+
+- confirm PR is still open and mergeable,
+- confirm exact head SHA,
+- confirm CI + Package success for that SHA,
+- confirm no unresolved review thread/blocker,
+- merge with expected head SHA.
+
+## Test Categories
+
+### Core/domain tests
+
+Cover:
+
+- scoring,
+- GPU bandwidth lookup,
+- MoE/model-size/quantization logic,
+- hardware helper fallbacks,
+- utility functions,
+- cache serialization and concurrency.
+
+### Provider contract tests
+
+Cover:
+
+- Hugging Face/Ollama retry and structured diagnostics,
+- LM Studio/Docker response parse containment,
+- Docker installed-list parse containment,
+- MLX I/O containment and global limit semantics,
+- provider capabilities,
+- pagination authority,
+- installed-model behavior.
+
+Provider error tests should assert both legacy human-readable errors and structured metadata when the provider supports both.
+
+### Search orchestration tests
+
+Cover:
+
+- parallel fan-in grouping,
+- provider exception fallback,
+- cancellation polling and shutdown behavior,
+- partial outcomes,
+- structured diagnostic preservation,
+- capability-gated pagination,
+- result counts/order.
+
+### REST contract tests
+
+Cover:
+
+- input validation,
+- provider descriptors/capabilities,
+- configured HF token propagation,
+- provider diagnostics,
+- partial results + diagnostics,
+- structured error serialization.
+
+### CLI contract tests
+
+Cover:
+
+- provider choices/capabilities,
+- HF token propagation,
+- provider diagnostics on stderr,
+- provider-specific search isolation,
+- `recommend --json` stdout remaining parseable JSON while warnings use stderr.
+
+### Download tests
+
+Cover store/state/lifecycle/client/runner behavior including:
+
+- job persistence,
+- cancellation/deletion guards,
+- command execution helpers,
+- debug/status behavior,
+- concurrent worker/store paths,
+- service compatibility and client behavior.
+
+### TUI tests
+
+TUI testing is deliberately split:
+
+- pure state/layout/presenter/view helpers where possible,
+- `app/` manager/state tests,
+- focused Textual test-mode smoke/interaction tests for mounted behavior.
+
+The active roadmap prioritizes additional coverage at TUI application boundaries before raising the coverage gate.
+
+### Live tests
+
+External live tests are skipped by default and enabled explicitly:
+
 ```bash
-pytest --cov=. --cov-report=term --cov-report=html
-coverage report                 # Show coverage with missing lines
+pytest --run-live
 ```
 
-## Test File Organization
-
-**Location:**
-- All tests in `tests/` directory (co-located test dir, not co-located with source)
-- 34 test files, 3172 lines total
-
-**Naming:**
-- `test_{module_name}.py` — Pattern matches the module being tested (e.g., `test_scoring.py` for `core/scoring.py`, `test_hardware_expanded.py` for `core/hardware.py`)
-- `test_{feature}_helpers.py` — Helper-specific tests (e.g., `test_hf_provider_helpers.py`, `test_ollama_provider_helpers.py`)
-
-**Structure:**
-```
-tests/
-├── conftest.py                         # Fixtures, --run-live flag
-├── test_scoring.py                     # Scoring engine (303 lines)
-├── test_hardware_expanded.py           # Hardware detection (79 lines)
-├── test_model_intelligence.py          # MoE + quant (214 lines)
-├── test_helpers.py                     # Core utils (53 lines)
-├── test_search_cache.py                # In-memory cache (81 lines)
-├── test_search_orchestration.py        # Search pipeline (64 lines)
-├── test_results_layout.py              # Column layout (83 lines)
-├── test_results_presenter.py           # Cell markup (82 lines)
-├── test_results_text.py                # Text helpers (34 lines)
-├── test_results_view.py                # Filter/sort (95 lines)
-├── test_download_manager.py            # Download commands (38 lines)
-├── test_download_status.py             # Status helpers (27 lines)
-├── test_download_history.py            # History helpers (40 lines)
-├── test_download_lifecycle.py          # Lifecycle (118 lines)
-├── test_download_service_store.py      # Job store (154 lines)
-├── test_download_service_debug.py      # Service debug (39 lines)
-├── test_service_client.py              # HTTP client (13 lines)
-├── test_providers_extended.py          # Provider integration (180 lines)
-├── test_hf_provider_helpers.py         # HF helpers (13 lines)
-├── test_ollama_provider_helpers.py     # Ollama helpers (59 lines)
-├── test_provider_error_helpers.py      # Error handling (25 lines)
-├── test_plan_mode.py                   # Plan mode modal (79 lines)
-├── test_scoring_ui.py                  # Scoring UI (205 lines)
-├── test_app_compact_mode.py            # Compact mode (85 lines)
-├── test_app_modal_polling.py           # Modal polling (72 lines)
-├── test_smoke_modes.py                 # Smoke tests (89 lines)
-├── test_api_server.py                  # REST API (168 lines)
-├── test_main_entrypoint.py             # entry point (14 lines)
-├── test_themes.py                      # Themes (58 lines)
-├── test_cache_db.py                    # SQLite cache (50 lines)
-├── test_live_platforms.py              # Live integration (80 lines)
-├── test_release_check_helpers.py       # Release check (20 lines)
-├── test_dev_script.py                  # Dev script (424 lines)
-└── __init__.py                         # Empty
-```
-
-## Test Structure
-
-**Suite Organization:**
-```python
-# Class-based grouping of related tests
-class TestFindGpuBandwidth:
-    def test_known_nvidia_gpu(self):
-        bw = find_gpu_bandwidth("NVIDIA GeForce RTX 4090")
-        assert bw == 1008
-
-    def test_unknown_gpu_returns_none(self):
-        bw = find_gpu_bandwidth("Some Random GPU 3000")
-        assert bw is None
-
-class TestComputeQualityScore:
-    def test_large_model_scores_higher(self):
-        s70b = compute_quality_score(params="70B", quant="Q4_K_M")
-        s7b = compute_quality_score(params="7B", quant="Q4_K_M")
-        assert s70b > s7b
-```
-
-**Patterns:**
-- Class names: `Test{Feature}` (e.g., `TestFindGpuBandwidth`, `TestScoreModel`, `TestComputeFitScore`)
-- Method names: `test_{behavior}` (e.g., `test_known_nvidia_gpu`, `test_cpu_offload_slower`, `test_all_weights_sum_to_one`)
-- No fixtures in most tests — inputs constructed inline
-- No teardown needed (no persistent state in unit tests)
-
-## Mocking
-
-**Framework:**
-- No mocking library detected. Tests rely on:
-  - Direct function calls with controlled inputs
-  - `--run-live` flag for integration tests that hit real services
-  - `conftest.py` skips live tests by default
-
-**Patterns:**
-```python
-# No mocking — test pure functions with known inputs
-def test_perfect_fit_scores_high(self):
-    score = compute_fit_score(model_size_gb=12.0, vram_gb=24.0, ram_gb=32.0, mode="GPU")
-    assert score >= 80
-```
-
-**What to Mock:**
-- External HTTP calls (HuggingFace API, Ollama registry)
-- Hardware detection (GPU availability, VRAM size)
-- Subprocess calls (ollama rm, rocm-smi)
-
-**What NOT to Mock:**
-- Scoring logic (tested directly with known inputs)
-- Layout/formatting functions (tested with sample data)
-- Cache logic (tested with controlled state)
-- Model intelligence (tested with model name strings)
-
-## Fixtures and Factories
-
-**Test Data:**
-```python
-# Inline test data — no factory functions
-specs = {
-    "vram_total": 24.0,
-    "vram_free": 20.0,
-    "ram_total": 32.0,
-    "ram_free": 28.0,
-    "gpu_name": "NVIDIA GeForce RTX 4090",
-    "has_gpu": True,
-}
-```
-
-**Location:**
-- No centralized test fixtures or factories
-- All test data constructed inline in test methods
-- `conftest.py` only provides pytest configuration (sys.path, --run-live, markers)
+Use live tests to validate actual external/provider behavior, not as a substitute for deterministic fixtures.
 
 ## Coverage
 
-**Requirements:**
+Current config:
+
 ```toml
 [tool.coverage.report]
-fail_under = 40  # CI gate — 40% minimum
+show_missing = true
+fail_under = 45
 ```
 
-**View Coverage:**
+Important distinction: **45 is configured, but the normal `scripts/dev.py verify` lane does not currently run pytest under coverage, so this is not yet an enforced CI threshold.**
+
+Active quality plan:
+
+1. add a reproducible measured coverage lane,
+2. record the real baseline,
+3. add tests for high-risk uncovered paths,
+4. enforce staged thresholds: 50 → 55 → 60.
+
+Do not raise coverage by excluding meaningful production code or by weakening tests.
+
+Useful commands once measuring locally:
+
 ```bash
-coverage run -m pytest && coverage report
-coverage html    # Open htmlcov/index.html
+pytest --cov=. --cov-report=term-missing
+pytest --cov=. --cov-report=html
 ```
 
-**Known gaps:** The `fail_under = 40` target is low, suggesting significant untested areas. The monolith `app.py` (2466 lines) has very limited test coverage — only 3 test files target the TUI (`test_app_compact_mode.py`, `test_app_modal_polling.py`, `test_smoke_modes.py`).
+## Regression-Test Rule
 
-## Test Types
+Every correctness fix should add a test that fails against the pre-fix behavior and pins the intended contract. Prefer the narrowest test seam that still proves the user-facing invariant.
 
-**Unit Tests (dominant):**
-- Pure function tests for scoring, hardware detection, model intelligence, utilities
-- No external dependencies, fast execution
-- Examples: `test_scoring.py`, `test_hardware_expanded.py`, `test_helpers.py`
+Examples of preferred assertions:
 
-**Service/Store Tests:**
-- Tests for `DownloadStore` SQLite operations (`test_download_service_store.py`)
-- Tests for download lifecycle (`test_download_lifecycle.py`)
-- Uses `DownloadStore.__init__` with temp/memory DB
+- exact result limit rather than implementation-specific loop structure,
+- diagnostic code/retryability/status rather than raw exception class when crossing provider boundaries,
+- stdout/stderr separation for CLI scripting contracts,
+- partial-success preservation when one provider fails,
+- no continuation UI for non-paginated providers.
 
-**Smoke Tests:**
-- `test_smoke_modes.py` — Smoke-mode TUI test via `app.run_test()`
-- `test_app_compact_mode.py` — Compact-mode UI behavior
-- `test_app_modal_polling.py` — Modal poll pause behavior
+## Documentation Rule
 
-**Live Integration Tests:**
-- `test_live_platforms.py` — Tests that hit real HuggingFace/Ollama APIs
-- Gated behind `--run-live` flag
-- Skipped by default
-
-**UI Tests:**
-- `test_results_layout.py`, `test_results_presenter.py`, `test_results_text.py`, `test_results_view.py` — Test formatting/computation (no actual widget rendering)
-
-**E2E Tests:**
-- Not used. Smoke tests (`test_smoke_modes.py`) are the closest equivalent.
-
-## Common Patterns
-
-**Async Testing:**
-```python
-# Textual's async test pilot — used in smoke tests
-async def test_smoke_mode():
-    app = AIModelViewer()
-    async with app.run_test() as pilot:
-        await pilot.pause(1.5)
-    assert app.return_code in (None, 0)
-```
-
-**Error Testing:**
-```python
-# Testing error conditions with known edge cases
-def test_no_fit_returns_zero(self):
-    tok_s = estimate_tok_per_s(
-        model_size_gb=4.8, gpu_name="NVIDIA GeForce RTX 4090", mode="No Fit"
-    )
-    assert tok_s == 0.0
-
-def test_empty_string(self):
-    bw = find_gpu_bandwidth("")
-    assert bw is None
-```
-
-**State Machine Testing:**
-```python
-# Download lifecycle state transitions
-class TestDownloadLifecycle:
-    def test_cancel_before_delete_required_for_active(self):
-        assert should_cancel_before_delete(delete_data=True, state="downloading") is True
-        assert should_cancel_before_delete(delete_data=True, state="completed") is False
-```
-
-**Hardware-Agnostic Testing:**
-```python
-class TestHardwareMonitorSpecs:
-    def test_specs_has_backend_field(self):
-        monitor = HardwareMonitor()
-        specs = monitor.get_specs()
-        assert "backend" in specs
-        assert specs["backend"] in ("cuda", "rocm", "metal", "sycl", "cpu")
-```
-
----
-
-*Testing analysis: 2026-06-09*
+When a merge changes test commands, CI matrices, coverage policy, provider contracts, or acceptance evidence, update this file in the same PR when practical. See `docs/maintenance.md`.

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -53,7 +53,7 @@ GitHub Actions runs verify and smoke on:
 | Windows | 3.12 |
 | Windows | 3.14 |
 
-The normal merge process also requires the separate `Package` workflow to be green on the exact PR head.
+For package-relevant changes, the path-filtered `Package` workflow also runs and must be green on the exact PR head. Documentation-only PRs do not trigger Package.
 
 ## Exact-Head Rule
 
@@ -63,7 +63,8 @@ Before merge:
 
 - confirm PR is still open and mergeable,
 - confirm exact head SHA,
-- confirm CI + Package success for that SHA,
+- confirm CI and every workflow applicable to the changed paths are successful for that SHA,
+- require Package success when the Package workflow is triggered,
 - confirm no unresolved review thread/blocker,
 - merge with expected head SHA.
 

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -1,130 +1,173 @@
-# AI Model Explorer — Roadmap
+# AI Model Explorer — Active Roadmap
 
-**Oluşturma:** 2026-06-09
-**Kaynak:** `.planning/codebase/` (gsd-codebase-mapper analizi)
+**Baseline date:** 2026-09-07  
+**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`  
+**Status:** post-hardening baseline; active roadmap only
 
----
+This roadmap replaces the 2026-06-09 mapper plan. Completed work stays documented here only as a baseline summary; it is not an active backlog.
 
-## Faz 1: Temel Sağlık & Bakım
-*Düşük risk, yüksek etki — tüm fazların temeli.*
+## Delivery Principles
 
-| # | Görev | Dosyalar | Süre |
-|---|-------|----------|------|
-| 1.1 | `except Exception: pass` → loguru logging | `app.py`, `core/cache_db.py`, `downloads/download_service.py` | 1g |
-| 1.2 | Lazy import'ları module seviyesine taşı | `app.py` (~5 yer) | 0.5g |
-| 1.3 | HTTP connection pooling (`requests.Session`) | Tüm provider'lar | 1g |
-| 1.4 | Provider retry/backoff (`tenacity`) | `providers/hf_provider.py`, `providers/ollama_provider.py` | 1g |
-| 1.5 | Error type hierarchy oluştur | `core/errors.py` (yeni) | 0.5g |
+1. Prefer small, reversible PRs with a single acceptance contract.
+2. Treat exact-head CI evidence as the merge gate. A new head SHA invalidates prior green evidence.
+3. Preserve existing public contracts unless the PR explicitly changes them.
+4. Add focused regression coverage for every correctness fix before merge.
+5. Keep provider failures observable: no silent false-success paths.
+6. Review documentation after every successful merge. Update affected docs in the same PR when practical; otherwise open an immediate narrow docs follow-up before unrelated feature work.
+7. Raise quality gates only when the repository already passes them; do not weaken tests or exclusions to make a gate green.
 
-**Toplam:** ~4g · **Test:** Mevcut testler yeşil + yeni error path testleri
+## Completed Baseline
 
----
+The following items from the old roadmap are already implemented and should not be re-opened as generic tasks:
 
-## Faz 2: Monoliti Kır — `app.py`
-*En kritik teknik borç. 2466 satır → modüler yapı.*
+- Modular TUI support modules under `app/` for viewer extensions, modals, widgets, download management, search state, and constants.
+- Parallel provider fan-out in `SearchOrchestrator` with bounded workers and cancellation polling.
+- Provider capability metadata as the authority for search, pagination, installed-list, and download behavior.
+- Shared `requests.Session` pooling plus retry/backoff for retryable GET failures.
+- Structured provider diagnostics via `ProviderError`, preserved through provider results and orchestration.
+- Structured/legacy diagnostic containment for Hugging Face, Ollama, LM Studio, Docker Model Runner, and MLX search paths.
+- REST `/api/v1/models` additive `errors` and `structured_errors` output.
+- CLI provider diagnostics on stderr while preserving script-safe JSON stdout.
+- Search cancellation and provider-authoritative pagination handling.
+- Shared SQLite cache connection with serialized access and retry-on-connection-error behavior.
+- Bounded multi-worker download service (`AIMODEL_DOWNLOAD_MAX_WORKERS`, default `2`).
+- Loopback-only download-service transport with optional bearer-token protection for non-health endpoints.
+- Platform-specific user-data locations for cache/download state and Hugging Face model files.
+- MoE-aware model-size estimation delegated to one canonical implementation.
+- Pre-built GPU bandwidth lookup instead of repeated linear scans.
+- REST parameter validation for provider, limit, context, and sort inputs.
+- CI verify + smoke matrices on Ubuntu and Windows with Python 3.12 and 3.14.
+- More than 600 deterministic tests in the current verify lane.
+- TUI stale-search-cache fallback for disconnected/offline search recovery.
 
-| # | Görev | Hedef | Süre |
-|---|-------|-------|------|
-| 2.1 | Modal screen'leri ayır | `app/modals.py` (4 modal) | 1.5g |
-| 2.2 | Widget'ları ayır | `app/widgets.py` (`SystemInfoWidget`) | 0.5g |
-| 2.3 | Download lifecycle'ı delegate'e çıkar | `app/download_delegate.py` | 2g |
-| 2.4 | Search orchestration'ı coordinator'a çıkar | `app/search_coordinator.py` | 2g |
-| 2.5 | `AIModelViewer`'ı compose et | `app/app.py` (yeni, ~600 satır) | 2g |
+## P1 — Quality Baseline
 
-**Toplam:** ~8g · **Risk:** YÜKSEK — regression riskine karşı Faz 3 ile paralel test yazılmalı
+### Q1. Establish a measured coverage baseline and enforce it in CI
 
----
+Current state:
 
-## Faz 3: Test Coverage Artırımı
-*Hedef: %40 → %60 coverage gate.*
+- `pyproject.toml` contains `fail_under = 45`.
+- The normal `scripts/dev.py verify` lane runs tests, import smoke, and Ruff; it does **not** currently enforce a coverage threshold.
 
-| # | Görev | Detay | Süre |
-|---|-------|-------|------|
-| 3.1 | Faz 2 çıktılarına unit test | Yeni modüller + mevcut `app.py` davranışı | 3g |
-| 3.2 | Download service testleri | Worker loop, cancellation, subprocess | 1.5g |
-| 3.3 | Ollama scraping mock testleri | HTML fixture + parse test | 1g |
-| 3.4 | Error path coverage | Tüm `except` blokları test edilsin | 1.5g |
-| 3.5 | Coverage gate güncelle | `fail_under = 40` → `60` | 0.5g |
+Plan:
 
-**Toplam:** ~7.5g · **Not:** Faz 2 ile paralel ilerleyebilir
+1. Add a reproducible coverage command/lane without changing production behavior.
+2. Record the measured baseline on Linux/Python 3.12.
+3. Add focused tests for low-coverage, high-risk paths before changing the gate.
+4. Raise the enforced threshold in stages: **50 → 55 → 60**.
+5. Do not reach targets by excluding meaningful production modules or weakening assertions.
 
----
+Priority coverage targets:
 
-## Faz 4: Mimari İyileştirme
-*Performans ve bakım kolaylığı.*
+- TUI search/application boundaries and state transitions.
+- Download service runner/store/cancellation/version-compatibility paths.
+- Provider error/parse/retry boundaries.
+- Platform-specific hardware detection fallbacks.
+- REST and CLI public contracts.
 
-| # | Görev | Detay | Süre |
-|---|-------|-------|------|
-| 4.1 | Duplicate `estimate_model_size_gb` tekilleştir | `utils.py` sürümünü deprecate et | 0.5g |
-| 4.2 | Provider aramalarını paralelleştir | `ThreadPoolExecutor` ile eşzamanlı sorgu | 1g |
-| 4.3 | SQLite connection pooling | Connection-per-operation → module-level pool | 1g |
-| 4.4 | `find_gpu_bandwidth` optimizasyonu | Linear scan → normalized lookup table | 0.5g |
-| 4.5 | GPU bandwidth linear search optimize | Build trie at module load time | 0.5g |
+### Q2. Residual silent-failure audit
 
-**Toplam:** ~3.5g · **Bağımlılık:** Faz 2 tamamlanmış olmalı
+Audit remaining broad exception/suppression boundaries and classify each as one of:
 
----
+- expected fail-closed behavior with logging,
+- user-visible diagnostic required,
+- specific exception types required,
+- intentional best-effort behavior that should be documented.
 
-## Faz 5: Provider Sağlamlaştırma
-*Güvenlik ve sağlamlık.*
+Initial targets:
 
-| # | Görev | Detay | Süre |
-|---|-------|-------|------|
-| 5.1 | Ollama scraping → resmi API | Ollama API dokümantasyonu araştır + implemente et | 2g |
-| 5.2 | HF token env → stdin pipe | Güvenlik iyileştirmesi | 0.5g |
-| 5.3 | `api_server.py` input validasyonu | 400 vs 500 hata yönetimi | 0.5g |
-| 5.4 | `shell=True` kaldır (legacy) | `terminal_ui/app.py` | 0.5g |
-| 5.5 | Hataları string → structured error tipleri | Tüm provider `search()` yöntemleri | 1g |
+- provider registry import/detection suppression,
+- `app/viewer.py` selector synchronization fallback,
+- download polling/update boundaries,
+- platform hardware probes.
 
-**Toplam:** ~4.5g · **Bağımlılık:** Faz 1 (error types), Faz 4 (paralel arama)
+The goal is not “remove every `except Exception`”; it is to eliminate unobservable failures where they can mislead users or hide correctness problems.
 
----
+## P1 — Ollama Registry Resilience
 
-## Faz 6: Performans & UX
-*Kullanıcıya yansıyan iyileştirmeler.*
+Ollama remote discovery still depends on `ollama.com` HTML structure. This is the largest remaining external-format fragility.
 
-| # | Görev | Detay | Süre |
-|---|-------|-------|------|
-| 6.1 | DataTable incremental update | `refresh_table()` rebuild → `update_cell()` | 1.5g |
-| 6.2 | Search cancellation | Yeni arama eskiyi iptal etsin | 1g |
-| 6.3 | Download multi-worker | `max_workers` ile paralel indirme | 1.5g |
-| 6.4 | Offline/cache-first mod | Ağ yoksa önbellekten oku | 2g |
-| 6.5 | UI donma azaltma | Uzun işlemlerde progress feedback | 1g |
+### O1. Fixture-backed parser contracts
 
-**Toplam:** ~7g · **Bağımlılık:** Faz 2 + Faz 4
+- Store representative sanitized/cached HTML fixtures for the currently supported result shapes.
+- Test table/card/anchor extraction and malformed/empty responses deterministically.
+- Pin filtering, ordering, metadata extraction, and no-result behavior.
 
----
+### O2. Structural failure detection
 
-## Dependency Graph
+- Distinguish a genuine zero-result search from “page shape changed and parser matched nothing” where evidence allows.
+- Surface a stable diagnostic rather than silently returning success on a broken parser contract.
 
-```
-Faz 1 (Temel Bakım)
-   │
-   ▼
-Faz 2 (Monolit Kırma) ──► Faz 3 (Test Coverage) [paralel]
-   │                           │
-   ▼                           ▼
-Faz 4 (Mimari İyileştirme) ◄──┘
-   │
-   ▼
-Faz 5 (Provider Sağlamlaştırma)
-   │
-   ▼
-Faz 6 (Performans & UX)
-```
+### O3. Structured-source/API research
 
----
+After parser coverage is strong, research whether Ollama exposes a supported structured registry/search source suitable for replacing or reducing HTML scraping. Do not migrate until compatibility, pagination, metadata quality, and rate-limit behavior are understood.
 
-## Toplam Tahmini Süre
+## P2 — TUI Results Performance
 
-| Faz | Gün |
-|-----|-----|
-| Faz 1 — Temel Sağlık | 4g |
-| Faz 2 — Monolit Kırma | 8g |
-| Faz 3 — Test Coverage | 7.5g |
-| Faz 4 — Mimari İyileştirme | 3.5g |
-| Faz 5 — Provider Sağlamlaştırma | 4.5g |
-| Faz 6 — Performans & UX | 7g |
-| **Toplam** | **~34.5g** |
+The TUI still clears/rebuilds result table rows in important refresh paths.
 
-*Tam zamanlı tek geliştirici — tahmini 7 hafta.*
+### U1. Measure before changing
+
+- Add a repeatable benchmark/test harness for row refresh at representative result counts.
+- Separate column-layout rebuilds from ordinary row-state updates.
+
+### U2. Incremental updates where safe
+
+- Use stable row keys and `DataTable.update_cell()`/row updates for download/progress/state changes that do not require full re-sort/re-filter.
+- Keep full rebuilds for structural column changes or result-order changes when simpler and safer.
+- Preserve cursor/scroll position and compact/comfortable layout behavior.
+
+## P2 — Platform Acceptance Matrix
+
+CI currently verifies Ubuntu and Windows on Python 3.12/3.14. Runtime support remains Python 3.10-3.14, but provider/platform acceptance needs clearer evidence.
+
+Build an explicit matrix for:
+
+- Windows native,
+- WSL/Linux,
+- Linux native,
+- macOS Apple Silicon.
+
+For each platform record:
+
+- bootstrap + package install,
+- CLI smoke,
+- REST smoke,
+- TUI startup smoke,
+- cache/download data paths,
+- provider detection behavior,
+- relevant runtime integrations (Ollama, LM Studio, Docker Model Runner, MLX).
+
+Automate only where runners and services make the result reliable; keep clearly documented manual acceptance where hosted CI cannot represent the real runtime.
+
+## P3 — Provider and Runtime Edge Cases
+
+Address these only after P1 work unless a concrete user-facing defect is found:
+
+- MLX `list_installed()` filesystem I/O containment parity with MLX search.
+- LM Studio metadata helper response-shape containment if/when it has a production caller.
+- Docker/LM Studio/MLX limit and installed-list edge cases not reachable through current user-facing limits.
+- Provider registry diagnostics/observability improvements.
+- Further type tightening around provider duck-typed interfaces.
+
+## P3 — Maintainability and Product Work
+
+Candidate work after the quality/resilience baseline:
+
+- More scriptable structured CLI output without breaking existing JSON contracts.
+- REST/provider surface convergence where it materially improves users rather than adding abstraction for its own sake.
+- Additional cache/offline behavior beyond the existing TUI stale-cache fallback, if CLI/REST offline workflows become a product requirement.
+- Packaging/release automation improvements once release cadence requires them.
+
+## Documentation Sync Policy
+
+`docs/maintenance.md` is the operational rule for keeping documentation current.
+
+At every successful merge, review at minimum:
+
+- `README.md` for user-facing behavior/configuration,
+- `CHANGELOG.md` for release-significant behavior,
+- this roadmap for completed/changed priorities,
+- `.planning/codebase/` when architecture, integrations, testing, stack, or known concerns changed.
+
+A merged implementation is not considered fully documented if it leaves a known active document materially false.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+**Unreleased development notes**
 
 ### Reliability and provider correctness
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## Unreleased
+
+### Reliability and provider correctness
+
+- Added canonical provider capabilities for Ollama, Hugging Face, LM Studio, Docker Model Runner, and MLX and moved pagination/download/search decisions away from UI heuristics.
+- Added parallel multi-provider search orchestration with bounded workers, deterministic result grouping, cancellation polling, partial-result preservation, and provider-authoritative pagination.
+- Added structured provider diagnostics (`ProviderError`) alongside legacy human-readable errors and preserved them through search orchestration.
+- Hardened Hugging Face and Ollama transient failures with retry/backoff and retry-after handling.
+- Added LM Studio and Docker HTTP/transport/parse containment with stable structured error codes.
+- Hardened Docker installed-model response parsing by reusing the validated search response parser.
+- Hardened MLX cache scanning against filesystem I/O failures and enforced a true global search result limit across cache roots.
+- Preserved orchestrator-generated provider failures as machine-readable diagnostics instead of dropping them to strings only.
+- Fixed provider pagination authority so non-paginated/multi-provider searches cannot synthesize false continuation from result counts.
+
+### REST and CLI contracts
+
+- REST `/api/v1/models` now preserves provider `errors` and additive `structured_errors`, allowing partial models and diagnostics to coexist without changing the existing HTTP-200 partial-success contract.
+- REST model/provider/limit/context/sort validation now returns bounded 400 responses for invalid inputs rather than relying on generic 500 handling.
+- CLI `search`, `fit`, and `recommend` now surface provider failures on stderr instead of presenting them as ordinary zero-result success.
+- Preserved `recommend --json` stdout as the existing JSON array contract while diagnostics are emitted separately on stderr.
+- Propagated configured Hugging Face authentication consistently through CLI and REST search paths.
+
+### Search, cache, and performance
+
+- Moved provider fan-out/fan-in into a Textual-independent `SearchOrchestrator` with focused cancellation and error-path tests.
+- Added hardware-aware search caching with stale-entry fallback for TUI disconnected/offline recovery.
+- Switched requests-based provider traffic to a shared pooled session with retryable GET handling.
+- Switched metadata cache access to a shared SQLite connection guarded by locks, with reopen/retry behavior after connection errors.
+- Consolidated model-size estimation on the MoE-aware implementation and replaced repeated GPU-bandwidth linear scans with pre-built lookup maps.
+
+### Download service and local security boundary
+
+- Refactored download service responsibilities across API, store, runner, service client, and lifecycle/state helpers.
+- Added bounded parallel download workers controlled by `AIMODEL_DOWNLOAD_MAX_WORKERS` (default `2`).
+- Moved runtime databases/model output toward OS-specific per-user application-data locations with configuration overrides.
+- Hardened the download-service trust boundary: loopback-only bind/client hosts, optional bearer-token protection for non-health endpoints, and explicit rejection of non-loopback transport until TLS exists.
+- Expanded cancellation, process, persistence, debug, service-version, and compatibility coverage.
+
+### Packaging, CI, and verification
+
+- Standardized development workflow around `scripts/dev.py bootstrap`, `verify`, and `smoke` with committed platform-specific dependency locks.
+- Expanded supported runtime metadata to Python 3.10-3.14 and CI verification to Ubuntu/Windows on Python 3.12 and 3.14.
+- Added/expanded separate CI verify, smoke, and Package gates used as exact-head merge evidence.
+- Expanded the deterministic verify suite to more than 600 tests (603 observed on the 2026-09-07 PR #63 Ubuntu/Python 3.12 verify job).
+
+### Documentation
+
+- Replaced the stale 2026-06-09 planning/codebase mapper baseline with a current post-hardening architecture, structure, stack, testing, integrations, concerns, and active roadmap baseline.
+- Added a documentation-maintenance policy requiring relevant README/CHANGELOG/roadmap/codebase docs to be reviewed after each successful merge.
+
 ## 1.0.1 - 2026-03-26
 
 ### Release Notes
@@ -26,7 +76,7 @@
 - Added unit tests for fallback history entries, external-entry detection, action labels, and cancel payload shaping.
 - Extracted results-table filtering and hidden-gem ordering into `results_view.py` and reused it in `app.py`.
 - Added tests for result row key generation and result filtering/sorting behavior.
-- Extracted responsive result-column layout rules into `results_layout.py` and reused them from `app.py`.
+- Extracted responsive result-column layout rules into `results_layout.py` and reused it in `app.py`.
 - Added unit tests for layout breakpoint key selection and width distribution.
 - Extracted results-cell markup formatting into `results_presenter.py` and delegated `app.py` cell helpers to it.
 - Added unit tests for fit/mode/source/score/use-case/download cell formatting behaviors.

--- a/README.md
+++ b/README.md
@@ -1,64 +1,117 @@
 # AI Model Explorer
 
-AI Model Explorer is a Textual terminal app for discovering, scoring, comparing, and downloading local LLM models across Ollama, Hugging Face, LM Studio, Docker Model Runner, and MLX.
+AI Model Explorer is a terminal-first workspace for discovering, scoring, comparing, and downloading local LLM models across Ollama, Hugging Face, LM Studio, Docker Model Runner, and MLX.
 
 ## About
 
-AI Model Explorer is a terminal-first workspace for people who run local LLMs and want faster answers to three practical questions: which models are worth trying, which ones will actually fit their hardware, and how to download or compare them without bouncing between multiple tools.
+AI Model Explorer helps answer three practical questions:
 
-The repo combines model discovery, hardware-aware scoring, plan-mode analysis, local provider integration, and download orchestration in one place. It is designed for developers and power users who want a Textual UI, a scriptable CLI, and a local REST API over the same core model intelligence.
+1. Which models are worth trying?
+2. Which models will actually fit this hardware?
+3. How can I compare or download them without switching between several tools?
+
+The repository combines a Textual TUI, a scriptable Click CLI, a localhost REST API, hardware-aware scoring, provider orchestration, stale-cache fallback, and a persistent background download service.
 
 ## Features
 
 ### Model Discovery & Search
-- Search across 5 providers: **Ollama**, **Hugging Face**, **LM Studio**, **Docker Model Runner**, **MLX**
-- Filter by provider, use case (coding, chat, vision, reasoning, math, embedding, general)
-- Hidden-gem detection for high-download, low-visibility HF models
-- Parallel provider search (Ollama + Hugging Face + extras concurrently)
-- Stale-cache fallback when offline
 
-### 4-Dimension Scoring System
-- **Quality** (0-100): Parameter count and quantization quality
-- **Speed** (0-100): Estimated tokens/sec based on GPU bandwidth and model size
-- **Fit** (0-100): VRAM utilization efficiency (sweet spot: 50-80%)
-- **Context** (0-100): Context window capacity
-- **Composite score**: Use-case-weighted average (e.g., chat prioritizes speed, reasoning prioritizes quality)
+- TUI search across **Ollama**, **Hugging Face**, **LM Studio**, **Docker Model Runner**, and **MLX**.
+- Filter by provider and use case (coding, chat, vision, reasoning, math, embedding, general).
+- Hidden-gem detection for high-download, low-visibility Hugging Face models.
+- Parallel provider fan-out with deterministic result grouping.
+- Search cancellation so a newer search can supersede in-flight work.
+- Capability-driven pagination; continuation is not inferred from result counts.
+- TUI stale-cache fallback when live search is unavailable and a matching stale entry exists.
+- Provider failures are contained and surfaced instead of silently appearing as ordinary zero-result success.
+
+### Provider Diagnostics
+
+Providers expose both human-readable errors and machine-readable structured diagnostics where supported.
+
+Structured diagnostics include stable metadata such as:
+
+- provider,
+- error code,
+- retryability,
+- optional HTTP status,
+- optional retry-after duration.
+
+The TUI/orchestrator preserves this metadata internally. REST exposes it directly, while CLI model-discovery commands surface human-readable warnings on stderr.
+
+### 4-Dimension Scoring
+
+- **Quality** (0-100): parameter count and quantization quality.
+- **Speed** (0-100): estimated tokens/sec based on GPU bandwidth and model size.
+- **Fit** (0-100): hardware utilization/fit.
+- **Context** (0-100): context-window capacity.
+- **Composite score**: use-case-weighted aggregate.
 
 ### Hardware Intelligence
-- **MoE awareness**: Auto-detects Mixture-of-Experts models (Mixtral, DeepSeek-V2/V3, etc.) and adjusts VRAM calculations
-- **Dynamic quantization**: Automatically selects the best quantization level (Q8_0 to Q2_K) for your hardware
-- **Speed estimation**: Token/sec prediction based on GPU memory bandwidth (80+ GPUs in lookup table)
-- **Multi-GPU support**: NVIDIA (CUDA), AMD (ROCm), Apple Silicon (Metal), Intel Arc (SYCL)
+
+- MoE-aware size/VRAM estimation.
+- Dynamic quantization planning.
+- Token/sec estimation from GPU memory bandwidth.
+- NVIDIA, AMD, Apple Silicon, Intel and CPU fallback detection paths.
+- Multi-GPU-aware hardware snapshots where platform tooling exposes the required data.
 
 ### Plan Mode & Comparison
-- **Plan Mode** (`P`): Reverse hardware analysis — see what GPU you need for any model at any quantization level
-- **Comparison** (`c`/`C`): Side-by-side comparison of up to 4 models with full scoring breakdown
+
+- **Plan Mode** (`P`): reverse hardware analysis for model/quantization choices.
+- **Comparison** (`c`/`C`): side-by-side comparison of up to four models.
 
 ### Download Management
-- Queue, monitor, cancel, and delete downloads through a background HTTP service
-- Track download history with status and details
-- Support for Ollama pull and Hugging Face GGUF downloads
 
-### Theming
-- 5 built-in themes: default, dracula, nord, solarized, monokai
-- Runtime toggle with `t` key
+- Persistent localhost download service.
+- Queue, monitor, cancel and delete jobs.
+- Bounded parallel workers (`AIMODEL_DOWNLOAD_MAX_WORKERS`, default `2`).
+- Ollama pull and Hugging Face download paths.
+- Persistent history independent of TUI lifetime.
+- Loopback-only transport; optional bearer token for non-health service endpoints.
 
 ### REST API
-- Local HTTP API on port 8787 for programmatic access
-- Endpoints: `/health`, `/api/v1/system`, `/api/v1/models`, `/api/v1/models/top`, `/api/v1/models/{name}/plan`, `/api/v1/scores/{name}`, `/api/v1/providers`
+
+Local HTTP API on `127.0.0.1:8787` by default.
+
+Endpoints:
+
+- `/health`
+- `/api/v1/system`
+- `/api/v1/models`
+- `/api/v1/models/top`
+- `/api/v1/models/{name}/plan`
+- `/api/v1/scores/{name}`
+- `/api/v1/providers`
+
+`/api/v1/models` currently searches **Ollama and Hugging Face**. Successful responses include additive `errors` and `structured_errors` arrays so callers can distinguish provider failure from a genuine zero-result search while still receiving partial results.
 
 ### CLI
-- Rich terminal output for search, fit analysis, recommendations, and scoring
-- JSON output support for scripting
+
+Rich terminal commands for system information, search, fit analysis, recommendations, planning and scoring.
+
+CLI search/fit/recommend provider failures are printed to **stderr**. `recommend --json` keeps stdout as valid JSON for scripting.
+
+### Theming
+
+- default
+- dracula
+- nord
+- solarized
+- monokai
+
+Cycle themes at runtime with `t`.
 
 ## Requirements
 
-- Python 3.10-3.14
-- Tested in CI: Python 3.12 and Python 3.14
-- Internet access for provider searches
-- Ollama (optional; required only for local runtime and `ollama pull/run`)
-- LM Studio (optional; auto-detected on `localhost:1234`)
-- Docker Desktop with Model Runner (optional; auto-detected on `localhost:12434`)
+- Python 3.10-3.14.
+- CI currently verifies Python 3.12 and 3.14 on Ubuntu and Windows.
+- Internet access for live remote provider searches.
+- Ollama optional; required for Ollama local runtime/pull operations.
+- LM Studio optional; auto-detected on `localhost:1234` by default.
+- Docker Desktop Model Runner optional; auto-detected on `localhost:12434` by default.
+- macOS Apple Silicon for MLX runtime/cache detection.
+
+The TUI can reuse a matching stale search-cache entry when a live search is unavailable, but this is not a general offline mirror of every provider.
 
 ## Installation
 
@@ -70,25 +123,19 @@ python scripts/dev.py verify
 python scripts/dev.py smoke
 ```
 
-Use a supported Python 3.10-3.14 interpreter for the bootstrap command. On Windows,
-that can be `py -3.14` or another selected interpreter; after bootstrap, prefer the
-project virtualenv instead of a random global `python` on your `PATH`.
+Use a supported Python 3.10-3.14 interpreter for bootstrap. On Windows that can be `py -3.14` or another selected interpreter. After bootstrap, prefer the project virtualenv over a random global Python on `PATH`.
 
-`scripts/dev.py bootstrap` creates or reuses `.venv` and installs from the committed
-platform-specific development lock file. Edit `requirements/requirements.in` and
-`requirements/requirements-dev.in` for dependency intent; bootstrap does not resolve or
-regenerate locks. Canonical lock maintenance stays on Python 3.12 even though the runtime
-support window is 3.10-3.14.
+`scripts/dev.py bootstrap` creates or reuses `.venv` and installs from the committed platform-specific development lock file. Edit `requirements/requirements.in` and `requirements/requirements-dev.in` for dependency intent; bootstrap does not resolve or regenerate locks. Canonical lock maintenance remains explicit.
 
-`scripts/dev.py verify` runs the required local checks in order: `pytest -q`, import smoke,
-and `ruff check .`.
+`scripts/dev.py verify` runs the required local checks: pytest, import smoke and Ruff.
 
-`scripts/dev.py smoke` runs the offline-safe process smoke checks for the CLI, API server,
-TUI startup path, and download service.
+`scripts/dev.py smoke` runs bounded/offline-safe smoke checks for the CLI, REST API, TUI startup path and download service.
+
+The current verify baseline contains **600+ tests** (603 observed in the 2026-09-07 PR #63 Ubuntu/Python 3.12 CI job).
 
 ## Run
 
-### TUI Application
+### TUI
 
 ```bash
 .venv/Scripts/python.exe main.py  # Windows
@@ -96,28 +143,29 @@ TUI startup path, and download service.
 .venv/bin/python main.py          # Linux/macOS
 ```
 
-Or with the installed script entrypoint:
+Installed entry point:
 
 ```bash
 ai-model-explorer
 ```
 
-### CLI Commands
+### CLI
 
 ```bash
-ai-model-explorer-cli system              # Show hardware info
-ai-model-explorer-cli search "llama" -n 5 # Search models
-ai-model-explorer-cli fit --perfect -n 5  # Find best-fitting models
-ai-model-explorer-cli recommend -u coding # Get coding model recommendations
-ai-model-explorer-cli plan "llama-3-8b"   # Hardware requirements analysis
-ai-model-explorer-cli scores "llama-70b"  # Detailed scoring breakdown
+ai-model-explorer-cli system
+ai-model-explorer-cli search "llama" -n 5
+ai-model-explorer-cli fit --perfect -n 5
+ai-model-explorer-cli recommend -u coding
+ai-model-explorer-cli recommend -u coding --json
+ai-model-explorer-cli plan "llama-3-8b"
+ai-model-explorer-cli scores "llama-70b"
 ```
 
-### REST API Server
+### REST API
 
 ```bash
-python -m api_server              # Start on localhost:8787
-python -m api_server --port 9000  # Custom port
+python -m api_server
+python -m api_server --port 9000
 ```
 
 ## Configuration
@@ -126,17 +174,17 @@ python -m api_server --port 9000  # Custom port
 
 | Variable | Default | Description |
 |---|---|---|
-| `AIMODEL_HF_TOKEN` | - | Canonical Hugging Face read-only token setting; standard `HF_TOKEN` is accepted as a fallback |
-| `AIMODEL_HF_MODELS_DIR` | OS-specific user-data `models/` directory | Hugging Face GGUF download directory |
-| `AIMODEL_DOWNLOAD_SERVICE_HOST` | `127.0.0.1` | Download-service bind/client host; non-loopback values are rejected until TLS transport is implemented |
-| `AIMODEL_DOWNLOAD_SERVICE_PORT` | `8765` | Download-service bind/client port |
-| `AIMODEL_DOWNLOAD_SERVICE_TOKEN` | - | Optional bearer token protecting download-service endpoints except `/health`; intended as loopback defence-in-depth |
-| `AIMODEL_DOWNLOAD_MAX_WORKERS` | 2 | Parallel download worker count |
-| `AIMODEL_HF_SEARCH_LIMIT` | 15 | HF results per page |
-| `AIMODEL_HF_SEARCH_MAX_PAGES` | 10 | Max HF pages |
-| `AIMODEL_OLLAMA_API_BASE` | `http://localhost:11434` | Ollama API base URL |
-| `AIMODEL_UI_MODE` | `compact` | UI density: `compact` or `comfortable` |
-| `AIMODEL_THEME` | `default` | Color theme: `default`, `dracula`, `nord`, `solarized`, `monokai` |
+| `AIMODEL_HF_TOKEN` | - | Canonical Hugging Face read-only token; standard `HF_TOKEN` is accepted as fallback |
+| `AIMODEL_HF_MODELS_DIR` | OS-specific user-data `models/` | Hugging Face model download directory |
+| `AIMODEL_DOWNLOAD_SERVICE_HOST` | `127.0.0.1` | Download-service bind/client host; non-loopback hosts are rejected |
+| `AIMODEL_DOWNLOAD_SERVICE_PORT` | `8765` | Download-service port |
+| `AIMODEL_DOWNLOAD_SERVICE_TOKEN` | - | Optional bearer token for download-service endpoints except `/health` |
+| `AIMODEL_DOWNLOAD_MAX_WORKERS` | `2` | Parallel download worker count |
+| `AIMODEL_HF_SEARCH_LIMIT` | `15` | Hugging Face results per page |
+| `AIMODEL_HF_SEARCH_MAX_PAGES` | `10` | Maximum Hugging Face pages |
+| `AIMODEL_OLLAMA_API_BASE` | `http://localhost:11434` | Ollama local API base |
+| `AIMODEL_UI_MODE` | `compact` | `compact` or `comfortable` |
+| `AIMODEL_THEME` | `default` | Color theme |
 | `LMSTUDIO_HOST` | `http://localhost:1234` | LM Studio API address |
 | `DOCKER_MODEL_RUNNER_HOST` | `http://localhost:12434` | Docker Model Runner API address |
 
@@ -144,7 +192,7 @@ python -m api_server --port 9000  # Custom port
 
 ```env
 AIMODEL_HF_TOKEN=hf_your_token_here
-# HF_TOKEN=hf_your_token_here  # Supported fallback for Hugging Face tooling compatibility
+# HF_TOKEN=hf_your_token_here
 # AIMODEL_HF_MODELS_DIR=/custom/path/models
 # AIMODEL_DOWNLOAD_SERVICE_TOKEN=replace-with-a-long-random-secret
 AIMODEL_UI_MODE=compact
@@ -154,56 +202,51 @@ AIMODEL_THEME=nord
 ## Keyboard Shortcuts
 
 | Key | Action |
-| --- | --- |
+|---|---|
 | `/` | Focus search |
 | `r` | Refresh current search |
 | `p` | Cycle provider filter |
-| `[` | Previous page (HF) |
-| `]` | Next page (HF) |
+| `[` | Previous page (Hugging Face) |
+| `]` | Next page (Hugging Face) |
 | `u` | Cycle use-case filter |
-| `s` | Cycle sort mode (composite, speed, quality, name, downloads) |
+| `s` | Cycle sort mode |
 | `f` | Cycle fit filter |
-| `P` | Open plan mode (hardware analysis for selected model) |
-| `c` | Toggle selected model into comparison set |
-| `C` | Show comparison modal (need 2+ models) |
+| `P` | Open plan mode |
+| `c` | Toggle selected model in comparison set |
+| `C` | Show comparison modal (2+ models) |
 | `v` | Toggle compact/comfortable view |
-| `h` | Toggle hidden gems filter |
-| `t` | Cycle color theme |
+| `h` | Toggle hidden-gems filter |
+| `t` | Cycle theme |
 | `q` | Quit |
 
 ## Project Structure
 
 ```text
 llm-terminal/
-  tui_app.py                # Main Textual TUI application
-  main.py                   # Entry point
-  cli.py                    # CLI commands (system, search, fit, recommend, plan, scores)
-  api_server.py             # REST API server (port 8787)
-  config.py                 # Pydantic-settings configuration
-  app/                      # Modular screens, widgets, download manager, search constants
-  core/                     # Shared cache, hardware, logging, model metadata, scoring, and helpers
-  requirements/            # Runtime/dev intent + committed platform locks
-  downloads/               # Download state, lifecycle, command builder, service client, HF downloader
-  results/                 # Table layout, formatting, filtering helpers
-  search/                   # Search cache and provider orchestration
-  scripts/                 # Dev, release, and maintenance utilities (Python + batch)
-  terminal_ui/             # Theme/style assets plus isolated legacy UI internals
-  providers/
-    __init__.py             # BaseProvider ABC + provider registry
-    ollama_provider.py      # Ollama registry search (HTML scraping)
-    hf_provider.py          # Hugging Face API search + download
-    lmstudio_provider.py    # LM Studio local server integration
-    docker_provider.py      # Docker Model Runner integration
-    mlx_provider.py         # Apple Silicon MLX cache integration
-  tests/                    # Test suite (370+ tests)
+  main.py                   # Primary TUI entry point
+  app/viewer.py             # Runtime AIModelViewer/provider selector
+  tui_app.py                # Base Textual application
+  cli.py                    # Click CLI
+  api_server.py             # Local REST API
+  config.py                 # Pydantic settings
+  app/                      # Modals, widgets, TUI state/download support
+  core/                     # Hardware, scoring, cache, HTTP, errors, intelligence
+  providers/                # Provider implementations + capabilities
+  search/                   # Search cache/orchestration/cancellation/pagination
+  results/                  # Result layout/presentation/filtering
+  downloads/                # Download service, API, store, runner, client/helpers
+  requirements/             # Dependency intent + committed platform locks
+  scripts/                  # Dev/release/maintenance tools
+  terminal_ui/              # Theme/style assets and isolated legacy internals
+  tests/                    # 600+ deterministic tests + optional live tests
+  docs/                     # Maintained project/process documentation
+  .planning/                # Active roadmap and current codebase baseline
 ```
 
 ## Scoring System
 
-The scoring engine evaluates models on 4 dimensions, then computes a use-case-weighted composite:
-
 | Use Case | Quality | Speed | Fit | Context |
-|---|---|---|---|---|
+|---|---:|---:|---:|---:|
 | Chat | 0.25 | 0.35 | 0.25 | 0.15 |
 | Coding | 0.35 | 0.30 | 0.20 | 0.15 |
 | Reasoning | 0.55 | 0.15 | 0.15 | 0.15 |
@@ -212,15 +255,33 @@ The scoring engine evaluates models on 4 dimensions, then computes a use-case-we
 | Embedding | 0.30 | 0.40 | 0.20 | 0.10 |
 | General | 0.30 | 0.25 | 0.25 | 0.20 |
 
-**Speed formula**: `tok/s = (GPU_bandwidth_GB/s / model_size_GB) × efficiency_factor`
+Speed approximation:
 
-Where efficiency depends on inference mode: GPU (0.55), GPU+CPU offload (0.30), CPU-only (0.18).
+```text
+tok/s = (GPU bandwidth GB/s / model size GB) × efficiency factor
+```
+
+Inference mode influences the efficiency factor (GPU, GPU+CPU offload, CPU-only).
+
+## Development Roadmap
+
+The active post-hardening roadmap is in `.planning/roadmap.md`.
+
+Current priorities:
+
+1. measured + CI-enforced coverage growth to 60 in stages,
+2. residual silent-failure audit,
+3. Ollama registry parser resilience and structured-source research,
+4. safer incremental TUI DataTable updates,
+5. explicit Windows/WSL/Linux/macOS Apple Silicon acceptance matrix.
+
+Documentation maintenance rules are in `docs/maintenance.md`.
 
 ## Notes
 
-- `terminal_ui/` now exists mainly for theme/style assets; the legacy experimental UI remains isolated there.
-- Download service data and metadata cache are stored in the OS-specific per-user application data directory by default; `AIMODEL_DOWNLOAD_DB_PATH` and `AIMODEL_CACHE_DB_PATH` can override those paths.
-- Hugging Face GGUF files are stored in the same per-user application data directory under `models/` by default; `AIMODEL_HF_MODELS_DIR` can override the destination.
-- Download service remains loopback-only. `0.0.0.0`, LAN addresses, and other non-loopback bind/client hosts are rejected until authenticated TLS transport is implemented. `/health` stays public for probes; when `AIMODEL_DOWNLOAD_SERVICE_TOKEN` is configured, job, debug, cancellation, deletion, and shutdown endpoints require the bearer token on loopback.
-- REST API binds to `127.0.0.1:8787` by default (localhost only).
-- Provider auto-detection runs at startup; unavailable providers are silently skipped.
+- `terminal_ui/` is not the primary application entry point; it mainly contains theme/style assets plus isolated legacy internals.
+- Runtime databases, logs and Hugging Face model files use OS-specific per-user application-data locations by default; configuration can override them.
+- The download service remains loopback-only. LAN/public transport is intentionally rejected until an authenticated TLS design exists.
+- REST API binds to `127.0.0.1:8787` by default and is intended for local use.
+- Optional provider detection failures are contained so unavailable local runtimes do not prevent other providers from working.
+- Ollama remote discovery still depends on `ollama.com` HTML structure; parser resilience is an active roadmap priority.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -92,12 +92,14 @@ Files under `.planning/codebase/` are current-state references, not historical m
 
 ## Merge Evidence Rule
 
-Documentation changes follow the same merge discipline as code:
+Documentation changes follow the same revision-bound merge discipline as code:
 
-- exact PR head SHA,
-- current CI + Package success for that head,
-- no unresolved blocking review thread,
-- squash merge with expected head SHA.
+- confirm the exact PR head SHA,
+- require current CI success for that head,
+- require every workflow applicable to the changed paths,
+- require Package success when the path-filtered Package workflow is triggered; documentation-only PRs do not require a Package run that is not scheduled,
+- confirm there is no unresolved blocking review thread,
+- squash merge with the expected head SHA.
 
 A new commit invalidates prior exact-head green evidence.
 
@@ -107,6 +109,6 @@ A work item is complete when:
 
 1. implementation/behavior is correct,
 2. focused tests pin the contract where applicable,
-3. exact-head verification is green,
+3. exact-head applicable verification is green,
 4. relevant documentation has been reviewed and updated if stale,
 5. linked issue/roadmap state reflects the merged result.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,112 @@
+# Documentation Maintenance
+
+**Effective:** 2026-09-07
+
+Documentation is part of the repository's definition of done. A successful code merge should not leave a known active document materially false.
+
+## Post-Merge Documentation Check
+
+After every successful merge, review whether the change affected any of these surfaces:
+
+| Change type | Documents to review |
+|---|---|
+| User-visible behavior, commands, configuration | `README.md`, `CHANGELOG.md` |
+| New/changed roadmap priority or completed milestone | `.planning/roadmap.md` |
+| Component boundaries, ownership, data flow | `.planning/codebase/ARCHITECTURE.md`, `STRUCTURE.md` |
+| Dependencies, Python/platform support, CI/tooling | `.planning/codebase/STACK.md`, `TESTING.md` |
+| Provider/API/service/storage/auth integration | `.planning/codebase/INTEGRATIONS.md` |
+| New risk, removed risk, resolved technical debt | `.planning/codebase/CONCERNS.md` |
+| Development/merge/documentation process | this file |
+
+Not every merge needs every document changed. The requirement is to **review the relevant documents and update only those that became stale**.
+
+## Preferred Timing
+
+### Same PR
+
+Update documentation in the implementation PR when:
+
+- the required wording is deterministic from the code change,
+- README/config examples change,
+- a roadmap item is completed,
+- an architecture/integration contract changes,
+- the update does not obscure code review.
+
+### Immediate follow-up docs PR
+
+Use a separate narrow docs PR when:
+
+- the implementation PR is already merged,
+- a larger baseline rewrite is required,
+- documentation needs synthesis across several recently merged PRs.
+
+Open and complete that docs follow-up **before starting unrelated feature work** when the stale documentation could mislead future development decisions.
+
+## Roadmap Rules
+
+`.planning/roadmap.md` contains active work plus a short completed-baseline summary.
+
+When a roadmap task merges successfully:
+
+1. remove it from active work or mark the next concrete sub-step,
+2. add it to Completed Baseline only when that summary materially helps prevent re-planning,
+3. do not leave completed work presented as an active TODO,
+4. do not add speculative work without a concrete user/product/quality reason.
+
+## CHANGELOG Rules
+
+Use `CHANGELOG.md` for release-significant behavior, not every internal refactor.
+
+Include changes that affect:
+
+- user-visible behavior,
+- public CLI/REST/config contracts,
+- provider support/reliability,
+- security boundaries,
+- platform/package support,
+- major performance/resilience behavior.
+
+Pure test/doc/internal refactors normally do not need a standalone changelog bullet unless they materially change release confidence or maintenance expectations.
+
+## README Rules
+
+`README.md` is user-facing. Keep it focused on:
+
+- what the product does,
+- supported surfaces/providers,
+- installation/run/configuration,
+- important behavior such as provider scope and diagnostics,
+- links to deeper developer docs.
+
+Do not turn README into an internal architecture diary.
+
+## Codebase Baseline Rules
+
+Files under `.planning/codebase/` are current-state references, not historical mapper output.
+
+- Avoid volatile line counts unless they are necessary.
+- Prefer component names/contracts over line-number references.
+- Remove resolved concerns rather than leaving them as ambiguous historical TODOs.
+- Keep verified remaining risks in `CONCERNS.md`.
+- If a statement cannot be verified from current source/config/CI evidence, omit or qualify it.
+
+## Merge Evidence Rule
+
+Documentation changes follow the same merge discipline as code:
+
+- exact PR head SHA,
+- current CI + Package success for that head,
+- no unresolved blocking review thread,
+- squash merge with expected head SHA.
+
+A new commit invalidates prior exact-head green evidence.
+
+## Definition of Done
+
+A work item is complete when:
+
+1. implementation/behavior is correct,
+2. focused tests pin the contract where applicable,
+3. exact-head verification is green,
+4. relevant documentation has been reviewed and updated if stale,
+5. linked issue/roadmap state reflects the merged result.


### PR DESCRIPTION
Closes #64

## Problem

The repository's active planning/codebase documents still described the 2026-06-09 architecture and repeated already-resolved findings such as the old root `app.py` monolith, sequential provider search, single-worker downloads, missing connection pooling/cancellation/structured errors, old coverage/test counts, and missing CI.

## Scope

This PR refreshes the documentation baseline at post-#63 `main` (`f371cbf357731db729345d1cd29bc663bfb6edf7`) without changing production/test/config code.

Updated:

- `.planning/roadmap.md`
- `.planning/codebase/ARCHITECTURE.md`
- `.planning/codebase/STRUCTURE.md`
- `.planning/codebase/STACK.md`
- `.planning/codebase/TESTING.md`
- `.planning/codebase/INTEGRATIONS.md`
- `.planning/codebase/CONCERNS.md`
- `README.md`
- `CHANGELOG.md`

Added:

- `docs/maintenance.md`

## New active roadmap

1. measured coverage baseline + CI-enforced staged target 50 -> 55 -> 60
2. residual silent-failure audit
3. Ollama registry fixture/parser resilience + structured-source research
4. measured/incremental TUI DataTable updates
5. Windows/WSL/Linux/macOS Apple Silicon acceptance matrix
6. lower-priority provider/runtime edge cases after the P1/P2 baseline

## Evidence used for the refresh

- current main/search/provider/download source at exact baseline revision
- CI workflow matrix: Ubuntu + Windows, Python 3.12 + 3.14
- latest PR #63 verify lane: 603 passing tests on Ubuntu/Python 3.12
- current `pyproject.toml`: `fail_under = 45`, while `scripts/dev.py verify` does not currently enforce coverage
- current TUI stale-cache fallback, shared provider HTTP session/retries, parallel SearchOrchestrator, structured diagnostics, bounded download workers, REST/CLI diagnostic surfaces
- Package workflow path filters: docs-only PRs do not schedule Package; package-relevant changes still require its exact-head success when triggered

## Documentation policy

`docs/maintenance.md` makes documentation review part of definition-of-done after every successful merge. Relevant README/CHANGELOG/roadmap/codebase docs should be updated in the same PR when practical; otherwise an immediate narrow docs follow-up should happen before unrelated feature work.

## Self-review

- branch is based exactly on post-#63 `main`
- 10 documentation files changed; no production, test, workflow, dependency, or config file changed
- historical CHANGELOG entries remain historical; active baseline docs no longer present resolved work as TODO/current concern
- README now documents current provider diagnostics, REST/CLI scope, stale-cache behavior, test scale, and active roadmap without claiming every surface supports all five providers
- merge policy now distinguishes always-running CI from the path-filtered Package workflow rather than requiring a nonexistent Package run for docs-only changes

## Acceptance

- active baseline docs no longer describe the obsolete 2026-06-09 architecture as current
- completed hardening is separated from active roadmap work
- current quality/CI/provider/download/error contracts are accurately represented
- documentation sync rule is explicit
- CI and every workflow applicable to the changed paths must pass on the exact head; Package is required when its path-filtered workflow is triggered