### PR TITLE
fix: surface action-triggered download sync failures

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -100,10 +100,10 @@ Broad catches are no longer the system-wide default, but some best-effort paths 
 
 - provider registry import/detection suppression,
 - provider-selector widget synchronization fallback,
-- remaining download sync/action update boundaries such as `DownloadManager.sync_jobs()`,
+- remaining download action fallbacks outside periodic polling and `DownloadManager.sync_jobs()`,
 - platform hardware probes.
 
-Periodic timer-driven download polling is no longer a silent broad-catch path: expected service failures preserve the last known state and surface deduplicated stale/recovery status, while unexpected programming failures propagate.
+Periodic timer-driven download polling and action-triggered `DownloadManager.sync_jobs()` are no longer silent broad-catch paths: expected service failures preserve last-known state and surface a diagnostic, while unexpected programming failures propagate.
 
 **Risk:** a broad catch can become a silent false-success path if its context changes.
 

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -33,6 +33,7 @@ The following items from the old roadmap are already implemented and should not 
 - Bounded multi-worker download service (`AIMODEL_DOWNLOAD_MAX_WORKERS`, default `2`).
 - Loopback-only download-service transport with optional bearer-token protection for non-health endpoints.
 - Periodic TUI download polling preserves last-known state on expected service failures, surfaces deduplicated stale/recovery status, and no longer swallows unexpected programming failures.
+- Action-triggered download synchronization preserves last-known state on expected service failures, reports the failed refresh, and no longer swallows unexpected programming failures.
 - Platform-specific user-data locations for cache/download state and Hugging Face model files.
 - MoE-aware model-size estimation delegated to one canonical implementation.
 - Pre-built GPU bandwidth lookup instead of repeated linear scans.
@@ -63,7 +64,7 @@ Initial targets:
 
 - provider registry import/detection suppression,
 - `app/viewer.py` selector synchronization fallback,
-- remaining download sync/action update boundaries (`DownloadManager.sync_jobs()` and action fallbacks; periodic polling is hardened),
+- remaining download action fallbacks after polling and `DownloadManager.sync_jobs()` hardening,
 - platform hardware probes.
 
 The goal is not “remove every `except Exception`”; it is to eliminate unobservable failures where they can mislead users or hide correctness problems.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The TUI/orchestrator preserves this metadata internally. REST exposes it directl
 - Ollama pull and Hugging Face download paths.
 - Persistent history independent of TUI lifetime.
 - Periodic polling failures preserve the last known download state and surface deduplicated stale/recovery status instead of silently appearing current.
+- Action-triggered download synchronization also preserves last-known state and reports a failed refresh instead of silently appearing current; unexpected programming failures are not masked.
 - Loopback-only transport; optional bearer token for non-health service endpoints.
 
 ### REST API

--- a/app/download_manager.py
+++ b/app/download_manager.py
@@ -167,8 +167,9 @@ class DownloadManager:
                     limit=self.download_history_limit,
                     timeout=self.download_poll_request_timeout,
                 )
-            except Exception:
-                return
+            except _DOWNLOAD_SERVICE_POLL_ERRORS as exc:
+                self._update_status(_download_poll_failure_status(exc))
+                return False
 
         running_targets = set()
         for job in jobs:
@@ -211,6 +212,7 @@ class DownloadManager:
                 running_targets.add(target_id)
 
         self.active_downloads = running_targets
+        return True
 
     def ensure_download_fields(self, all_results: list[dict]) -> bool:
         changed = False

--- a/tests/test_download_sync_errors.py
+++ b/tests/test_download_sync_errors.py
@@ -38,9 +38,11 @@ def test_expected_sync_failure_preserves_state_and_surfaces_status():
 def test_unexpected_sync_failure_is_not_silently_swallowed():
     manager = _manager()
 
-    with patch("app.download_manager.list_jobs", side_effect=AssertionError("programming bug")):
-        with pytest.raises(AssertionError, match="programming bug"):
-            manager.sync_jobs(force=True)
+    with (
+        patch("app.download_manager.list_jobs", side_effect=AssertionError("programming bug")),
+        pytest.raises(AssertionError, match="programming bug"),
+    ):
+        manager.sync_jobs(force=True)
 
 
 def test_successful_self_fetch_returns_true():

--- a/tests/test_download_sync_errors.py
+++ b/tests/test_download_sync_errors.py
@@ -1,0 +1,57 @@
+"""Regression tests for action-triggered download job synchronization failures."""
+
+from unittest.mock import MagicMock, patch
+from urllib.error import URLError
+
+import pytest
+
+from app.download_manager import DownloadManager
+
+
+def _manager() -> DownloadManager:
+    return DownloadManager(
+        update_status=MagicMock(),
+        refresh_table=MagicMock(),
+        refresh_download_history_table=MagicMock(),
+        request_download_history_refresh=MagicMock(),
+        render_download_debug=MagicMock(),
+        find_model_by_target_id=MagicMock(return_value=None),
+    )
+
+
+def test_expected_sync_failure_preserves_state_and_surfaces_status():
+    manager = _manager()
+    manager.download_registry = {"hf:existing": {"state": "downloading"}}
+    manager.active_downloads = {"hf:existing"}
+
+    with patch("app.download_manager.list_jobs", side_effect=URLError("offline")):
+        synced = manager.sync_jobs(force=True)
+
+    assert synced is False
+    assert manager.download_registry == {"hf:existing": {"state": "downloading"}}
+    assert manager.active_downloads == {"hf:existing"}
+    manager._update_status.assert_called_once_with(
+        "Download service is unavailable; showing last known download state."
+    )
+
+
+def test_unexpected_sync_failure_is_not_silently_swallowed():
+    manager = _manager()
+
+    with patch("app.download_manager.list_jobs", side_effect=AssertionError("programming bug")):
+        with pytest.raises(AssertionError, match="programming bug"):
+            manager.sync_jobs(force=True)
+
+
+def test_successful_self_fetch_returns_true():
+    manager = _manager()
+
+    with patch("app.download_manager.list_jobs", return_value=[]):
+        assert manager.sync_jobs(force=True) is True
+
+
+def test_supplied_jobs_bypass_service_fetch():
+    manager = _manager()
+
+    with patch("app.download_manager.list_jobs", side_effect=AssertionError("must not fetch")):
+        assert manager.sync_jobs(jobs=[]) is True


### PR DESCRIPTION
Closes #74

## Goal

Make action-triggered `DownloadManager.sync_jobs()` failures observable without changing download lifecycle semantics.

## Final behavior

- reuses the periodic polling expected-error boundary (`OSError`, `ValueError`, `RuntimeError`)
- expected self-fetch failures preserve the current registry/active-download state and surface the same last-known-state status
- `sync_jobs()` returns `False` on expected fetch failure and `True` on successful synchronization
- unexpected programming exceptions propagate instead of being silently swallowed
- caller-supplied `jobs=` continues to bypass service fetch
- focused deterministic regression tests cover failure preservation, propagation, success, and supplied-job behavior

## Non-goals

- no start/cancel/delete lifecycle change
- no periodic polling change
- no unrelated exception-boundary refactor

## Documentation sync

README, roadmap, and CONCERNS are updated in this PR. CHANGELOG was reviewed; the existing download-polling observability entry remains accurate and did not require another release bullet.

## Baseline

Post-#73 main: `68a32e913183e45527bd5d9cf0627820b8b961fe`

## Validation

Exact head: `2884175cf3ec81e5776677c744efff0513549f55`

- CI #258: success
- Package #153: success
- coverage 60% gate: success
- open review threads: none