### PR TITLE
ci: establish measured coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,39 @@ jobs:
           path: verify.log
           if-no-files-found: ignore
 
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install lock tooling
+        run: |
+          python -m pip install --upgrade pip "pip-tools==7.5.3"
+
+      - name: Bootstrap environment
+        run: python scripts/dev.py bootstrap
+
+      - name: Measure coverage baseline
+        shell: bash
+        run: |
+          set -o pipefail
+          python scripts/dev.py coverage --fail-under 0 2>&1 | tee coverage.log
+
+      - name: Upload coverage logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-logs-ubuntu-py3.12
+          path: coverage.log
+          if-no-files-found: ignore
+
   smoke:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,11 @@ jobs:
       - name: Bootstrap environment
         run: python scripts/dev.py bootstrap
 
-      - name: Measure coverage baseline
+      - name: Run coverage gate
         shell: bash
         run: |
           set -o pipefail
-          python scripts/dev.py coverage --fail-under 0 2>&1 | tee coverage.log
+          python scripts/dev.py coverage 2>&1 | tee coverage.log
 
       - name: Upload coverage logs
         if: failure()

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,9 +1,9 @@
 # Codebase Concerns
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`
+**Baseline revision:** `5dd4014ef2a50ba14210da0d7b3bf675281c8586`
 
-This file lists **current, verified concerns**. It intentionally removes old mapper findings that have already been addressed, including the root `app.py` monolith claim, missing connection pooling, sequential provider search, single-worker downloads, missing search cancellation, missing REST validation, and missing structured errors.
+This file lists **current, verified concerns**. Resolved mapper findings are retained only in the historical summary so completed work is not accidentally re-planned.
 
 ## Priority 1
 
@@ -30,23 +30,38 @@ Remote Ollama discovery still fetches `ollama.com/search`/library HTML and parse
 2. structural-failure detection/diagnostics,
 3. research a supported structured registry/search source before considering migration.
 
-### 2. Coverage policy is configured but not enforced by the normal verify lane
+### 2. Aggregate coverage is healthy but uneven across high-risk modules
 
-**Area:** `pyproject.toml`, `scripts/dev.py`, CI
+**Area:** TUI, download execution/client paths, platform hardware probes
 
-`fail_under = 45` exists, but `scripts/dev.py verify` currently runs pytest/import smoke/Ruff without a coverage-enforced pytest invocation.
+A canonical Ubuntu/Python 3.12 coverage run measured **63% total coverage** (`5043` statements, `1841` missed). CI now enforces an initial **50%** floor through `python scripts/dev.py coverage`.
+
+The aggregate can still hide concentrated risk. Measured examples:
+
+- `downloads/runner.py` — 24%,
+- `app/modals.py` — 25%,
+- `app/viewer.py` — 35%,
+- `tui_app.py` — 38%,
+- `core/hardware.py` — 44%,
+- `downloads/api.py` / `downloads/service_client.py` — 46%.
 
 **Risk:**
 
-- the configured threshold can be mistaken for a real CI gate,
-- large changes can reduce coverage without the merge gate noticing,
-- the existing 600+ tests are broad but do not guarantee high-risk application boundaries are sufficiently covered.
+- aggregate coverage can remain green while consequential UI/process/platform branches are weakly exercised,
+- future changes in low-coverage modules can regress without a focused contract test.
+
+**Current mitigation:**
+
+- 50% exact-head aggregate gate,
+- 600+ deterministic tests,
+- separate verify/smoke matrices,
+- regression-test requirement for correctness fixes.
 
 **Next work:**
 
-- measure a reproducible baseline,
-- add focused high-risk tests,
-- enforce staged CI thresholds 50 → 55 → 60.
+- target consequential uncovered paths in the modules above,
+- ratchet the enforced floor to 55%, then 60%,
+- do not inflate coverage by excluding meaningful production modules or weakening assertions.
 
 ### 3. TUI result refresh still performs full table rebuilds in important paths
 
@@ -100,7 +115,8 @@ Project metadata supports Python 3.10-3.14 and integrations span Windows/Linux/m
 
 - Ubuntu + Windows,
 - Python 3.12 + 3.14,
-- offline-safe verify/smoke behavior.
+- offline-safe verify/smoke behavior,
+- canonical aggregate coverage on Ubuntu/Python 3.12.
 
 Hosted CI does not prove:
 
@@ -183,6 +199,7 @@ The following old concerns are retained here only to prevent accidental re-plann
 - **GPU bandwidth repeated linear scan:** resolved by pre-built lookup maps.
 - **No REST input validation:** core model-search/plan inputs now validate to 400 responses.
 - **Provider failures hidden in REST/CLI:** resolved with REST diagnostics and CLI stderr warnings.
+- **Coverage configured but not enforced:** resolved by a canonical Ubuntu/Python 3.12 CI coverage job; first enforced floor is 50% against a measured 63% baseline.
 - **Legacy `shell=True` finding:** no active source match; old planning reference removed from current concerns.
 
 ## Maintenance Rule

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,7 +1,7 @@
 # Technology Stack
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`
+**Baseline revision:** `5dd4014ef2a50ba14210da0d7b3bf675281c8586`
 
 ## Runtime
 
@@ -87,6 +87,7 @@ Canonical workflow:
 ```bash
 python scripts/dev.py bootstrap
 python scripts/dev.py verify
+python scripts/dev.py coverage
 python scripts/dev.py smoke
 ```
 
@@ -94,28 +95,44 @@ python scripts/dev.py smoke
 
 ### Verification
 
-- **pytest** — main test runner.
+- **pytest** — main deterministic test runner.
+- **pytest-cov / coverage.py** — canonical aggregate coverage measurement and merge gate.
 - **Ruff** — lint/import/static style checks.
 - **Mypy** — configured, non-strict static typing; not the primary merge gate.
-- **coverage / pytest-cov** — available in dev locks.
 
-The current verify lane contains **600+ tests** (603 observed on the 2026-09-07 PR #63 Ubuntu/Python 3.12 verify job).
+The verify suite contains **600+ tests**. Coverage is measured separately so the four-way cross-platform verify matrix is not burdened with redundant coverage execution.
 
-`pyproject.toml` currently sets `fail_under = 45`, but `scripts/dev.py verify` does not run a coverage-enforced lane. Establishing and enforcing a measured staged coverage target is active P1 roadmap work.
+Canonical coverage evidence from PR #67:
+
+- environment: Ubuntu / Python 3.12,
+- measured total: **63%**,
+- statements: `5043`,
+- missed: `1841`,
+- first enforced floor: **50%**.
+
+`pyproject.toml` is authoritative for the normal coverage threshold. The active quality roadmap ratchets the enforced floor to 55% and then 60% using focused tests around high-risk low-coverage modules.
 
 ## CI
 
-GitHub Actions `CI` workflow runs two independent matrices:
+GitHub Actions `CI` workflow contains:
 
-- verify,
-- smoke.
-
-Each matrix covers:
+### Verify matrix
 
 - `ubuntu-latest`,
 - `windows-latest`,
 - Python 3.12,
 - Python 3.14.
+
+### Canonical coverage job
+
+- `ubuntu-latest`,
+- Python 3.12,
+- `python scripts/dev.py coverage`,
+- threshold inherited from `pyproject.toml`.
+
+### Smoke matrix
+
+The same Ubuntu/Windows × Python 3.12/3.14 matrix runs bounded/offline-safe startup smoke checks.
 
 A separate `Package` workflow validates wheel build/install/entry points for package-relevant changes. It is path-filtered, so documentation-only PRs do not trigger it. When Package is applicable and triggered, it must be green on the exact PR head before merge.
 
@@ -129,6 +146,12 @@ A separate `Package` workflow validates wheel build/install/entry points for pac
 
 The active roadmap includes a clearer acceptance matrix for Windows, WSL/Linux, Linux native, and macOS Apple Silicon.
 
-## Known Stack Risk
+## Known Stack Risks
 
-The most important external-format risk is Ollama registry HTML scraping. BeautifulSoup itself is not the problem; the contract depends on a third-party page structure that can change without API-version guarantees. Parser fixture coverage and structural-failure detection are P1 roadmap work.
+### Uneven coverage distribution
+
+Aggregate coverage is 63%, but several consequential modules are much lower: `downloads/runner.py` 24%, `app/modals.py` 25%, `tui_app.py` 38%, `core/hardware.py` 44%, and download API/client paths around 46%. This is why the first enforced floor is 50% rather than immediately matching the aggregate baseline.
+
+### Ollama registry HTML dependency
+
+The most important external-format risk remains Ollama registry HTML scraping. BeautifulSoup itself is not the problem; the contract depends on a third-party page structure that can change without API-version guarantees. Parser fixture coverage and structural-failure detection are P1 roadmap work.

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,7 +1,7 @@
 # Testing and Verification
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`
+**Baseline revision:** `5dd4014ef2a50ba14210da0d7b3bf675281c8586`
 
 ## Test Framework
 
@@ -9,27 +9,54 @@
 - **Default test path:** `tests/`.
 - **Default pytest args:** `-q` via `pyproject.toml`.
 - **Live external tests:** opt-in with `--run-live`.
+- **Coverage:** pytest-cov / coverage.py.
 - **Mocking:** pytest `monkeypatch`, `unittest.mock`, small fake response/session/provider classes, and deterministic pure-function tests.
-
-The old 2026-06-09 document described 34 test files and little/no mocking. That is no longer representative.
 
 ## Normal Developer Commands
 
 ```bash
 python scripts/dev.py bootstrap
 python scripts/dev.py verify
+python scripts/dev.py coverage
 python scripts/dev.py smoke
 ```
 
 ### `verify`
 
-The required local verify lane currently runs:
+The required local verify lane runs:
 
 1. pytest,
 2. import smoke,
 3. Ruff checks.
 
-The latest baseline CI verify job observed **603 passing tests** on Ubuntu/Python 3.12 for PR #63.
+The latest baseline verify suite contains more than 600 deterministic tests.
+
+### `coverage`
+
+`python scripts/dev.py coverage` runs the same deterministic pytest suite under pytest-cov and enforces the threshold configured in `pyproject.toml`.
+
+Canonical CI coverage environment:
+
+- Ubuntu,
+- Python 3.12.
+
+Measured baseline from PR #67:
+
+- statements: `5043`,
+- missed: `1841`,
+- total coverage: **63%**.
+
+Current enforced merge floor:
+
+```toml
+[tool.coverage.report]
+show_missing = true
+fail_under = 50
+```
+
+The optional `--fail-under` argument exists for explicit measurement/debugging. `--fail-under 0` was used to establish the baseline and must not be used as a merge gate.
+
+The next planned ratchets are **55%** and **60%**, backed by focused tests rather than new exclusions.
 
 ### `smoke`
 
@@ -44,7 +71,9 @@ Smoke is not a replacement for the full unit/contract suite.
 
 ## CI Matrix
 
-GitHub Actions runs verify and smoke on:
+GitHub Actions `CI` contains three verification shapes:
+
+### Verify matrix
 
 | OS | Python |
 |---|---|
@@ -52,6 +81,20 @@ GitHub Actions runs verify and smoke on:
 | Ubuntu | 3.14 |
 | Windows | 3.12 |
 | Windows | 3.14 |
+
+### Coverage job
+
+A single canonical coverage job runs on Ubuntu/Python 3.12 and executes:
+
+```bash
+python scripts/dev.py coverage
+```
+
+Coverage is deliberately not repeated across all four verify environments. The purpose of the job is a stable aggregate merge floor, while the verify matrix continues to prove cross-platform/cross-version test compatibility.
+
+### Smoke matrix
+
+Smoke runs on the same Ubuntu/Windows × Python 3.12/3.14 matrix.
 
 For package-relevant changes, the path-filtered `Package` workflow also runs and must be green on the exact PR head. Documentation-only PRs do not trigger Package.
 
@@ -147,8 +190,6 @@ TUI testing is deliberately split:
 - `app/` manager/state tests,
 - focused Textual test-mode smoke/interaction tests for mounted behavior.
 
-The active roadmap prioritizes additional coverage at TUI application boundaries before raising the coverage gate.
-
 ### Live tests
 
 External live tests are skipped by default and enabled explicitly:
@@ -159,33 +200,23 @@ pytest --run-live
 
 Use live tests to validate actual external/provider behavior, not as a substitute for deterministic fixtures.
 
-## Coverage
+## Coverage Distribution and Next Targets
 
-Current config:
+The aggregate baseline is healthy enough to enforce a floor, but coverage is uneven. The measured PR #67 report identified high-value low-coverage areas:
 
-```toml
-[tool.coverage.report]
-show_missing = true
-fail_under = 45
-```
+| Module | Measured coverage |
+|---|---:|
+| `downloads/runner.py` | 24% |
+| `app/modals.py` | 25% |
+| `app/viewer.py` | 35% |
+| `tui_app.py` | 38% |
+| `core/hardware.py` | 44% |
+| `downloads/api.py` | 46% |
+| `downloads/service_client.py` | 46% |
 
-Important distinction: **45 is configured, but the normal `scripts/dev.py verify` lane does not currently run pytest under coverage, so this is not yet an enforced CI threshold.**
+Other critical seams are already materially higher, including provider parsing and search orchestration.
 
-Active quality plan:
-
-1. add a reproducible measured coverage lane,
-2. record the real baseline,
-3. add tests for high-risk uncovered paths,
-4. enforce staged thresholds: 50 → 55 → 60.
-
-Do not raise coverage by excluding meaningful production code or by weakening tests.
-
-Useful commands once measuring locally:
-
-```bash
-pytest --cov=. --cov-report=term-missing
-pytest --cov=. --cov-report=html
-```
+The 55%/60% ratchets should come from tests around consequential behavior in the low-coverage modules above. Do not raise coverage by excluding meaningful production code, counting tests as production source, or weakening assertions.
 
 ## Regression-Test Rule
 

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -39,31 +39,46 @@ The following items from the old roadmap are already implemented and should not 
 - CI verify + smoke matrices on Ubuntu and Windows with Python 3.12 and 3.14.
 - More than 600 deterministic tests in the current verify lane.
 - TUI stale-search-cache fallback for disconnected/offline search recovery.
+- Canonical coverage measurement lane on Ubuntu/Python 3.12 with a first enforced 50% gate.
 
 ## P1 — Quality Baseline
 
-### Q1. Establish a measured coverage baseline and enforce it in CI
+### Q1. Ratchet measured coverage from 50% to 60%
 
-Current state:
+Measured evidence from PR #67's baseline head:
 
-- `pyproject.toml` contains `fail_under = 45`.
-- The normal `scripts/dev.py verify` lane runs tests, import smoke, and Ruff; it does **not** currently enforce a coverage threshold.
+- canonical environment: Ubuntu / Python 3.12,
+- statements: `5043`,
+- missed: `1841`,
+- total measured coverage: **63%**,
+- first enforced CI threshold: **50%**.
 
-Plan:
+The repository now exposes the same lane locally with:
 
-1. Add a reproducible coverage command/lane without changing production behavior.
-2. Record the measured baseline on Linux/Python 3.12.
-3. Add focused tests for low-coverage, high-risk paths before changing the gate.
-4. Raise the enforced threshold in stages: **50 → 55 → 60**.
-5. Do not reach targets by excluding meaningful production modules or weakening assertions.
+```bash
+python scripts/dev.py coverage
+```
 
-Priority coverage targets:
+The CI coverage job is intentionally single-environment rather than duplicated across the full verify matrix. The normal command uses `pyproject.toml`'s configured threshold; `--fail-under 0` exists only for explicit baseline measurement and must not be used as the merge gate.
 
-- TUI search/application boundaries and state transitions.
-- Download service runner/store/cancellation/version-compatibility paths.
-- Provider error/parse/retry boundaries.
-- Platform-specific hardware detection fallbacks.
-- REST and CLI public contracts.
+Next stages:
+
+1. keep **50%** as the first stable enforced floor,
+2. add focused tests for high-risk low-coverage paths,
+3. ratchet to **55%** with exact-head evidence,
+4. ratchet to **60%** with exact-head evidence,
+5. do not reach targets by excluding meaningful production modules or weakening assertions.
+
+Priority coverage targets from the measured report:
+
+- `downloads/runner.py` — 24%,
+- `app/modals.py` — 25%,
+- `tui_app.py` — 38%,
+- `core/hardware.py` — 44%,
+- `downloads/api.py` / `downloads/service_client.py` — 46%,
+- CLI and other user-facing public contracts where uncovered paths are consequential.
+
+The aggregate already exceeds 60%; staged thresholds are deliberately lower than the observed baseline so coverage becomes a stable merge floor before being tightened around high-risk modules.
 
 ### Q2. Residual silent-failure audit
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ git clone https://github.com/kefyusuf/llm-terminal
 cd llm-terminal
 python scripts/dev.py bootstrap
 python scripts/dev.py verify
+python scripts/dev.py coverage
 python scripts/dev.py smoke
 ```
 
@@ -128,6 +129,8 @@ Use a supported Python 3.10-3.14 interpreter for bootstrap. On Windows that can 
 `scripts/dev.py bootstrap` creates or reuses `.venv` and installs from the committed platform-specific development lock file. Edit `requirements/requirements.in` and `requirements/requirements-dev.in` for dependency intent; bootstrap does not resolve or regenerate locks. Canonical lock maintenance remains explicit.
 
 `scripts/dev.py verify` runs the required local checks: pytest, import smoke and Ruff.
+
+`scripts/dev.py coverage` runs the deterministic pytest-cov lane and enforces the threshold configured in `pyproject.toml`. The canonical Ubuntu/Python 3.12 baseline measured **63% total coverage** (`5043` statements, `1841` missed); the first enforced merge floor is **50%**. The roadmap ratchets this floor to 55% and then 60% using focused tests rather than coverage exclusions.
 
 `scripts/dev.py smoke` runs bounded/offline-safe smoke checks for the CLI, REST API, TUI startup path and download service.
 
@@ -269,7 +272,7 @@ The active post-hardening roadmap is in `.planning/roadmap.md`.
 
 Current priorities:
 
-1. measured + CI-enforced coverage growth to 60 in stages,
+1. ratchet the enforced coverage floor from 50% to 55% and then 60% with focused high-risk tests,
 2. residual silent-failure audit,
 3. Ollama registry parser resilience and structured-source research,
 4. safer incremental TUI DataTable updates,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,4 +106,4 @@ omit = ["tests/*", "scripts/*"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 45
+fail_under = 50

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -245,11 +245,17 @@ def lock(*, check: bool = False) -> int:
     return 0
 
 
-def run_checked_step(step_name: str, command: list[str], root: Path) -> None:
+def run_checked_step(
+    step_name: str,
+    command: list[str],
+    root: Path,
+    *,
+    lane: str = "verify",
+) -> None:
     try:
         subprocess.run(command, check=True, cwd=root)
     except subprocess.CalledProcessError as exc:
-        raise SystemExit(f"[verify] {step_name} failed") from exc
+        raise SystemExit(f"[{lane}] {step_name} failed") from exc
 
 
 def verify() -> int:
@@ -267,6 +273,30 @@ def verify() -> int:
         root,
     )
     run_checked_step("ruff", [str(venv_python), "-m", "ruff", "check", "."], root)
+    return 0
+
+
+def coverage(*, fail_under: float | None = None) -> int:
+    """Run the deterministic pytest-cov lane through the project virtualenv."""
+    ensure_supported_python()
+    root = project_root()
+    venv_python = venv_python_path(root)
+
+    if not venv_python.exists():
+        raise SystemExit("[coverage] missing virtualenv; run python scripts/dev.py bootstrap first")
+
+    command = [
+        str(venv_python),
+        "-m",
+        "pytest",
+        "-q",
+        "--cov=.",
+        "--cov-report=term-missing",
+    ]
+    if fail_under is not None:
+        command.append(f"--cov-fail-under={fail_under:g}")
+
+    run_checked_step("pytest-cov", command, root, lane="coverage")
     return 0
 
 
@@ -371,6 +401,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     subparsers.add_parser("bootstrap", help="Create or reuse .venv and install the platform dev lock")
     subparsers.add_parser("verify", help="Run the project verify lane")
+    coverage_parser = subparsers.add_parser(
+        "coverage", help="Run pytest with coverage reporting and the configured coverage gate"
+    )
+    coverage_parser.add_argument(
+        "--fail-under",
+        type=float,
+        default=None,
+        metavar="PERCENT",
+        help="Override the configured coverage threshold (use 0 only for baseline measurement)",
+    )
     subparsers.add_parser("smoke", help="Run the project smoke lane")
     subparsers.add_parser("live", help="Run the live integration lane (pytest --run-live + release preflight)")
     lock_parser = subparsers.add_parser("lock", help="Manage committed lock files")
@@ -387,6 +427,8 @@ def main(argv: list[str] | None = None) -> int:
         return bootstrap()
     if args.command == "verify":
         return verify()
+    if args.command == "coverage":
+        return coverage(fail_under=args.fail_under)
     if args.command == "smoke":
         return smoke()
     if args.command == "live":

--- a/tests/test_dev_coverage.py
+++ b/tests/test_dev_coverage.py
@@ -1,0 +1,110 @@
+"""Regression coverage for the local/CI coverage development lane."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_dev_module():
+    """Load scripts/dev.py without requiring scripts to be a package."""
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "dev.py"
+    spec = importlib.util.spec_from_file_location("dev_coverage_script", module_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _windows_venv(tmp_path: Path) -> Path:
+    """Create the minimal virtualenv Python marker expected by dev.py tests."""
+    venv_python = tmp_path / ".venv" / "Scripts" / "python.exe"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("", encoding="utf-8")
+    return venv_python
+
+
+def test_coverage_runs_pytest_cov_with_explicit_baseline_override(tmp_path, monkeypatch):
+    """Baseline measurement should be able to override the configured gate to zero."""
+    dev = _load_dev_module()
+    venv_python = _windows_venv(tmp_path)
+    calls = []
+
+    def _fake_run(cmd, check, cwd, **kwargs):
+        calls.append((cmd, check, cwd, kwargs))
+
+    monkeypatch.setattr(dev, "project_root", lambda: tmp_path)
+    monkeypatch.setattr(dev.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(dev.subprocess, "run", _fake_run)
+
+    assert dev.coverage(fail_under=0) == 0
+    assert calls == [
+        (
+            [
+                str(venv_python),
+                "-m",
+                "pytest",
+                "-q",
+                "--cov=.",
+                "--cov-report=term-missing",
+                "--cov-fail-under=0",
+            ],
+            True,
+            tmp_path,
+            {},
+        )
+    ]
+
+
+def test_coverage_uses_project_threshold_when_override_is_omitted(tmp_path, monkeypatch):
+    """Normal local coverage runs should defer to pyproject.toml's fail_under value."""
+    dev = _load_dev_module()
+    venv_python = _windows_venv(tmp_path)
+    calls = []
+
+    def _fake_run(cmd, check, cwd, **kwargs):
+        calls.append(cmd)
+
+    monkeypatch.setattr(dev, "project_root", lambda: tmp_path)
+    monkeypatch.setattr(dev.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(dev.subprocess, "run", _fake_run)
+
+    assert dev.coverage() == 0
+    assert calls == [
+        [
+            str(venv_python),
+            "-m",
+            "pytest",
+            "-q",
+            "--cov=.",
+            "--cov-report=term-missing",
+        ]
+    ]
+
+
+def test_coverage_requires_bootstrapped_virtualenv(tmp_path, monkeypatch):
+    """Coverage should fail closed when the project virtualenv is missing."""
+    dev = _load_dev_module()
+    monkeypatch.setattr(dev, "project_root", lambda: tmp_path)
+    monkeypatch.setattr(dev.platform, "system", lambda: "Windows")
+
+    with pytest.raises(SystemExit, match=r"\[coverage\] missing virtualenv"):
+        dev.coverage()
+
+
+def test_main_forwards_coverage_threshold_override(monkeypatch):
+    """CLI parsing should pass an explicit coverage threshold to the lane."""
+    dev = _load_dev_module()
+    observed = []
+
+    def _fake_coverage(*, fail_under=None):
+        observed.append(fail_under)
+        return 0
+
+    monkeypatch.setattr(dev, "coverage", _fake_coverage)
+
+    assert dev.main(["coverage", "--fail-under", "50"]) == 0
+    assert observed == [50.0]


### PR DESCRIPTION
Closes #66

## Goal

Turn the repository's previously non-enforced coverage configuration into a measured, reproducible, exact-head CI gate.

## Measured baseline

The initial measurement-only head ran the canonical coverage lane on Ubuntu / Python 3.12 with `--fail-under 0` and produced:

- statements: `5043`
- missed: `1841`
- total coverage: **63%**

Important low-coverage areas from that report include:

- `downloads/runner.py` — 24%
- `app/modals.py` — 25%
- `app/viewer.py` — 35%
- `tui_app.py` — 38%
- `core/hardware.py` — 44%
- `downloads/api.py` / `downloads/service_client.py` — 46%

## Final state

- add `python scripts/dev.py coverage`
- keep optional `--fail-under PERCENT` for explicit baseline/debug measurement
- add focused regression tests for the new dev lane
- add one canonical coverage CI job on Ubuntu / Python 3.12
- change `pyproject.toml` from `fail_under = 45` to **`fail_under = 50`**
- remove the zero-threshold override from CI; final CI runs `python scripts/dev.py coverage`
- keep existing verify and smoke matrices unchanged
- synchronize README, roadmap, testing, stack, and concerns documentation

The first enforced floor is intentionally below the measured 63% aggregate. The next roadmap stages are 55% and 60%, reached with focused tests around consequential low-coverage paths rather than exclusions.

## Invariants

- no production behavior changes
- no production modules excluded to inflate coverage
- normal `verify` and `smoke` behavior stays unchanged
- one canonical coverage environment avoids redundant four-way coverage execution
- normal local `scripts/dev.py coverage` uses the `pyproject.toml` threshold
- `--fail-under 0` is measurement-only and is not present in the final CI gate

## Baseline revision

`5dd4014ef2a50ba14210da0d7b3bf675281c8586`

## Self-review

- branch remains based exactly on the post-#65 main baseline
- production application/provider/download behavior is untouched
- changed source is limited to development tooling, CI, coverage configuration, focused tests, and affected documentation
- aggregate coverage is measured rather than inferred
- documentation no longer claims coverage is configured-but-unenforced
- Package is applicable because `pyproject.toml` changed and must pass on the final exact head

## Merge acceptance

- exact final head must pass the full CI workflow, including the canonical 50% coverage job
- exact final head Package workflow must pass
- no unresolved blocking review thread
- squash merge with expected head SHA