### PR TITLE
test: harden service client lifecycle and ratchet gate to 60

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,7 +1,7 @@
 # Codebase Concerns
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `9d9e23bf59ca5089e287c4e98b377935699fbe97`
+**Baseline revision:** `d2c8913f3623eaaab8087a3c9d427b0a2686b375`
 
 This file lists **current, verified concerns**. Resolved mapper findings are retained only in the historical summary so completed work is not accidentally re-planned.
 
@@ -32,11 +32,14 @@ Remote Ollama discovery still fetches `ollama.com/search`/library HTML and parse
 
 ### 2. Aggregate coverage is healthy but uneven across high-risk modules
 
-**Area:** TUI, download API/client paths, platform hardware probes
+**Area:** TUI, download API, platform hardware probes
 
-The canonical Ubuntu/Python 3.12 coverage lane now measures **65.38% total coverage** (`5043` statements, `1746` missed) and enforces a **55%** floor.
+The canonical Ubuntu/Python 3.12 coverage lane now measures **66.59% total coverage** (`5043` statements, `1685` missed) and enforces a **60%** floor.
 
-Focused fake-process/state tests have already removed one major weak point: `downloads/runner.py` increased from **24% to 90%** without production-code changes.
+Focused deterministic tests have removed two consequential weak points without production-source changes:
+
+- `downloads/runner.py` — **24% → 90%**,
+- `downloads/service_client.py` — **46% → 90%**.
 
 Remaining measured examples:
 
@@ -44,25 +47,25 @@ Remaining measured examples:
 - `app/viewer.py` — 35%,
 - `tui_app.py` — 38%,
 - `core/hardware.py` — 44%,
-- `downloads/api.py` / `downloads/service_client.py` — 46%.
+- `downloads/api.py` — 46%.
 
 **Risk:**
 
-- aggregate coverage can remain green while consequential UI/platform/client branches are weakly exercised,
+- aggregate coverage can remain green while consequential UI/platform/API branches are weakly exercised,
 - future changes in low-coverage modules can regress without a focused contract test.
 
 **Current mitigation:**
 
-- 55% exact-head aggregate gate,
+- 60% exact-head aggregate gate,
 - 600+ deterministic tests,
 - separate verify/smoke matrices,
-- high coverage on provider/search/store/runner seams,
+- high coverage on provider/search/store/runner/service-client seams,
 - regression-test requirement for correctness fixes.
 
 **Next work:**
 
-- target consequential uncovered paths in one or more remaining weak modules,
-- ratchet the enforced floor to 60%,
+- add focused tests when concrete correctness/resilience/platform/performance work touches the remaining weak modules,
+- do not create percentage-only PRs indefinitely,
 - do not inflate coverage by excluding meaningful production modules or weakening assertions.
 
 ### 3. TUI result refresh still performs full table rebuilds in important paths
@@ -202,7 +205,9 @@ The following old concerns are retained here only to prevent accidental re-plann
 - **No REST input validation:** core model-search/plan inputs now validate to 400 responses.
 - **Provider failures hidden in REST/CLI:** resolved with REST diagnostics and CLI stderr warnings.
 - **Coverage configured but not enforced:** resolved by a canonical Ubuntu/Python 3.12 CI coverage job.
+- **Staged aggregate coverage goal:** completed at **50% → 55% → 60%**, with current measured aggregate 66.59%.
 - **Download runner execution largely untested:** resolved with deterministic fake-process/state coverage raising `downloads/runner.py` from 24% to 90%.
+- **Download service-client lifecycle largely untested:** resolved with deterministic lifecycle/request tests raising `downloads/service_client.py` from 46% to 90%.
 - **Legacy `shell=True` finding:** no active source match; old planning reference removed from current concerns.
 
 ## Maintenance Rule

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,7 +1,7 @@
 # Technology Stack
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `9d9e23bf59ca5089e287c4e98b377935699fbe97`
+**Baseline revision:** `d2c8913f3623eaaab8087a3c9d427b0a2686b375`
 
 ## Runtime
 
@@ -102,16 +102,17 @@ python scripts/dev.py smoke
 
 The verify suite contains **600+ tests**. Coverage is measured separately so the four-way cross-platform verify matrix is not burdened with redundant coverage execution.
 
-Canonical coverage evidence from PR #69:
+Canonical coverage evidence from PR #71:
 
 - environment: Ubuntu / Python 3.12,
-- measured total: **65.38%**,
+- measured total: **66.59%**,
 - statements: `5043`,
-- missed: `1746`,
-- enforced floor: **55%**,
-- `downloads/runner.py`: **90%**, up from 24% through fake-process/state execution tests.
+- missed: `1685`,
+- enforced floor: **60%**,
+- `downloads/runner.py`: **90%**, up from 24%,
+- `downloads/service_client.py`: **90%**, up from 46%.
 
-`pyproject.toml` is authoritative for the normal coverage threshold. The active quality roadmap has one remaining aggregate ratchet: 55% → 60%, backed by focused tests around another consequential weak boundary.
+`pyproject.toml` is authoritative for the normal coverage threshold. The staged **50% → 55% → 60%** ratchet is complete. Future increases should follow concrete risk reduction rather than percentage-only work.
 
 ## CI
 
@@ -151,7 +152,7 @@ The active roadmap includes a clearer acceptance matrix for Windows, WSL/Linux, 
 
 ### Uneven coverage distribution
 
-Aggregate coverage is now 65.38% and `downloads/runner.py` is 90%, but several consequential modules remain much lower: `app/modals.py` 25%, `app/viewer.py` 35%, `tui_app.py` 38%, `core/hardware.py` 44%, and download API/client paths around 46%. These are better targets for the final 60% ratchet than further broad aggregate-only changes.
+Aggregate coverage is now 66.59%; download runner and service-client lifecycle seams are both 90%. Remaining consequential low-coverage modules include `app/modals.py` 25%, `app/viewer.py` 35%, `tui_app.py` 38%, `core/hardware.py` 44%, and `downloads/api.py` 46%. Treat these as targets when concrete work touches them, not as a perpetual percentage-only backlog.
 
 ### Ollama registry HTML dependency
 

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,7 +1,7 @@
 # Testing and Verification
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `9d9e23bf59ca5089e287c4e98b377935699fbe97`
+**Baseline revision:** `d2c8913f3623eaaab8087a3c9d427b0a2686b375`
 
 ## Test Framework
 
@@ -10,7 +10,7 @@
 - **Default pytest args:** `-q` via `pyproject.toml`.
 - **Live external tests:** opt-in with `--run-live`.
 - **Coverage:** pytest-cov / coverage.py.
-- **Mocking:** pytest `monkeypatch`, `unittest.mock`, small fake response/session/provider/process/state classes, and deterministic pure-function tests.
+- **Mocking:** pytest `monkeypatch`, `unittest.mock`, small fake response/session/provider/process/state/psutil objects, and deterministic pure-function tests.
 
 ## Normal Developer Commands
 
@@ -40,24 +40,25 @@ Canonical CI coverage environment:
 - Ubuntu,
 - Python 3.12.
 
-Current measured evidence from PR #69:
+Current measured evidence from PR #71:
 
 - statements: `5043`,
-- missed: `1746`,
-- total coverage: **65.38%**,
-- `downloads/runner.py`: **90%** after focused fake-process/state execution tests.
+- missed: `1685`,
+- total coverage: **66.59%**,
+- `downloads/runner.py`: **90%**,
+- `downloads/service_client.py`: **90%**.
 
 Current enforced merge floor:
 
 ```toml
 [tool.coverage.report]
 show_missing = true
-fail_under = 55
+fail_under = 60
 ```
 
 The optional `--fail-under` argument exists for explicit measurement/debugging. `--fail-under 0` was used only to establish the original baseline and must not be used as a merge gate.
 
-The remaining planned aggregate ratchet is **60%**, backed by focused tests rather than new exclusions.
+The staged **50% → 55% → 60%** aggregate ratchet is complete. Future threshold increases should be backed by concrete risk-driven tests rather than percentage-only work or new exclusions.
 
 ### `smoke`
 
@@ -184,7 +185,7 @@ Cover store/state/lifecycle/client/runner behavior including:
 - service compatibility and client behavior,
 - runner terminal states and subprocess cancellation behavior through deterministic fake processes.
 
-`tests/test_downloads_runner_execution.py` deliberately avoids spawning real subprocesses. It pins:
+`tests/test_downloads_runner_execution.py` avoids spawning real subprocesses and pins:
 
 - Hugging Face payload validation,
 - running → completed/failed/cancelled transitions,
@@ -192,6 +193,16 @@ Cover store/state/lifecycle/client/runner behavior including:
 - streamed progress and idle heartbeat updates,
 - last-line failure details,
 - `process_job` dispatch and spawn-error containment.
+
+`tests/test_service_client_lifecycle.py` avoids starting a real background service and pins:
+
+- healthy/unreachable service probes,
+- Windows/POSIX detached launch command shapes,
+- startup retry/deadline behavior,
+- graceful shutdown and psutil fallback kill,
+- compatible-service reuse and stale-service restart,
+- public job request adapters,
+- delete-endpoint 404 restart/retry behavior.
 
 ### TUI tests
 
@@ -211,11 +222,14 @@ pytest --run-live
 
 Use live tests to validate actual external/provider behavior, not as a substitute for deterministic fixtures.
 
-## Coverage Distribution and Next Targets
+## Coverage Distribution and Future Targets
 
-Focused runner execution coverage removed one of the largest consequential gaps: `downloads/runner.py` increased from **24% to 90%** and aggregate coverage increased from 63.51% to **65.38%**.
+The staged aggregate ratchet is complete at **60% enforced / 66.59% measured**. Focused execution/lifecycle work removed two consequential weak seams:
 
-Remaining high-value low-coverage areas from the same canonical environment:
+- `downloads/runner.py`: **24% → 90%**,
+- `downloads/service_client.py`: **46% → 90%**.
+
+Remaining lower-coverage modules in the canonical environment include:
 
 | Module | Measured coverage |
 |---|---:|
@@ -224,11 +238,8 @@ Remaining high-value low-coverage areas from the same canonical environment:
 | `tui_app.py` | 38% |
 | `core/hardware.py` | 44% |
 | `downloads/api.py` | 46% |
-| `downloads/service_client.py` | 46% |
 
-Other critical seams are materially higher, including provider parsing, search orchestration, download store, and download runner execution paths.
-
-The final 60% ratchet should come from tests around consequential behavior in one or more remaining weak modules. Do not raise coverage by excluding meaningful production code, counting tests as production source, or weakening assertions.
+These are not an instruction to create percentage-only PRs. Add focused tests when a concrete correctness/resilience/platform/performance change touches them. Future aggregate gate increases should follow real risk reduction and must not exclude meaningful production code, count tests as production source, or weaken assertions.
 
 ## Regression-Test Rule
 

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -1,7 +1,7 @@
 # AI Model Explorer — Active Roadmap
 
 **Baseline date:** 2026-09-07  
-**Baseline revision:** `9d9e23bf59ca5089e287c4e98b377935699fbe97`  
+**Baseline revision:** `d2c8913f3623eaaab8087a3c9d427b0a2686b375`  
 **Status:** post-hardening baseline; active roadmap only
 
 This roadmap replaces the 2026-06-09 mapper plan. Completed work stays documented here only as a baseline summary; it is not an active backlog.
@@ -40,49 +40,16 @@ The following items from the old roadmap are already implemented and should not 
 - More than 600 deterministic tests in the current verify lane.
 - TUI stale-search-cache fallback for disconnected/offline search recovery.
 - Canonical coverage measurement lane on Ubuntu/Python 3.12.
-- First aggregate coverage gate at 50% against a measured 63.51% baseline.
-- Focused fake-process/state coverage for `downloads/runner.py`, raising that module from 24% to 90% and aggregate coverage to 65.38% while ratcheting the enforced floor to 55%.
+- Staged aggregate coverage gate ratchet **50% → 55% → 60%**.
+- Focused fake-process/state coverage for `downloads/runner.py`, raising that module from 24% to 90%.
+- Focused lifecycle/request coverage for `downloads/service_client.py`, raising that module from 46% to 90%.
+- Current canonical coverage evidence: `5043` statements, `1685` missed, **66.59%** aggregate, **60% enforced floor**.
 
 ## P1 — Quality Baseline
 
-### Q1. Ratchet measured coverage from 55% to 60%
+### Q1. Residual silent-failure audit
 
-Current exact-head evidence from PR #69's focused runner-coverage head:
-
-- canonical environment: Ubuntu / Python 3.12,
-- statements: `5043`,
-- missed: `1746`,
-- total measured coverage: **65.38%**,
-- enforced CI threshold: **55%**,
-- `downloads/runner.py`: **90%** (up from 24%).
-
-The repository exposes the same lane locally with:
-
-```bash
-python scripts/dev.py coverage
-```
-
-The CI coverage job is intentionally single-environment rather than duplicated across the full verify matrix. The normal command uses `pyproject.toml`'s configured threshold; `--fail-under 0` exists only for explicit baseline measurement and must not be used as the merge gate.
-
-Remaining stage:
-
-1. keep **55%** as the stable enforced floor,
-2. add focused tests for another consequential low-coverage boundary,
-3. ratchet to **60%** with exact-head evidence,
-4. do not reach the target by excluding meaningful production modules or weakening assertions.
-
-Priority coverage targets after the runner work:
-
-- `app/modals.py` — 25%,
-- `app/viewer.py` — 35%,
-- `tui_app.py` — 38%,
-- `core/hardware.py` — 44%,
-- `downloads/api.py` / `downloads/service_client.py` — 46%,
-- CLI and other user-facing public contracts where uncovered paths are consequential.
-
-The aggregate already exceeds 60%; the 60% gate should still be preceded by focused tests so the ratchet represents stronger assurance around a weak boundary rather than merely copying the aggregate number.
-
-### Q2. Residual silent-failure audit
+The staged aggregate coverage goal is complete. Coverage remains a merge gate and should continue to improve when concrete work touches weak boundaries, but there is no active generic “raise the percentage” task.
 
 Audit remaining broad exception/suppression boundaries and classify each as one of:
 
@@ -99,6 +66,18 @@ Initial targets:
 - platform hardware probes.
 
 The goal is not “remove every `except Exception`”; it is to eliminate unobservable failures where they can mislead users or hide correctness problems.
+
+### Q2. Targeted coverage when consequential weak seams are touched
+
+Remaining lower-coverage modules include:
+
+- `app/modals.py` — 25%,
+- `app/viewer.py` — 35%,
+- `tui_app.py` — 38%,
+- `core/hardware.py` — 44%,
+- `downloads/api.py` — 46%.
+
+Do not create percentage-only PRs indefinitely. Add focused tests when these modules are changed for a concrete correctness, resilience, performance, or platform goal. Future aggregate gate increases should be evidence-driven and should not use new production exclusions or weaker assertions.
 
 ## P1 — Ollama Registry Resilience
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Use a supported Python 3.10-3.14 interpreter for bootstrap. On Windows that can 
 
 `scripts/dev.py verify` runs the required local checks: pytest, import smoke and Ruff.
 
-`scripts/dev.py coverage` runs the deterministic pytest-cov lane and enforces the threshold configured in `pyproject.toml`. The canonical Ubuntu/Python 3.12 lane now measures **65.38% total coverage** (`5043` statements, `1746` missed) and enforces a **55%** merge floor. Focused fake-process/state tests raised `downloads/runner.py` from **24% to 90%** without changing production behavior. The remaining planned aggregate ratchet is 60%, reached through additional high-risk tests rather than coverage exclusions.
+`scripts/dev.py coverage` runs the deterministic pytest-cov lane and enforces the threshold configured in `pyproject.toml`. The canonical Ubuntu/Python 3.12 lane now measures **66.59% total coverage** (`5043` statements, `1685` missed) and enforces a **60%** merge floor. Focused deterministic tests raised `downloads/runner.py` from **24% to 90%** and `downloads/service_client.py` from **46% to 90%** without changing production behavior. The staged 50% → 55% → 60% coverage ratchet is complete; future increases should remain evidence-driven and must not rely on production-code exclusions.
 
 `scripts/dev.py smoke` runs bounded/offline-safe smoke checks for the CLI, REST API, TUI startup path and download service.
 
@@ -272,11 +272,11 @@ The active post-hardening roadmap is in `.planning/roadmap.md`.
 
 Current priorities:
 
-1. ratchet the enforced coverage floor from 55% to 60% with focused high-risk tests,
-2. residual silent-failure audit,
-3. Ollama registry parser resilience and structured-source research,
-4. safer incremental TUI DataTable updates,
-5. explicit Windows/WSL/Linux/macOS Apple Silicon acceptance matrix.
+1. residual silent-failure audit,
+2. Ollama registry parser resilience and structured-source research,
+3. safer incremental TUI DataTable updates,
+4. explicit Windows/WSL/Linux/macOS Apple Silicon acceptance matrix,
+5. targeted tests for consequential weak modules as concrete changes require them.
 
 Documentation maintenance rules are in `docs/maintenance.md`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,4 +106,4 @@ omit = ["tests/*", "scripts/*"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 55
+fail_under = 60

--- a/tests/test_service_client_lifecycle.py
+++ b/tests/test_service_client_lifecycle.py
@@ -1,0 +1,255 @@
+"""Deterministic lifecycle coverage for downloads.service_client."""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from downloads import service_client
+
+
+def test_is_service_running_distinguishes_healthy_and_failed_requests(monkeypatch):
+    """Reachability should require an explicit truthy health flag and contain request failures."""
+    monkeypatch.setattr(service_client, "_request", lambda *_args, **_kwargs: {"ok": True})
+    assert service_client.is_service_running() is True
+
+    monkeypatch.setattr(service_client, "_request", lambda *_args, **_kwargs: {"ok": False})
+    assert service_client.is_service_running() is False
+
+    def _raise(*_args, **_kwargs):
+        raise URLError("offline")
+
+    monkeypatch.setattr(service_client, "_request", _raise)
+    assert service_client.is_service_running() is False
+
+
+def test_start_service_process_uses_platform_specific_detached_launch(monkeypatch):
+    """Windows should use pythonw while POSIX should start a new session."""
+    calls = []
+
+    def _fake_popen(command, **kwargs):
+        calls.append((command, kwargs))
+        return object()
+
+    monkeypatch.setattr(service_client.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(service_client.sys, "executable", "C:/Python/python.exe")
+    monkeypatch.setattr(service_client.sys, "platform", "win32")
+
+    service_client._start_service_process()
+
+    assert calls == [
+        (
+            ["C:/Python/pythonw.exe", "-m", "downloads.download_service"],
+            {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL},
+        )
+    ]
+
+    calls.clear()
+    monkeypatch.setattr(service_client.sys, "executable", "/usr/bin/python3")
+    monkeypatch.setattr(service_client.sys, "platform", "linux")
+
+    service_client._start_service_process()
+
+    assert calls == [
+        (
+            ["/usr/bin/python3", "-m", "downloads.download_service"],
+            {
+                "stdout": subprocess.DEVNULL,
+                "stderr": subprocess.DEVNULL,
+                "start_new_session": True,
+            },
+        )
+    ]
+
+
+def test_wait_for_service_retries_until_healthy_compatible_response(monkeypatch):
+    """Transient health failures and incompatible versions should be retried within the deadline."""
+    health_calls = []
+    responses = [URLError("booting"), {"ok": True, "version": "1.7"}, {"ok": True, "version": "1.8"}]
+
+    def _health():
+        health_calls.append(True)
+        value = responses.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    monkeypatch.setattr(service_client, "get_service_health", _health)
+    monkeypatch.setattr(service_client.time, "time", lambda: 0.0)
+    monkeypatch.setattr(service_client.time, "sleep", lambda _seconds: None)
+
+    assert service_client._wait_for_service(deadline_seconds=1.0) is True
+    assert len(health_calls) == 3
+
+
+def test_wait_for_service_returns_false_after_deadline(monkeypatch):
+    """The startup poll must terminate when its deadline expires."""
+    time_values = iter([10.0, 12.0])
+    monkeypatch.setattr(service_client.time, "time", lambda: next(time_values))
+
+    assert service_client._wait_for_service(deadline_seconds=1.0) is False
+
+
+def test_stop_service_returns_true_after_graceful_shutdown(monkeypatch):
+    """A successful shutdown request followed by a dead health probe is a clean stop."""
+    requests = []
+
+    def _request(method, path, payload=None, timeout=2.0):
+        requests.append((method, path, payload, timeout))
+        return {"ok": True}
+
+    monkeypatch.setattr(service_client, "_request", _request)
+    monkeypatch.setattr(service_client, "psutil", None)
+    monkeypatch.setattr(service_client, "is_service_running", lambda: False)
+
+    assert service_client.stop_service() is True
+    assert requests == [("POST", "/shutdown", {}, 1.0)]
+
+
+def test_stop_service_falls_back_to_matching_process_kill(monkeypatch):
+    """If graceful shutdown fails, the known service process should be killed as fallback."""
+    process = SimpleNamespace(info={"cmdline": ["python", "-m", "downloads.download_service"]})
+    killed = []
+    process.kill = lambda: killed.append(True)
+
+    fake_psutil = SimpleNamespace(
+        process_iter=lambda _attrs: [process],
+        NoSuchProcess=type("NoSuchProcess", (Exception,), {}),
+        AccessDenied=type("AccessDenied", (Exception,), {}),
+        ZombieProcess=type("ZombieProcess", (Exception,), {}),
+    )
+
+    def _shutdown_failure(*_args, **_kwargs):
+        raise URLError("service unreachable")
+
+    monkeypatch.setattr(service_client, "_request", _shutdown_failure)
+    monkeypatch.setattr(service_client, "psutil", fake_psutil)
+    monkeypatch.setattr(service_client, "is_service_running", lambda: False)
+
+    assert service_client.stop_service() is True
+    assert killed == [True]
+
+
+def test_stop_service_returns_false_when_nothing_was_stopped(monkeypatch):
+    """No reachable service and no matching process must report that nothing stopped."""
+    def _shutdown_failure(*_args, **_kwargs):
+        raise URLError("service unreachable")
+
+    monkeypatch.setattr(service_client, "_request", _shutdown_failure)
+    monkeypatch.setattr(service_client, "psutil", None)
+
+    assert service_client.stop_service() is False
+
+
+def test_ensure_service_running_reuses_compatible_service(monkeypatch):
+    """A healthy compatible service should be reused without restart."""
+    actions = []
+    monkeypatch.setattr(service_client, "is_service_running", lambda: True)
+    monkeypatch.setattr(service_client, "get_service_health", lambda: {"ok": True, "version": "1.8"})
+    monkeypatch.setattr(service_client, "stop_service", lambda: actions.append("stop"))
+    monkeypatch.setattr(service_client, "_start_service_process", lambda: actions.append("start"))
+    monkeypatch.setattr(service_client, "_wait_for_service", lambda **_kwargs: actions.append("wait"))
+
+    assert service_client.ensure_service_running() is True
+    assert actions == []
+
+
+def test_ensure_service_running_restarts_incompatible_service(monkeypatch):
+    """A reachable but stale protocol version must be stopped and replaced."""
+    actions = []
+    monkeypatch.setattr(service_client, "is_service_running", lambda: True)
+    monkeypatch.setattr(service_client, "get_service_health", lambda: {"ok": True, "version": "1.7"})
+    monkeypatch.setattr(service_client, "stop_service", lambda: actions.append("stop") or True)
+    monkeypatch.setattr(service_client, "_start_service_process", lambda: actions.append("start"))
+    monkeypatch.setattr(
+        service_client,
+        "_wait_for_service",
+        lambda deadline_seconds: actions.append(("wait", deadline_seconds)) or True,
+    )
+
+    assert service_client.ensure_service_running() is True
+    assert actions == ["stop", "start", ("wait", 6.0)]
+
+
+def test_ensure_service_running_recovers_from_health_error(monkeypatch):
+    """A reachable probe followed by a failed detailed health read should still restart safely."""
+    actions = []
+
+    def _health_error():
+        raise ValueError("malformed health")
+
+    monkeypatch.setattr(service_client, "is_service_running", lambda: True)
+    monkeypatch.setattr(service_client, "get_service_health", _health_error)
+    monkeypatch.setattr(service_client, "stop_service", lambda: actions.append("stop") or True)
+    monkeypatch.setattr(service_client, "_start_service_process", lambda: actions.append("start"))
+    monkeypatch.setattr(
+        service_client,
+        "_wait_for_service",
+        lambda deadline_seconds: actions.append(("wait", deadline_seconds)) or False,
+    )
+
+    assert service_client.ensure_service_running() is False
+    assert actions == ["stop", "start", ("wait", 6.0)]
+
+
+def test_request_wrappers_preserve_methods_paths_payloads_and_timeouts(monkeypatch):
+    """Public client helpers should remain thin, stable request-contract adapters."""
+    calls = []
+
+    def _request(method, path, payload=None, timeout=2.0):
+        calls.append((method, path, payload, timeout))
+        if path.startswith("/jobs?limit="):
+            return {"jobs": [{"target_id": "job-1"}]}
+        return {"ok": True}
+
+    monkeypatch.setattr(service_client, "_request", _request)
+
+    assert service_client.list_jobs(limit=7, timeout=1.25) == [{"target_id": "job-1"}]
+    assert service_client.get_active_download_debug(timeout=1.5) == {"ok": True}
+    assert service_client.create_job({"name": "model"}) == {"ok": True}
+    assert service_client.cancel_job("job-1") == {"ok": True}
+
+    assert calls == [
+        ("GET", "/jobs?limit=7", None, 1.25),
+        ("GET", "/debug/active", None, 1.5),
+        ("POST", "/jobs", {"model": {"name": "model"}}, 3.0),
+        ("POST", "/jobs/cancel", {"target_id": "job-1"}, 2.0),
+    ]
+
+
+def _http_404():
+    return HTTPError("http://localhost/jobs/delete", 404, "not found", None, None)
+
+
+def test_delete_job_restarts_and_retries_once_after_404(monkeypatch):
+    """A stale service missing the delete endpoint should restart and retry exactly once."""
+    calls = []
+
+    def _request(method, path, payload=None, timeout=2.0):
+        calls.append((method, path, payload, timeout))
+        if len(calls) == 1:
+            raise _http_404()
+        return {"ok": True}
+
+    monkeypatch.setattr(service_client, "_request", _request)
+    monkeypatch.setattr(service_client, "ensure_service_running", lambda: True)
+
+    assert service_client.delete_job("job-1") == {"ok": True}
+    assert calls == [
+        ("POST", "/jobs/delete", {"target_id": "job-1"}, 2.0),
+        ("POST", "/jobs/delete", {"target_id": "job-1"}, 2.0),
+    ]
+
+
+def test_delete_job_reraises_404_when_restart_is_unavailable(monkeypatch):
+    """Delete retry must fail closed if a compatible replacement service cannot be started."""
+    monkeypatch.setattr(service_client, "_request", lambda *_args, **_kwargs: (_ for _ in ()).throw(_http_404()))
+    monkeypatch.setattr(service_client, "ensure_service_running", lambda: False)
+
+    with pytest.raises(HTTPError) as exc_info:
+        service_client.delete_job("job-1")
+
+    assert exc_info.value.code == 404


### PR DESCRIPTION
Closes #70

## Goal

Harden deterministic coverage around `downloads/service_client.py` lifecycle/request behavior and complete the staged aggregate coverage ratchet from 55% to 60%.

## What changed

- added `tests/test_service_client_lifecycle.py` using fake request/process/psutil/time seams only
- covered healthy/unreachable service probes
- covered Windows/POSIX detached service launch command shapes
- covered startup retry/deadline behavior
- covered graceful shutdown and psutil fallback process kill
- covered compatible-service reuse and incompatible/failed-health restart
- covered public job request wrapper contracts
- covered delete-on-404 restart/retry behavior
- raised `pyproject.toml` `fail_under` from 55 to 60
- synchronized README, roadmap, TESTING, STACK and CONCERNS
- reviewed CHANGELOG; no runtime/public contract changed, so no standalone release bullet was added

## Measured effect

Canonical Ubuntu / Python 3.12 coverage job:

- pre-change aggregate: 65.38%
- final aggregate: **66.59%**
- statements: `5043`
- missed: `1685`
- `downloads/service_client.py`: **46% -> 90%**
- `downloads/runner.py`: remains **90%**
- enforced floor: **60%**

The focused suite does not launch a real background service, spawn its real process, or make network calls. Production source is unchanged.

## Contracts pinned

- health probes fail closed on transport/parse failures
- platform-specific detached launch commands remain stable
- startup polling retries transient/incompatible health states and respects the deadline
- shutdown uses graceful request first and process kill fallback when required
- compatible service instances are reused; stale or malformed-health services are restarted
- job helper methods preserve HTTP method/path/payload/timeout contracts
- a 404 delete endpoint triggers one compatible-service restart/retry and otherwise re-raises

## Coverage policy state

The staged **50% -> 55% -> 60%** aggregate coverage ratchet is complete. Current canonical measurement is **66.59%** with a **60%** merge floor. Future coverage increases are risk-driven rather than percentage-only work.

Remaining lower-coverage seams include `app/modals.py`, `app/viewer.py`, `tui_app.py`, `core/hardware.py`, and `downloads/api.py`; tests should be added when concrete work touches those boundaries.

## Baseline

Post-#69 main: `d2c8913f3623eaaab8087a3c9d427b0a2686b375`

## Merge acceptance

- exact final head must pass CI including the canonical 60% coverage gate
- exact final head Package workflow must pass
- no unresolved blocking review thread
- squash merge with expected head SHA