### PR TITLE
fix: narrow provider selector synchronization fallback

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -98,9 +98,10 @@ Result refresh still uses `DataTable.clear()` in normal/structural refresh paths
 
 Broad catches are no longer the system-wide default, but some best-effort paths still use them, for example:
 
-- provider-selector widget synchronization fallback,
 - remaining download action fallbacks outside periodic polling and `DownloadManager.sync_jobs()`,
 - platform hardware probes.
+
+Provider-selector widget synchronization is now an explicitly bounded best-effort path: a temporarily absent Textual selector (`NoMatches`) is contained so provider state/search can continue during lifecycle transitions, while wrong-type/value/programming failures are no longer swallowed.
 
 Provider registry lazy imports and detection are no longer silent suppression paths: expected missing imports are contained with warnings, unexpected import-time programming failures propagate, unexpected optional-provider construction/detection failures fail closed with warnings, and built-in Ollama/Hugging Face fallback availability is preserved when their dynamic detection raises unexpectedly.
 
@@ -202,6 +203,7 @@ The following old concerns are retained here only to prevent accidental re-plann
 - **Sequential provider search:** resolved by `SearchOrchestrator` parallel fan-out.
 - **No search cancellation:** resolved by orchestrator cancellation polling/UI search IDs.
 - **Provider registry silent suppression:** lazy imports now contain only expected `ImportError` with warnings; unexpected import-time programming failures propagate, and unexpected optional-provider detection failures fail closed with warnings.
+- **Provider-selector broad synchronization catch:** narrowed to expected Textual `NoMatches`; other synchronization failures propagate.
 - **SQLite connection per operation:** resolved for metadata cache by shared locked connection.
 - **Download service single worker:** resolved by bounded configurable worker pool.
 - **Duplicate model-size estimator:** `core.utils` delegates to canonical MoE-aware estimator.

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -27,6 +27,7 @@ The following items from the old roadmap are already implemented and should not 
 - Structured provider diagnostics via `ProviderError`, preserved through provider results and orchestration.
 - Structured/legacy diagnostic containment for Hugging Face, Ollama, LM Studio, Docker Model Runner, and MLX search paths.
 - Provider registry lazy imports contain expected `ImportError` with warnings, unexpected import-time programming failures propagate, and unexpected optional-provider detection failures fail closed with warnings.
+- Provider-selector widget synchronization contains only expected Textual `NoMatches` lifecycle absence; other synchronization/programming failures propagate.
 - REST `/api/v1/models` additive `errors` and `structured_errors` output.
 - CLI provider diagnostics on stderr while preserving script-safe JSON stdout.
 - Search cancellation and provider-authoritative pagination handling.
@@ -63,7 +64,6 @@ Audit remaining broad exception/suppression boundaries and classify each as one 
 
 Initial targets:
 
-- `app/viewer.py` selector synchronization fallback,
 - remaining download action fallbacks after polling and `DownloadManager.sync_jobs()` hardening,
 - platform hardware probes.
 

--- a/app/viewer.py
+++ b/app/viewer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from textual.containers import Vertical
+from textual.css.query import NoMatches
 from textual.widgets import Input, Select
 
 from providers import get_provider_filter_labels
@@ -71,7 +72,7 @@ class AIModelViewer(BaseAIModelViewer):
                 selector = self.query_one("#provider-select", Select)
                 if selector.value != label:
                     selector.value = label
-            except Exception:
+            except NoMatches:
                 pass
 
         current_query = self.query_one("#search-input", Input).value.strip()

--- a/tests/test_provider_selector_viewer.py
+++ b/tests/test_provider_selector_viewer.py
@@ -1,6 +1,24 @@
 """Regression coverage for the runtime TUI provider selector."""
 
-from app.viewer import cycle_provider_label, provider_compact_tag
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from textual.css.query import NoMatches
+
+from app.viewer import AIModelViewer, cycle_provider_label, provider_compact_tag
+
+
+def _viewer_harness(*, query: str = "") -> SimpleNamespace:
+    harness = SimpleNamespace(
+        provider_filter_labels=("Ollama", "Hugging Face"),
+        current_filter="Ollama",
+        start_search=MagicMock(),
+        update_status=MagicMock(),
+        refresh_table=MagicMock(),
+    )
+    harness.search_input = SimpleNamespace(value=query)
+    return harness
 
 
 def test_cycle_provider_label_uses_full_snapshot():
@@ -35,3 +53,63 @@ def test_provider_compact_tag_distinguishes_optional_providers():
     assert provider_compact_tag("LM Studio") == "LM"
     assert provider_compact_tag("Docker") == "DK"
     assert provider_compact_tag("MLX") == "MLX"
+
+
+def test_missing_selector_is_best_effort_and_provider_refresh_continues():
+    """A transiently absent selector must not block the underlying provider change."""
+    viewer = _viewer_harness()
+
+    def query_one(selector, _expect_type):
+        if selector == "#provider-select":
+            raise NoMatches("provider selector not mounted")
+        assert selector == "#search-input"
+        return viewer.search_input
+
+    viewer.query_one = query_one
+
+    AIModelViewer._apply_provider_filter(viewer, "Hugging Face", sync_widget=True)
+
+    assert viewer.current_filter == "Hugging Face"
+    viewer.refresh_table.assert_called_once_with()
+    viewer.start_search.assert_not_called()
+    viewer.update_status.assert_called_once_with("Provider filter set to Hugging Face.")
+
+
+def test_unexpected_selector_sync_failure_is_not_swallowed():
+    """Programming failures in selector synchronization must remain observable."""
+    viewer = _viewer_harness()
+
+    def query_one(selector, _expect_type):
+        if selector == "#provider-select":
+            raise AssertionError("programming bug")
+        return viewer.search_input
+
+    viewer.query_one = query_one
+
+    with pytest.raises(AssertionError, match="programming bug"):
+        AIModelViewer._apply_provider_filter(viewer, "Hugging Face", sync_widget=True)
+
+    assert viewer.current_filter == "Hugging Face"
+    viewer.refresh_table.assert_not_called()
+    viewer.start_search.assert_not_called()
+
+
+def test_selector_sync_updates_widget_before_search_dispatch():
+    """Normal keyboard cycling must keep the mounted selector and search flow aligned."""
+    viewer = _viewer_harness(query="qwen")
+    selector = SimpleNamespace(value="Ollama")
+
+    def query_one(query, _expect_type):
+        if query == "#provider-select":
+            return selector
+        assert query == "#search-input"
+        return viewer.search_input
+
+    viewer.query_one = query_one
+
+    AIModelViewer._apply_provider_filter(viewer, "Hugging Face", sync_widget=True)
+
+    assert selector.value == "Hugging Face"
+    viewer.start_search.assert_called_once_with("qwen")
+    viewer.refresh_table.assert_not_called()
+    viewer.update_status.assert_called_once_with("Provider switched to Hugging Face. Searching...")


### PR DESCRIPTION
Closes #78

## Goal

Keep provider-selector synchronization best-effort for the expected Textual lifecycle race without swallowing unrelated programming failures.

## Final behavior

- `_apply_provider_filter()` contains only Textual `NoMatches` while synchronizing `#provider-select`
- a temporarily absent selector still allows provider state changes and normal refresh/search/status behavior to continue
- unexpected synchronization failures now propagate
- normal mounted-selector synchronization remains unchanged
- deterministic harness tests cover missing-selector continuation, unexpected failure propagation, and normal selector+search behavior without mounting a real terminal UI

## Non-goals

- no selector redesign
- no provider availability changes
- no search/filter semantics changes
- no Textual upgrade

## Documentation sync

Roadmap and CONCERNS are updated in this PR. README and CHANGELOG were reviewed; no user-facing feature/config or release contract required another update.

## Baseline

Post-#77 main: `19cc86c57e7229216b44fe49215dbdb42e42c5df`

## Validation

Exact head: `f4c8ecc38203df4a7584c9405ba390f32b3197e0`

- CI #268: success
- Package #161: success
- coverage 60% gate: success
- open review threads: none
- submitted reviews: none