### PR TITLE
fix: make provider registry failures observable

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -98,12 +98,13 @@ Result refresh still uses `DataTable.clear()` in normal/structural refresh paths
 
 Broad catches are no longer the system-wide default, but some best-effort paths still use them, for example:
 
-- provider registry import/detection suppression,
 - provider-selector widget synchronization fallback,
 - remaining download action fallbacks outside periodic polling and `DownloadManager.sync_jobs()`,
 - platform hardware probes.
 
-Periodic timer-driven download polling and action-triggered `DownloadManager.sync_jobs()` are no longer silent broad-catch paths: expected service failures preserve last-known state and surface a diagnostic, while unexpected programming failures propagate.
+Provider registry lazy imports and detection are no longer silent suppression paths: expected missing imports are contained with warnings, unexpected import-time programming failures propagate, unexpected optional-provider construction/detection failures fail closed with warnings, and built-in Ollama/Hugging Face fallback availability is preserved when their dynamic detection raises unexpectedly.
+
+Periodic timer-driven download polling and action-triggered `DownloadManager.sync_jobs()` are also no longer silent broad-catch paths: expected service failures preserve last-known state and surface a diagnostic, while unexpected programming failures propagate.
 
 **Risk:** a broad catch can become a silent false-success path if its context changes.
 
@@ -200,6 +201,7 @@ The following old concerns are retained here only to prevent accidental re-plann
 - **No formal provider errors:** resolved by `ProviderError` + `SearchResult.structured_errors`.
 - **Sequential provider search:** resolved by `SearchOrchestrator` parallel fan-out.
 - **No search cancellation:** resolved by orchestrator cancellation polling/UI search IDs.
+- **Provider registry silent suppression:** lazy imports now contain only expected `ImportError` with warnings; unexpected import-time programming failures propagate, and unexpected optional-provider detection failures fail closed with warnings.
 - **SQLite connection per operation:** resolved for metadata cache by shared locked connection.
 - **Download service single worker:** resolved by bounded configurable worker pool.
 - **Duplicate model-size estimator:** `core.utils` delegates to canonical MoE-aware estimator.

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -26,6 +26,7 @@ The following items from the old roadmap are already implemented and should not 
 - Shared `requests.Session` pooling plus retry/backoff for retryable GET failures.
 - Structured provider diagnostics via `ProviderError`, preserved through provider results and orchestration.
 - Structured/legacy diagnostic containment for Hugging Face, Ollama, LM Studio, Docker Model Runner, and MLX search paths.
+- Provider registry lazy imports contain expected `ImportError` with warnings, unexpected import-time programming failures propagate, and unexpected optional-provider detection failures fail closed with warnings.
 - REST `/api/v1/models` additive `errors` and `structured_errors` output.
 - CLI provider diagnostics on stderr while preserving script-safe JSON stdout.
 - Search cancellation and provider-authoritative pagination handling.
@@ -62,7 +63,6 @@ Audit remaining broad exception/suppression boundaries and classify each as one 
 
 Initial targets:
 
-- provider registry import/detection suppression,
 - `app/viewer.py` selector synchronization fallback,
 - remaining download action fallbacks after polling and `DownloadManager.sync_jobs()` hardening,
 - platform hardware probes.
@@ -145,7 +145,6 @@ Address these only after P1 work unless a concrete user-facing defect is found:
 - MLX `list_installed()` filesystem I/O containment parity with MLX search.
 - LM Studio metadata helper response-shape containment if/when it has a production caller.
 - Docker/LM Studio/MLX limit and installed-list edge cases not reachable through current user-facing limits.
-- Provider registry diagnostics/observability improvements.
 - Further type tightening around provider duck-typed interfaces.
 
 ## P3 — Maintainability and Product Work

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -9,7 +9,6 @@ Provides a unified provider architecture with:
 
 from __future__ import annotations
 
-from contextlib import suppress
 from abc import ABC, abstractmethod
 from loguru import logger
 from typing import Any
@@ -113,15 +112,14 @@ def _get_mlx_provider():
 
 
 def get_all_provider_classes() -> list[type]:
-    """Return all available provider classes (may fail on non-matching platforms).
+    """Return importable provider classes while containing dependency failures.
 
-    Note: returns a mix of :class:`BaseProvider` subclasses and
-    duck-typed providers (HuggingFaceProvider, OllamaProvider) that
-    expose the same interface (``slug``, ``display_name``,
-    ``detect()``, ``search()``, ``list_installed()``,
-    ``search_with_installed()``).
+    Provider modules are platform-safe at import time; runtime/platform
+    availability belongs in ``detect()``. A missing dependency is contained so
+    other providers remain usable, while unexpected import-time programming
+    errors propagate instead of silently removing a provider from the registry.
     """
-    providers = []
+    provider_classes = []
     for getter in [
         _get_hf_provider,
         _get_ollama_provider,
@@ -129,15 +127,24 @@ def get_all_provider_classes() -> list[type]:
         _get_docker_provider,
         _get_mlx_provider,
     ]:
-        with suppress(ImportError, Exception):
-            providers.append(getter())
-    return providers
+        try:
+            provider_classes.append(getter())
+        except ImportError:
+            logger.warning(
+                "Provider import via {} failed; skipping ({})",
+                getter.__name__,
+                "ImportError",
+            )
+    return provider_classes
 
 
 def detect_available_providers() -> dict[str, bool]:
     """Detect which providers are available on this system.
 
-    Returns a dict mapping provider slug to availability bool.
+    Returns a dict mapping provider slug to availability bool. Expected runtime
+    unavailability is handled inside provider ``detect()`` implementations.
+    Unexpected construction/detection failures remain fail-closed for optional
+    providers but are logged as warnings instead of disappearing silently.
     """
     from core.hardware import check_ollama_running
 
@@ -146,13 +153,21 @@ def detect_available_providers() -> dict[str, bool]:
         "huggingface": True,  # Always available via API
     }
 
+    built_in_slugs = {"ollama", "huggingface"}
     for provider_cls in get_all_provider_classes():
+        slug = str(getattr(provider_cls, "slug", "") or "")
         try:
             instance = provider_cls()
-            available[instance.slug] = instance.detect()
-        except Exception:
-            logger.debug("Provider {} detection failed, skipping", provider_cls.__name__)
-            pass
+            slug = str(getattr(instance, "slug", slug) or slug)
+            available[slug] = instance.detect()
+        except Exception as exc:
+            if slug and slug not in built_in_slugs:
+                available[slug] = False
+            logger.warning(
+                "Provider {} detection failed unexpectedly; treating as unavailable ({})",
+                provider_cls.__name__,
+                type(exc).__name__,
+            )
 
     return available
 

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -161,13 +161,21 @@ def detect_available_providers() -> dict[str, bool]:
             slug = str(getattr(instance, "slug", slug) or slug)
             available[slug] = instance.detect()
         except Exception as exc:
-            if slug and slug not in built_in_slugs:
-                available[slug] = False
-            logger.warning(
-                "Provider {} detection failed unexpectedly; treating as unavailable ({})",
-                provider_cls.__name__,
-                type(exc).__name__,
-            )
+            if slug in built_in_slugs:
+                logger.warning(
+                    "Provider {} detection failed unexpectedly; preserving fallback availability={} ({})",
+                    provider_cls.__name__,
+                    available.get(slug, False),
+                    type(exc).__name__,
+                )
+            else:
+                if slug:
+                    available[slug] = False
+                logger.warning(
+                    "Provider {} detection failed unexpectedly; treating as unavailable ({})",
+                    provider_cls.__name__,
+                    type(exc).__name__,
+                )
 
     return available
 

--- a/tests/test_provider_registry_observability.py
+++ b/tests/test_provider_registry_observability.py
@@ -1,0 +1,96 @@
+"""Regression tests for provider registry import and detection failure boundaries."""
+
+from unittest.mock import patch
+
+import pytest
+
+import providers
+
+
+class _BrokenOptionalProvider:
+    slug = "broken"
+    display_name = "Broken"
+
+    def detect(self) -> bool:
+        raise AssertionError("programming bug")
+
+
+class _BrokenOptionalConstructor:
+    slug = "broken-constructor"
+    display_name = "Broken Constructor"
+
+    def __init__(self):
+        raise RuntimeError("constructor bug")
+
+
+def test_import_error_is_contained_and_warned():
+    with (
+        patch("providers._get_mlx_provider", side_effect=ImportError("missing dependency")),
+        patch("providers.logger.warning") as warning,
+    ):
+        classes = providers.get_all_provider_classes()
+
+    assert all(cls.__name__ != "MLXProvider" for cls in classes)
+    warning.assert_called_once_with(
+        "Provider import via {} failed; skipping ({})",
+        "_get_mlx_provider",
+        "ImportError",
+    )
+
+
+def test_unexpected_lazy_import_exception_propagates():
+    with patch("providers._get_mlx_provider", side_effect=RuntimeError("programming bug")):
+        with pytest.raises(RuntimeError, match="programming bug"):
+            providers.get_all_provider_classes()
+
+
+def test_unexpected_detection_failure_is_fail_closed_and_warned():
+    with (
+        patch("providers.get_all_provider_classes", return_value=[_BrokenOptionalProvider]),
+        patch("core.hardware.check_ollama_running", return_value=False),
+        patch("providers.logger.warning") as warning,
+    ):
+        available = providers.detect_available_providers()
+
+    assert available["broken"] is False
+    assert available["huggingface"] is True
+    warning.assert_called_once_with(
+        "Provider {} detection failed unexpectedly; treating as unavailable ({})",
+        "_BrokenOptionalProvider",
+        "AssertionError",
+    )
+
+
+def test_unexpected_constructor_failure_is_fail_closed_and_warned():
+    with (
+        patch("providers.get_all_provider_classes", return_value=[_BrokenOptionalConstructor]),
+        patch("core.hardware.check_ollama_running", return_value=True),
+        patch("providers.logger.warning") as warning,
+    ):
+        available = providers.detect_available_providers()
+
+    assert available["broken-constructor"] is False
+    assert available["ollama"] is True
+    warning.assert_called_once_with(
+        "Provider {} detection failed unexpectedly; treating as unavailable ({})",
+        "_BrokenOptionalConstructor",
+        "RuntimeError",
+    )
+
+
+def test_builtin_availability_survives_unexpected_detection_failure():
+    class _BrokenHuggingFaceProvider:
+        slug = "huggingface"
+        display_name = "Hugging Face"
+
+        def detect(self) -> bool:
+            raise AssertionError("programming bug")
+
+    with (
+        patch("providers.get_all_provider_classes", return_value=[_BrokenHuggingFaceProvider]),
+        patch("core.hardware.check_ollama_running", return_value=False),
+        patch("providers.logger.warning"),
+    ):
+        available = providers.detect_available_providers()
+
+    assert available["huggingface"] is True

--- a/tests/test_provider_registry_observability.py
+++ b/tests/test_provider_registry_observability.py
@@ -24,8 +24,11 @@ class _BrokenOptionalConstructor:
 
 
 def test_import_error_is_contained_and_warned():
+    def _get_mlx_provider():
+        raise ImportError("missing dependency")
+
     with (
-        patch("providers._get_mlx_provider", side_effect=ImportError("missing dependency")),
+        patch("providers._get_mlx_provider", new=_get_mlx_provider),
         patch("providers.logger.warning") as warning,
     ):
         classes = providers.get_all_provider_classes()

--- a/tests/test_provider_registry_observability.py
+++ b/tests/test_provider_registry_observability.py
@@ -39,9 +39,11 @@ def test_import_error_is_contained_and_warned():
 
 
 def test_unexpected_lazy_import_exception_propagates():
-    with patch("providers._get_mlx_provider", side_effect=RuntimeError("programming bug")):
-        with pytest.raises(RuntimeError, match="programming bug"):
-            providers.get_all_provider_classes()
+    with (
+        patch("providers._get_mlx_provider", side_effect=RuntimeError("programming bug")),
+        pytest.raises(RuntimeError, match="programming bug"),
+    ):
+        providers.get_all_provider_classes()
 
 
 def test_unexpected_detection_failure_is_fail_closed_and_warned():

--- a/tests/test_provider_registry_observability.py
+++ b/tests/test_provider_registry_observability.py
@@ -94,8 +94,14 @@ def test_builtin_availability_survives_unexpected_detection_failure():
     with (
         patch("providers.get_all_provider_classes", return_value=[_BrokenHuggingFaceProvider]),
         patch("core.hardware.check_ollama_running", return_value=False),
-        patch("providers.logger.warning"),
+        patch("providers.logger.warning") as warning,
     ):
         available = providers.detect_available_providers()
 
     assert available["huggingface"] is True
+    warning.assert_called_once_with(
+        "Provider {} detection failed unexpectedly; preserving fallback availability={} ({})",
+        "_BrokenHuggingFaceProvider",
+        True,
+        "AssertionError",
+    )


### PR DESCRIPTION
Closes #76

## Goal

Keep optional-provider isolation while preventing provider import/detection failures from disappearing silently.

## Final behavior

- lazy provider getters contain only `ImportError` and emit a warning identifying the getter
- unexpected import-time runtime/programming exceptions propagate instead of silently removing a provider
- unexpected optional-provider construction/detection failures remain fail-closed (`availability=False`) and emit a warning with provider class + exception type
- unexpected Ollama/Hugging Face detection failures preserve their existing precomputed fallback availability and emit a distinct warning
- normal provider detection/filter ordering remains unchanged
- focused deterministic tests cover import containment, unexpected import propagation, optional detection/constructor failures, built-in fallback preservation, and the built-in warning contract

## Non-goals

- no provider search changes
- no capability schema changes
- no TUI selector redesign
- no logging subsystem refactor

## Documentation sync

Roadmap and CONCERNS are updated in this PR. README and CHANGELOG were reviewed; no public command/config or release-facing contract required another update.

## Baseline

Post-#75 main: `b7f38b696d1edac537ff9d2b40dffbfb74416085`

## Validation

Exact head: `5eb5f3adfcc9d5a28dc39f23a279f1781d29d40e`

- CI #264: success
- Package #158: success
- coverage 60% gate: success
- open review threads: none
- submitted reviews: none