### PR TITLE
test: harden download runner coverage and ratchet gate to 55

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,7 +1,7 @@
 # Codebase Concerns
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `5dd4014ef2a50ba14210da0d7b3bf675281c8586`
+**Baseline revision:** `9d9e23bf59ca5089e287c4e98b377935699fbe97`
 
 This file lists **current, verified concerns**. Resolved mapper findings are retained only in the historical summary so completed work is not accidentally re-planned.
 
@@ -32,13 +32,14 @@ Remote Ollama discovery still fetches `ollama.com/search`/library HTML and parse
 
 ### 2. Aggregate coverage is healthy but uneven across high-risk modules
 
-**Area:** TUI, download execution/client paths, platform hardware probes
+**Area:** TUI, download API/client paths, platform hardware probes
 
-A canonical Ubuntu/Python 3.12 coverage run measured **63% total coverage** (`5043` statements, `1841` missed). CI now enforces an initial **50%** floor through `python scripts/dev.py coverage`.
+The canonical Ubuntu/Python 3.12 coverage lane now measures **65.38% total coverage** (`5043` statements, `1746` missed) and enforces a **55%** floor.
 
-The aggregate can still hide concentrated risk. Measured examples:
+Focused fake-process/state tests have already removed one major weak point: `downloads/runner.py` increased from **24% to 90%** without production-code changes.
 
-- `downloads/runner.py` — 24%,
+Remaining measured examples:
+
 - `app/modals.py` — 25%,
 - `app/viewer.py` — 35%,
 - `tui_app.py` — 38%,
@@ -47,20 +48,21 @@ The aggregate can still hide concentrated risk. Measured examples:
 
 **Risk:**
 
-- aggregate coverage can remain green while consequential UI/process/platform branches are weakly exercised,
+- aggregate coverage can remain green while consequential UI/platform/client branches are weakly exercised,
 - future changes in low-coverage modules can regress without a focused contract test.
 
 **Current mitigation:**
 
-- 50% exact-head aggregate gate,
+- 55% exact-head aggregate gate,
 - 600+ deterministic tests,
 - separate verify/smoke matrices,
+- high coverage on provider/search/store/runner seams,
 - regression-test requirement for correctness fixes.
 
 **Next work:**
 
-- target consequential uncovered paths in the modules above,
-- ratchet the enforced floor to 55%, then 60%,
+- target consequential uncovered paths in one or more remaining weak modules,
+- ratchet the enforced floor to 60%,
 - do not inflate coverage by excluding meaningful production modules or weakening assertions.
 
 ### 3. TUI result refresh still performs full table rebuilds in important paths
@@ -199,7 +201,8 @@ The following old concerns are retained here only to prevent accidental re-plann
 - **GPU bandwidth repeated linear scan:** resolved by pre-built lookup maps.
 - **No REST input validation:** core model-search/plan inputs now validate to 400 responses.
 - **Provider failures hidden in REST/CLI:** resolved with REST diagnostics and CLI stderr warnings.
-- **Coverage configured but not enforced:** resolved by a canonical Ubuntu/Python 3.12 CI coverage job; first enforced floor is 50% against a measured 63% baseline.
+- **Coverage configured but not enforced:** resolved by a canonical Ubuntu/Python 3.12 CI coverage job.
+- **Download runner execution largely untested:** resolved with deterministic fake-process/state coverage raising `downloads/runner.py` from 24% to 90%.
 - **Legacy `shell=True` finding:** no active source match; old planning reference removed from current concerns.
 
 ## Maintenance Rule

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,7 +1,7 @@
 # Technology Stack
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `5dd4014ef2a50ba14210da0d7b3bf675281c8586`
+**Baseline revision:** `9d9e23bf59ca5089e287c4e98b377935699fbe97`
 
 ## Runtime
 
@@ -102,15 +102,16 @@ python scripts/dev.py smoke
 
 The verify suite contains **600+ tests**. Coverage is measured separately so the four-way cross-platform verify matrix is not burdened with redundant coverage execution.
 
-Canonical coverage evidence from PR #67:
+Canonical coverage evidence from PR #69:
 
 - environment: Ubuntu / Python 3.12,
-- measured total: **63%**,
+- measured total: **65.38%**,
 - statements: `5043`,
-- missed: `1841`,
-- first enforced floor: **50%**.
+- missed: `1746`,
+- enforced floor: **55%**,
+- `downloads/runner.py`: **90%**, up from 24% through fake-process/state execution tests.
 
-`pyproject.toml` is authoritative for the normal coverage threshold. The active quality roadmap ratchets the enforced floor to 55% and then 60% using focused tests around high-risk low-coverage modules.
+`pyproject.toml` is authoritative for the normal coverage threshold. The active quality roadmap has one remaining aggregate ratchet: 55% → 60%, backed by focused tests around another consequential weak boundary.
 
 ## CI
 
@@ -150,7 +151,7 @@ The active roadmap includes a clearer acceptance matrix for Windows, WSL/Linux, 
 
 ### Uneven coverage distribution
 
-Aggregate coverage is 63%, but several consequential modules are much lower: `downloads/runner.py` 24%, `app/modals.py` 25%, `tui_app.py` 38%, `core/hardware.py` 44%, and download API/client paths around 46%. This is why the first enforced floor is 50% rather than immediately matching the aggregate baseline.
+Aggregate coverage is now 65.38% and `downloads/runner.py` is 90%, but several consequential modules remain much lower: `app/modals.py` 25%, `app/viewer.py` 35%, `tui_app.py` 38%, `core/hardware.py` 44%, and download API/client paths around 46%. These are better targets for the final 60% ratchet than further broad aggregate-only changes.
 
 ### Ollama registry HTML dependency
 

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,7 +1,7 @@
 # Testing and Verification
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `5dd4014ef2a50ba14210da0d7b3bf675281c8586`
+**Baseline revision:** `9d9e23bf59ca5089e287c4e98b377935699fbe97`
 
 ## Test Framework
 
@@ -10,7 +10,7 @@
 - **Default pytest args:** `-q` via `pyproject.toml`.
 - **Live external tests:** opt-in with `--run-live`.
 - **Coverage:** pytest-cov / coverage.py.
-- **Mocking:** pytest `monkeypatch`, `unittest.mock`, small fake response/session/provider classes, and deterministic pure-function tests.
+- **Mocking:** pytest `monkeypatch`, `unittest.mock`, small fake response/session/provider/process/state classes, and deterministic pure-function tests.
 
 ## Normal Developer Commands
 
@@ -29,7 +29,7 @@ The required local verify lane runs:
 2. import smoke,
 3. Ruff checks.
 
-The latest baseline verify suite contains more than 600 deterministic tests.
+The verify suite contains more than 600 deterministic tests.
 
 ### `coverage`
 
@@ -40,23 +40,24 @@ Canonical CI coverage environment:
 - Ubuntu,
 - Python 3.12.
 
-Measured baseline from PR #67:
+Current measured evidence from PR #69:
 
 - statements: `5043`,
-- missed: `1841`,
-- total coverage: **63%**.
+- missed: `1746`,
+- total coverage: **65.38%**,
+- `downloads/runner.py`: **90%** after focused fake-process/state execution tests.
 
 Current enforced merge floor:
 
 ```toml
 [tool.coverage.report]
 show_missing = true
-fail_under = 50
+fail_under = 55
 ```
 
-The optional `--fail-under` argument exists for explicit measurement/debugging. `--fail-under 0` was used to establish the baseline and must not be used as a merge gate.
+The optional `--fail-under` argument exists for explicit measurement/debugging. `--fail-under 0` was used only to establish the original baseline and must not be used as a merge gate.
 
-The next planned ratchets are **55%** and **60%**, backed by focused tests rather than new exclusions.
+The remaining planned aggregate ratchet is **60%**, backed by focused tests rather than new exclusions.
 
 ### `smoke`
 
@@ -180,7 +181,17 @@ Cover store/state/lifecycle/client/runner behavior including:
 - command execution helpers,
 - debug/status behavior,
 - concurrent worker/store paths,
-- service compatibility and client behavior.
+- service compatibility and client behavior,
+- runner terminal states and subprocess cancellation behavior through deterministic fake processes.
+
+`tests/test_downloads_runner_execution.py` deliberately avoids spawning real subprocesses. It pins:
+
+- Hugging Face payload validation,
+- running → completed/failed/cancelled transitions,
+- terminate → kill escalation,
+- streamed progress and idle heartbeat updates,
+- last-line failure details,
+- `process_job` dispatch and spawn-error containment.
 
 ### TUI tests
 
@@ -202,11 +213,12 @@ Use live tests to validate actual external/provider behavior, not as a substitut
 
 ## Coverage Distribution and Next Targets
 
-The aggregate baseline is healthy enough to enforce a floor, but coverage is uneven. The measured PR #67 report identified high-value low-coverage areas:
+Focused runner execution coverage removed one of the largest consequential gaps: `downloads/runner.py` increased from **24% to 90%** and aggregate coverage increased from 63.51% to **65.38%**.
+
+Remaining high-value low-coverage areas from the same canonical environment:
 
 | Module | Measured coverage |
 |---|---:|
-| `downloads/runner.py` | 24% |
 | `app/modals.py` | 25% |
 | `app/viewer.py` | 35% |
 | `tui_app.py` | 38% |
@@ -214,9 +226,9 @@ The aggregate baseline is healthy enough to enforce a floor, but coverage is une
 | `downloads/api.py` | 46% |
 | `downloads/service_client.py` | 46% |
 
-Other critical seams are already materially higher, including provider parsing and search orchestration.
+Other critical seams are materially higher, including provider parsing, search orchestration, download store, and download runner execution paths.
 
-The 55%/60% ratchets should come from tests around consequential behavior in the low-coverage modules above. Do not raise coverage by excluding meaningful production code, counting tests as production source, or weakening assertions.
+The final 60% ratchet should come from tests around consequential behavior in one or more remaining weak modules. Do not raise coverage by excluding meaningful production code, counting tests as production source, or weakening assertions.
 
 ## Regression-Test Rule
 

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -1,7 +1,7 @@
 # AI Model Explorer — Active Roadmap
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `f371cbf357731db729345d1cd29bc663bfb6edf7`  
+**Baseline revision:** `9d9e23bf59ca5089e287c4e98b377935699fbe97`  
 **Status:** post-hardening baseline; active roadmap only
 
 This roadmap replaces the 2026-06-09 mapper plan. Completed work stays documented here only as a baseline summary; it is not an active backlog.
@@ -39,21 +39,24 @@ The following items from the old roadmap are already implemented and should not 
 - CI verify + smoke matrices on Ubuntu and Windows with Python 3.12 and 3.14.
 - More than 600 deterministic tests in the current verify lane.
 - TUI stale-search-cache fallback for disconnected/offline search recovery.
-- Canonical coverage measurement lane on Ubuntu/Python 3.12 with a first enforced 50% gate.
+- Canonical coverage measurement lane on Ubuntu/Python 3.12.
+- First aggregate coverage gate at 50% against a measured 63.51% baseline.
+- Focused fake-process/state coverage for `downloads/runner.py`, raising that module from 24% to 90% and aggregate coverage to 65.38% while ratcheting the enforced floor to 55%.
 
 ## P1 — Quality Baseline
 
-### Q1. Ratchet measured coverage from 50% to 60%
+### Q1. Ratchet measured coverage from 55% to 60%
 
-Measured evidence from PR #67's baseline head:
+Current exact-head evidence from PR #69's focused runner-coverage head:
 
 - canonical environment: Ubuntu / Python 3.12,
 - statements: `5043`,
-- missed: `1841`,
-- total measured coverage: **63%**,
-- first enforced CI threshold: **50%**.
+- missed: `1746`,
+- total measured coverage: **65.38%**,
+- enforced CI threshold: **55%**,
+- `downloads/runner.py`: **90%** (up from 24%).
 
-The repository now exposes the same lane locally with:
+The repository exposes the same lane locally with:
 
 ```bash
 python scripts/dev.py coverage
@@ -61,24 +64,23 @@ python scripts/dev.py coverage
 
 The CI coverage job is intentionally single-environment rather than duplicated across the full verify matrix. The normal command uses `pyproject.toml`'s configured threshold; `--fail-under 0` exists only for explicit baseline measurement and must not be used as the merge gate.
 
-Next stages:
+Remaining stage:
 
-1. keep **50%** as the first stable enforced floor,
-2. add focused tests for high-risk low-coverage paths,
-3. ratchet to **55%** with exact-head evidence,
-4. ratchet to **60%** with exact-head evidence,
-5. do not reach targets by excluding meaningful production modules or weakening assertions.
+1. keep **55%** as the stable enforced floor,
+2. add focused tests for another consequential low-coverage boundary,
+3. ratchet to **60%** with exact-head evidence,
+4. do not reach the target by excluding meaningful production modules or weakening assertions.
 
-Priority coverage targets from the measured report:
+Priority coverage targets after the runner work:
 
-- `downloads/runner.py` — 24%,
 - `app/modals.py` — 25%,
+- `app/viewer.py` — 35%,
 - `tui_app.py` — 38%,
 - `core/hardware.py` — 44%,
 - `downloads/api.py` / `downloads/service_client.py` — 46%,
 - CLI and other user-facing public contracts where uncovered paths are consequential.
 
-The aggregate already exceeds 60%; staged thresholds are deliberately lower than the observed baseline so coverage becomes a stable merge floor before being tightened around high-risk modules.
+The aggregate already exceeds 60%; the 60% gate should still be preceded by focused tests so the ratchet represents stronger assurance around a weak boundary rather than merely copying the aggregate number.
 
 ### Q2. Residual silent-failure audit
 

--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ Use a supported Python 3.10-3.14 interpreter for bootstrap. On Windows that can 
 
 `scripts/dev.py verify` runs the required local checks: pytest, import smoke and Ruff.
 
-`scripts/dev.py coverage` runs the deterministic pytest-cov lane and enforces the threshold configured in `pyproject.toml`. The canonical Ubuntu/Python 3.12 baseline measured **63% total coverage** (`5043` statements, `1841` missed); the first enforced merge floor is **50%**. The roadmap ratchets this floor to 55% and then 60% using focused tests rather than coverage exclusions.
+`scripts/dev.py coverage` runs the deterministic pytest-cov lane and enforces the threshold configured in `pyproject.toml`. The canonical Ubuntu/Python 3.12 lane now measures **65.38% total coverage** (`5043` statements, `1746` missed) and enforces a **55%** merge floor. Focused fake-process/state tests raised `downloads/runner.py` from **24% to 90%** without changing production behavior. The remaining planned aggregate ratchet is 60%, reached through additional high-risk tests rather than coverage exclusions.
 
 `scripts/dev.py smoke` runs bounded/offline-safe smoke checks for the CLI, REST API, TUI startup path and download service.
 
-The current verify baseline contains **600+ tests** (603 observed in the 2026-09-07 PR #63 Ubuntu/Python 3.12 CI job).
+The current verify baseline contains **600+ tests**.
 
 ## Run
 
@@ -272,7 +272,7 @@ The active post-hardening roadmap is in `.planning/roadmap.md`.
 
 Current priorities:
 
-1. ratchet the enforced coverage floor from 50% to 55% and then 60% with focused high-risk tests,
+1. ratchet the enforced coverage floor from 55% to 60% with focused high-risk tests,
 2. residual silent-failure audit,
 3. Ollama registry parser resilience and structured-source research,
 4. safer incremental TUI DataTable updates,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,4 +106,4 @@ omit = ["tests/*", "scripts/*"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 50
+fail_under = 55

--- a/tests/test_downloads_runner_execution.py
+++ b/tests/test_downloads_runner_execution.py
@@ -10,8 +10,6 @@ import sys
 from io import StringIO
 from types import SimpleNamespace
 
-import pytest
-
 from downloads import runner
 
 

--- a/tests/test_downloads_runner_execution.py
+++ b/tests/test_downloads_runner_execution.py
@@ -1,0 +1,372 @@
+"""Deterministic execution-path tests for downloads.runner.
+
+These tests use fake process/state objects. They must not spawn real subprocesses,
+perform network requests, or write outside pytest temporary directories.
+"""
+
+from __future__ import annotations
+
+import sys
+from io import StringIO
+from types import SimpleNamespace
+
+import pytest
+
+from downloads import runner
+
+
+class _Store:
+    def __init__(self, *, command=None, cancel_values=None):
+        self.command = command
+        self.updates = []
+        self._cancel_values = list(cancel_values or [False])
+        self._cancel_index = 0
+
+    def update_job(self, target_id, **fields):
+        self.updates.append((target_id, fields))
+
+    def get_job_by_target(self, _target_id):
+        index = min(self._cancel_index, len(self._cancel_values) - 1)
+        value = self._cancel_values[index]
+        self._cancel_index += 1
+        return {"cancel_requested": value}
+
+    def get_command(self, _target_id):
+        return self.command
+
+
+class _State:
+    def __init__(self, store):
+        self.store = store
+        self.set_calls = []
+        self.clear_calls = []
+
+    def set_process(self, target_id, process):
+        self.set_calls.append((target_id, process))
+
+    def clear_process(self, target_id):
+        self.clear_calls.append(target_id)
+
+
+class _HFProcess:
+    def __init__(self, poll_values, *, stderr=""):
+        self._poll_values = list(poll_values)
+        self._poll_index = 0
+        self.stderr = StringIO(stderr)
+        self.terminate_calls = 0
+        self.kill_calls = 0
+
+    def poll(self):
+        index = min(self._poll_index, len(self._poll_values) - 1)
+        value = self._poll_values[index]
+        self._poll_index += 1
+        return value
+
+    def terminate(self):
+        self.terminate_calls += 1
+
+    def kill(self):
+        self.kill_calls += 1
+
+
+class _StreamProcess:
+    def __init__(self, lines, *, return_code=0):
+        self.stdout = list(lines) if lines is not None else None
+        self.return_code = return_code
+        self.terminate_calls = 0
+
+    def terminate(self):
+        self.terminate_calls += 1
+
+    def wait(self):
+        return self.return_code
+
+
+def _install_fake_config(monkeypatch, models_dir):
+    fake_config = SimpleNamespace(
+        settings=SimpleNamespace(
+            hf_models_dir=models_dir,
+            hf_token=None,
+        )
+    )
+    monkeypatch.setitem(sys.modules, "config", fake_config)
+
+
+def _last_update(store):
+    return store.updates[-1][1]
+
+
+def test_finalize_terminal_pins_completed_failed_and_cancelled_states():
+    store = _Store()
+    state = _State(store)
+
+    runner._finalize_terminal(state, "completed", 0, cancelled=False)
+    runner._finalize_terminal(state, "failed", 2, cancelled=False, last_line="fatal error")
+    runner._finalize_terminal(state, "cancelled", -15, cancelled=True)
+
+    assert store.updates == [
+        (
+            "completed",
+            {"status": "completed", "detail": "Completed", "progress": "", "return_code": 0},
+        ),
+        (
+            "failed",
+            {"status": "failed", "detail": "fatal error", "progress": "", "return_code": 2},
+        ),
+        (
+            "cancelled",
+            {"status": "cancelled", "detail": "Canceled", "progress": "", "return_code": -15},
+        ),
+    ]
+
+
+def test_hf_download_rejects_missing_repo_and_target_file(tmp_path, monkeypatch):
+    _install_fake_config(monkeypatch, tmp_path / "models")
+
+    missing_repo_store = _Store()
+    missing_repo_state = _State(missing_repo_store)
+    runner.run_hf_download(missing_repo_state, "hf:missing-repo", ["hf_api_download"])
+
+    assert _last_update(missing_repo_store) == {
+        "status": "failed",
+        "detail": "missing Hugging Face repository id",
+        "return_code": 1,
+    }
+    assert missing_repo_state.set_calls == []
+
+    missing_file_store = _Store()
+    missing_file_state = _State(missing_file_store)
+    runner.run_hf_download(
+        missing_file_state,
+        "hf:missing-file",
+        ["hf_api_download", "owner/repo"],
+    )
+
+    assert _last_update(missing_file_store) == {
+        "status": "failed",
+        "detail": "missing Hugging Face target file",
+        "return_code": 1,
+    }
+    assert missing_file_state.set_calls == []
+
+
+def test_hf_download_success_sets_running_then_completed(tmp_path, monkeypatch):
+    models_dir = tmp_path / "models"
+    _install_fake_config(monkeypatch, models_dir)
+    process = _HFProcess([None, 0])
+    store = _Store(cancel_values=[False])
+    state = _State(store)
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(runner.time, "sleep", lambda _seconds: None)
+
+    runner.run_hf_download(
+        state,
+        "hf:success",
+        ["hf_api_download", "owner/repo", "model.gguf"],
+    )
+
+    assert models_dir.is_dir()
+    assert store.updates[0][1] == {
+        "status": "running",
+        "detail": "Downloading",
+        "progress": "",
+    }
+    assert _last_update(store) == {
+        "status": "completed",
+        "detail": "Completed",
+        "progress": "",
+        "return_code": 0,
+    }
+    assert state.set_calls == [("hf:success", process)]
+    assert state.clear_calls == ["hf:success"]
+
+
+def test_hf_download_failure_uses_last_stderr_line(tmp_path, monkeypatch):
+    _install_fake_config(monkeypatch, tmp_path / "models")
+    process = _HFProcess([2], stderr="first line\nremote failed hard\n")
+    store = _Store(cancel_values=[False])
+    state = _State(store)
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *args, **kwargs: process)
+
+    runner.run_hf_download(
+        state,
+        "hf:failed",
+        ["hf_api_download", "owner/repo", "model.gguf"],
+    )
+
+    assert _last_update(store) == {
+        "status": "failed",
+        "detail": "remote failed hard",
+        "progress": "",
+        "return_code": 2,
+    }
+    assert state.clear_calls == ["hf:failed"]
+
+
+def test_hf_download_cancel_escalates_from_terminate_to_kill(tmp_path, monkeypatch):
+    _install_fake_config(monkeypatch, tmp_path / "models")
+    process = _HFProcess([None, None, -9])
+    store = _Store(cancel_values=[True])
+    state = _State(store)
+    monotonic_values = iter([10.0, 12.0])
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(runner.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(runner.time, "monotonic", lambda: next(monotonic_values))
+
+    runner.run_hf_download(
+        state,
+        "hf:cancel",
+        ["hf_api_download", "owner/repo", "model.gguf"],
+    )
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+    assert _last_update(store) == {
+        "status": "cancelled",
+        "detail": "Canceled",
+        "progress": "",
+        "return_code": -9,
+    }
+    assert state.clear_calls == ["hf:cancel"]
+
+
+def test_streamed_command_reports_progress_heartbeat_and_completion(monkeypatch):
+    process = _StreamProcess(["downloading 42%\n", "waiting for data\n"], return_code=0)
+    store = _Store(cancel_values=[False])
+    state = _State(store)
+    monotonic_values = iter([0.0, 0.1, 1.2])
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(runner, "_service_popen_kwargs", lambda: {})
+    monkeypatch.setattr(runner.time, "monotonic", lambda: next(monotonic_values))
+
+    runner.run_streamed_command(state, "ollama:progress", ["ollama", "pull", "model"])
+
+    assert store.updates[0][1] == {
+        "status": "running",
+        "detail": "Downloading",
+        "progress": "42%",
+    }
+    assert store.updates[1][1] == {
+        "status": "running",
+        "detail": "Downloading",
+        "progress": "1s",
+    }
+    assert _last_update(store) == {
+        "status": "completed",
+        "detail": "Completed",
+        "progress": "",
+        "return_code": 0,
+    }
+    assert state.clear_calls == ["ollama:progress"]
+
+
+def test_streamed_command_cancel_terminates_and_finalizes_cancelled(monkeypatch):
+    process = _StreamProcess(["cancel requested\n"], return_code=-15)
+    store = _Store(cancel_values=[True])
+    state = _State(store)
+    monotonic_values = iter([0.0, 0.1])
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(runner, "_service_popen_kwargs", lambda: {})
+    monkeypatch.setattr(runner.time, "monotonic", lambda: next(monotonic_values))
+
+    runner.run_streamed_command(state, "ollama:cancel", ["ollama", "pull", "model"])
+
+    assert process.terminate_calls == 1
+    assert _last_update(store) == {
+        "status": "cancelled",
+        "detail": "Canceled",
+        "progress": "",
+        "return_code": -15,
+    }
+    assert state.clear_calls == ["ollama:cancel"]
+
+
+def test_streamed_command_failure_preserves_last_output_line(monkeypatch):
+    process = _StreamProcess(["fatal registry failure\n"], return_code=3)
+    store = _Store(cancel_values=[False])
+    state = _State(store)
+    monotonic_values = iter([0.0, 0.1])
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(runner, "_service_popen_kwargs", lambda: {})
+    monkeypatch.setattr(runner.time, "monotonic", lambda: next(monotonic_values))
+
+    runner.run_streamed_command(state, "ollama:failed", ["ollama", "pull", "model"])
+
+    assert _last_update(store) == {
+        "status": "failed",
+        "detail": "fatal registry failure",
+        "progress": "",
+        "return_code": 3,
+    }
+
+
+def test_process_job_dispatches_hf_and_streamed_commands(monkeypatch):
+    hf_store = _Store(command=["hf_api_download", "owner/repo", "model.gguf"])
+    hf_state = _State(hf_store)
+    hf_calls = []
+    streamed_calls = []
+
+    monkeypatch.setattr(
+        runner,
+        "run_hf_download",
+        lambda state, target_id, command: hf_calls.append((state, target_id, command)),
+    )
+    monkeypatch.setattr(
+        runner,
+        "run_streamed_command",
+        lambda state, target_id, command: streamed_calls.append((state, target_id, command)),
+    )
+
+    runner.process_job(hf_state, "hf:dispatch")
+
+    assert hf_calls == [
+        (hf_state, "hf:dispatch", ["hf_api_download", "owner/repo", "model.gguf"])
+    ]
+    assert streamed_calls == []
+    assert hf_state.clear_calls == ["hf:dispatch"]
+
+    stream_store = _Store(command=["ollama", "pull", "model"])
+    stream_state = _State(stream_store)
+    runner.process_job(stream_state, "ollama:dispatch")
+
+    assert streamed_calls == [
+        (stream_state, "ollama:dispatch", ["ollama", "pull", "model"])
+    ]
+    assert stream_state.clear_calls == ["ollama:dispatch"]
+
+
+def test_process_job_contains_missing_command_and_os_errors(monkeypatch):
+    missing_store = _Store(command=None)
+    missing_state = _State(missing_store)
+    runner.process_job(missing_state, "missing")
+    assert _last_update(missing_store) == {
+        "status": "failed",
+        "detail": "missing command",
+        "return_code": 1,
+    }
+
+    for exc, expected_detail, expected_code in [
+        (FileNotFoundError(), "required command not found", 127),
+        (OSError("spawn denied"), "spawn denied", 1),
+    ]:
+        store = _Store(command=["ollama", "pull", "model"])
+        state = _State(store)
+
+        def _raise(*_args, _exc=exc, **_kwargs):
+            raise _exc
+
+        monkeypatch.setattr(runner, "run_streamed_command", _raise)
+        runner.process_job(state, "error")
+
+        assert _last_update(store) == {
+            "status": "failed",
+            "detail": expected_detail,
+            "return_code": expected_code,
+        }
+        assert state.clear_calls == ["error"]


### PR DESCRIPTION
Closes #68

## Goal

Add deterministic execution-path coverage for the download runner, then ratchet the enforced aggregate coverage floor from 50% to 55%.

## What changed

- added `tests/test_downloads_runner_execution.py` using fake state/store/process objects only
- covered HF payload validation, success/failure/cancellation escalation
- covered streamed progress, idle heartbeat, cancellation and non-zero finalization
- covered `process_job` dispatch, missing-command handling, FileNotFoundError and OSError containment
- raised `pyproject.toml` `fail_under` from 50 to 55
- synchronized README, roadmap, TESTING, STACK and CONCERNS
- reviewed CHANGELOG; no runtime/public contract changed, so no standalone release bullet was added

## Measured effect

Canonical Ubuntu / Python 3.12 coverage job:

- pre-change aggregate: 63.51%
- final aggregate: **65.38%**
- statements: `5043`
- missed: `1746`
- `downloads/runner.py`: **24% -> 90%**
- enforced floor: **55%**

The focused suite does not spawn real subprocesses, make network calls, or modify production runner behavior.

## Contracts pinned

- invalid HF payloads fail closed before subprocess creation
- HF success/failure/cancel terminal states remain deterministic
- cancellation escalates terminate -> kill after the existing grace period
- streamed output updates progress/heartbeat and preserves the last failure line
- `process_job` routes HF vs streamed commands correctly
- missing executable / OS spawn errors become stable failed job states

## Documentation state

The active coverage roadmap is now only **55% -> 60%**. `downloads/runner.py` is no longer listed as a low-coverage gap; remaining priority targets include `app/modals.py`, `app/viewer.py`, `tui_app.py`, `core/hardware.py`, `downloads/api.py`, and `downloads/service_client.py`.

## Baseline

Post-#67 main: `9d9e23bf59ca5089e287c4e98b377935699fbe97`

## Merge acceptance

- exact final head must pass CI including the canonical 55% coverage gate
- exact final head Package workflow must pass
- no unresolved blocking review thread
- squash merge with expected head SHA