### PR TITLE
fix: keep NVIDIA detection state atomic

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -34,25 +34,26 @@ Remote Ollama discovery still fetches `ollama.com/search`/library HTML and parse
 
 **Area:** TUI, download API, platform hardware probes
 
-The canonical Ubuntu/Python 3.12 coverage lane now measures **66.59% total coverage** (`5043` statements, `1685` missed) and enforces a **60%** floor.
+The canonical Ubuntu/Python 3.12 coverage lane now measures **67.40% total coverage** (`5095` statements, `1661` missed) and enforces a **60%** floor.
 
-Focused deterministic tests have removed two consequential weak points without production-source changes:
+Focused deterministic tests have removed several consequential weak points:
 
 - `downloads/runner.py` — **24% → 90%**,
-- `downloads/service_client.py` — **46% → 90%**.
+- `downloads/service_client.py` — **46% → 90%**,
+- `core/hardware.py` — **44% → 52%**, with atomic NVIDIA probe-state coverage.
 
 Remaining measured examples:
 
 - `app/modals.py` — 25%,
-- `app/viewer.py` — 35%,
 - `tui_app.py` — 38%,
-- `core/hardware.py` — 44%,
-- `downloads/api.py` — 46%.
+- `downloads/api.py` — 46%,
+- `core/hardware.py` — 52%,
+- `app/viewer.py` — 57%.
 
 **Risk:**
 
 - aggregate coverage can remain green while consequential UI/platform/API branches are weakly exercised,
-- future changes in low-coverage modules can regress without a focused contract test.
+- future changes in lower-coverage modules can regress without a focused contract test.
 
 **Current mitigation:**
 
@@ -94,31 +95,7 @@ Result refresh still uses `DataTable.clear()` in normal/structural refresh paths
 
 ## Priority 2
 
-### 4. Residual broad exception/suppression boundaries remain
-
-Broad catches are no longer the system-wide default, but some best-effort paths still use them, for example:
-
-- remaining download action fallbacks outside periodic polling and `DownloadManager.sync_jobs()`,
-- platform hardware probes.
-
-Provider-selector widget synchronization is now an explicitly bounded best-effort path: a temporarily absent Textual selector (`NoMatches`) is contained so provider state/search can continue during lifecycle transitions, while wrong-type/value/programming failures are no longer swallowed.
-
-Provider registry lazy imports and detection are no longer silent suppression paths: expected missing imports are contained with warnings, unexpected import-time programming failures propagate, unexpected optional-provider construction/detection failures fail closed with warnings, and built-in Ollama/Hugging Face fallback availability is preserved when their dynamic detection raises unexpectedly.
-
-Periodic timer-driven download polling and action-triggered `DownloadManager.sync_jobs()` are also no longer silent broad-catch paths: expected service failures preserve last-known state and surface a diagnostic, while unexpected programming failures propagate.
-
-**Risk:** a broad catch can become a silent false-success path if its context changes.
-
-**Required audit rule:** classify each boundary as:
-
-- expected fail-closed + logged,
-- user-visible diagnostic required,
-- narrower exception types required,
-- intentional best-effort behavior with a comment/test.
-
-Do not mechanically replace broad catches that protect platform/UI teardown behavior; audit observable semantics instead.
-
-### 5. Platform acceptance is broader than hosted CI evidence
+### 4. Platform acceptance is broader than hosted CI evidence
 
 Project metadata supports Python 3.10-3.14 and integrations span Windows/Linux/macOS/Apple Silicon, but hosted CI currently verifies only:
 
@@ -136,7 +113,7 @@ Hosted CI does not prove:
 
 **Next work:** explicit automated/manual platform acceptance matrix.
 
-### 6. Main TUI base module remains large
+### 5. Main TUI base module remains large
 
 The old “single root `app.py` monolith” concern is obsolete: provider selector, modals, widgets, download manager, search state, search orchestration, result helpers, and download internals have been extracted.
 
@@ -152,7 +129,7 @@ However, `tui_app.py` still owns the base Textual layout/event lifecycle and rem
 
 ## Priority 3
 
-### 7. Local-provider helper parity has minor remaining edge cases
+### 6. Local-provider helper parity has minor remaining edge cases
 
 Known lower-priority examples:
 
@@ -162,7 +139,7 @@ Known lower-priority examples:
 
 These should be handled when a concrete caller/bug justifies them rather than bundled into speculative refactors.
 
-### 8. Textual 0.x dependency pin
+### 7. Textual 0.x dependency pin
 
 The project intentionally pins `textual>=0.86,<1.0`.
 
@@ -204,6 +181,10 @@ The following old concerns are retained here only to prevent accidental re-plann
 - **No search cancellation:** resolved by orchestrator cancellation polling/UI search IDs.
 - **Provider registry silent suppression:** lazy imports now contain only expected `ImportError` with warnings; unexpected import-time programming failures propagate, and unexpected optional-provider detection failures fail closed with warnings.
 - **Provider-selector broad synchronization catch:** narrowed to expected Textual `NoMatches`; other synchronization failures propagate.
+- **Download polling/sync silent stale-state paths:** expected service failures preserve last-known state with diagnostics and unexpected programming failures propagate.
+- **Residual download action broad catches:** classified as intentional user-visible containment; start/cancel/delete operations return explicit failure status rather than false success.
+- **Hardware broad-probe audit:** AMD/Apple/Intel use bounded platform exception sets; NVIDIA NVML broad catches remain intentional third-party backend fallbacks, with state committed atomically only after a complete probe so partial failures cannot create false CUDA state.
+- **Residual silent-failure audit:** completed for the tracked provider registry, selector, download polling/sync/action, and hardware-probe boundaries.
 - **SQLite connection per operation:** resolved for metadata cache by shared locked connection.
 - **Download service single worker:** resolved by bounded configurable worker pool.
 - **Duplicate model-size estimator:** `core.utils` delegates to canonical MoE-aware estimator.
@@ -211,7 +192,7 @@ The following old concerns are retained here only to prevent accidental re-plann
 - **No REST input validation:** core model-search/plan inputs now validate to 400 responses.
 - **Provider failures hidden in REST/CLI:** resolved with REST diagnostics and CLI stderr warnings.
 - **Coverage configured but not enforced:** resolved by a canonical Ubuntu/Python 3.12 CI coverage job.
-- **Staged aggregate coverage goal:** completed at **50% → 55% → 60%**, with current measured aggregate 66.59%.
+- **Staged aggregate coverage goal:** completed at **50% → 55% → 60%**, with current measured aggregate **67.40%**.
 - **Download runner execution largely untested:** resolved with deterministic fake-process/state coverage raising `downloads/runner.py` from 24% to 90%.
 - **Download service-client lifecycle largely untested:** resolved with deterministic lifecycle/request tests raising `downloads/service_client.py` from 46% to 90%.
 - **Legacy `shell=True` finding:** no active source match; old planning reference removed from current concerns.

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -102,15 +102,16 @@ python scripts/dev.py smoke
 
 The verify suite contains **600+ tests**. Coverage is measured separately so the four-way cross-platform verify matrix is not burdened with redundant coverage execution.
 
-Canonical coverage evidence from PR #71:
+Current canonical coverage evidence:
 
 - environment: Ubuntu / Python 3.12,
-- measured total: **66.59%**,
-- statements: `5043`,
-- missed: `1685`,
+- measured total: **67.40%**,
+- statements: `5095`,
+- missed: `1661`,
 - enforced floor: **60%**,
 - `downloads/runner.py`: **90%**, up from 24%,
-- `downloads/service_client.py`: **90%**, up from 46%.
+- `downloads/service_client.py`: **90%**, up from 46%,
+- `core/hardware.py`: **52%**, up from 44% after atomic NVIDIA probe coverage.
 
 `pyproject.toml` is authoritative for the normal coverage threshold. The staged **50% → 55% → 60%** ratchet is complete. Future increases should follow concrete risk reduction rather than percentage-only work.
 
@@ -146,13 +147,15 @@ A separate `Package` workflow validates wheel build/install/entry points for pac
 - **Docker Model Runner:** local `/models` API.
 - **MLX:** macOS/Apple-Silicon detection plus local cache scanning.
 
+Hardware detection is fail-soft across platform tooling. NVIDIA probes try `nvidia_smi` then `pynvml`; state is committed only after a complete backend probe, preventing partial NVML failures from leaving a false CUDA result. AMD/Apple/Intel command probes use bounded platform-specific exception handling and fall through when tooling is absent.
+
 The active roadmap includes a clearer acceptance matrix for Windows, WSL/Linux, Linux native, and macOS Apple Silicon.
 
 ## Known Stack Risks
 
 ### Uneven coverage distribution
 
-Aggregate coverage is now 66.59%; download runner and service-client lifecycle seams are both 90%. Remaining consequential low-coverage modules include `app/modals.py` 25%, `app/viewer.py` 35%, `tui_app.py` 38%, `core/hardware.py` 44%, and `downloads/api.py` 46%. Treat these as targets when concrete work touches them, not as a perpetual percentage-only backlog.
+Aggregate coverage is now 67.40%; download runner and service-client lifecycle seams are both 90%. Remaining consequential lower-coverage modules include `app/modals.py` 25%, `tui_app.py` 38%, `downloads/api.py` 46%, `core/hardware.py` 52%, and `app/viewer.py` 57%. Treat these as targets when concrete work touches them, not as a perpetual percentage-only backlog.
 
 ### Ollama registry HTML dependency
 

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -10,7 +10,7 @@
 - **Default pytest args:** `-q` via `pyproject.toml`.
 - **Live external tests:** opt-in with `--run-live`.
 - **Coverage:** pytest-cov / coverage.py.
-- **Mocking:** pytest `monkeypatch`, `unittest.mock`, small fake response/session/provider/process/state/psutil objects, and deterministic pure-function tests.
+- **Mocking:** pytest `monkeypatch`, `unittest.mock`, small fake response/session/provider/process/state/psutil/module objects, and deterministic pure-function tests.
 
 ## Normal Developer Commands
 
@@ -40,13 +40,14 @@ Canonical CI coverage environment:
 - Ubuntu,
 - Python 3.12.
 
-Current measured evidence from PR #71:
+Current measured evidence from the NVIDIA atomicity hardening run:
 
-- statements: `5043`,
-- missed: `1685`,
-- total coverage: **66.59%**,
+- statements: `5095`,
+- missed: `1661`,
+- total coverage: **67.40%**,
 - `downloads/runner.py`: **90%**,
-- `downloads/service_client.py`: **90%**.
+- `downloads/service_client.py`: **90%**,
+- `core/hardware.py`: **52%**, up from 44%.
 
 Current enforced merge floor:
 
@@ -122,9 +123,16 @@ Cover:
 - scoring,
 - GPU bandwidth lookup,
 - MoE/model-size/quantization logic,
-- hardware helper fallbacks,
+- hardware helper/probe fallbacks,
+- atomic hardware-detection state,
 - utility functions,
 - cache serialization and concurrency.
+
+The NVIDIA probe regression suite uses fake `nvidia_smi`/`pynvml` modules so partial NVML success/failure can be tested without a GPU. It pins three invariants:
+
+- failed partial probes do not commit false NVIDIA state,
+- a successful fallback backend commits only its complete result,
+- a successful primary backend short-circuits fallback detection.
 
 ### Provider contract tests
 
@@ -135,6 +143,7 @@ Cover:
 - Docker installed-list parse containment,
 - MLX I/O containment and global limit semantics,
 - provider capabilities,
+- provider registry import/detection observability,
 - pagination authority,
 - installed-model behavior.
 
@@ -183,6 +192,7 @@ Cover store/state/lifecycle/client/runner behavior including:
 - debug/status behavior,
 - concurrent worker/store paths,
 - service compatibility and client behavior,
+- stale-state diagnostics for polling/action-triggered sync,
 - runner terminal states and subprocess cancellation behavior through deterministic fake processes.
 
 `tests/test_downloads_runner_execution.py` avoids spawning real subprocesses and pins:
@@ -212,6 +222,8 @@ TUI testing is deliberately split:
 - `app/` manager/state tests,
 - focused Textual test-mode smoke/interaction tests for mounted behavior.
 
+The provider-selector regression harness pins that expected `NoMatches` lifecycle absence is best-effort while unrelated synchronization failures remain observable.
+
 ### Live tests
 
 External live tests are skipped by default and enabled explicitly:
@@ -224,20 +236,21 @@ Use live tests to validate actual external/provider behavior, not as a substitut
 
 ## Coverage Distribution and Future Targets
 
-The staged aggregate ratchet is complete at **60% enforced / 66.59% measured**. Focused execution/lifecycle work removed two consequential weak seams:
+The staged aggregate ratchet is complete at **60% enforced / 67.40% measured**. Focused execution/lifecycle/hardware work removed several consequential weak seams:
 
 - `downloads/runner.py`: **24% → 90%**,
-- `downloads/service_client.py`: **46% → 90%**.
+- `downloads/service_client.py`: **46% → 90%**,
+- `core/hardware.py`: **44% → 52%**.
 
 Remaining lower-coverage modules in the canonical environment include:
 
 | Module | Measured coverage |
 |---|---:|
 | `app/modals.py` | 25% |
-| `app/viewer.py` | 35% |
 | `tui_app.py` | 38% |
-| `core/hardware.py` | 44% |
 | `downloads/api.py` | 46% |
+| `core/hardware.py` | 52% |
+| `app/viewer.py` | 57% |
 
 These are not an instruction to create percentage-only PRs. Add focused tests when a concrete correctness/resilience/platform/performance change touches them. Future aggregate gate increases should follow real risk reduction and must not exclude meaningful production code, count tests as production source, or weaken assertions.
 
@@ -251,6 +264,7 @@ Examples of preferred assertions:
 - diagnostic code/retryability/status rather than raw exception class when crossing provider boundaries,
 - stdout/stderr separation for CLI scripting contracts,
 - partial-success preservation when one provider fails,
+- atomic state commit when a hardware probe can fail after partial reads,
 - no continuation UI for non-paginated providers.
 
 ## Documentation Rule

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -36,6 +36,8 @@ The following items from the old roadmap are already implemented and should not 
 - Loopback-only download-service transport with optional bearer-token protection for non-health endpoints.
 - Periodic TUI download polling preserves last-known state on expected service failures, surfaces deduplicated stale/recovery status, and no longer swallows unexpected programming failures.
 - Action-triggered download synchronization preserves last-known state on expected service failures, reports the failed refresh, and no longer swallows unexpected programming failures.
+- Download start/cancel/delete broad catches are classified as intentional user-visible containment: callers receive explicit failure status rather than false success.
+- Hardware probe fallbacks are classified as intentional best-effort platform detection; NVIDIA NVML state is committed only after a complete probe so partial failures cannot leave false CUDA state or suppress later vendor fallbacks.
 - Platform-specific user-data locations for cache/download state and Hugging Face model files.
 - MoE-aware model-size estimation delegated to one canonical implementation.
 - Pre-built GPU bandwidth lookup instead of repeated linear scans.
@@ -47,43 +49,29 @@ The following items from the old roadmap are already implemented and should not 
 - Staged aggregate coverage gate ratchet **50% → 55% → 60%**.
 - Focused fake-process/state coverage for `downloads/runner.py`, raising that module from 24% to 90%.
 - Focused lifecycle/request coverage for `downloads/service_client.py`, raising that module from 46% to 90%.
-- Current canonical coverage evidence: `5043` statements, `1685` missed, **66.59%** aggregate, **60% enforced floor**.
+- Focused NVIDIA probe coverage raised `core/hardware.py` from 44% to 52% while pinning atomic state semantics.
+- Current canonical coverage evidence: `5095` statements, `1661` missed, **67.40%** aggregate, **60% enforced floor**.
+- Residual silent-failure audit completed for the previously tracked provider registry, selector synchronization, download polling/sync/action, and hardware-probe boundaries.
 
 ## P1 — Quality Baseline
 
-### Q1. Residual silent-failure audit
+### Q1. Targeted coverage when consequential weak seams are touched
 
-The staged aggregate coverage goal is complete. Coverage remains a merge gate and should continue to improve when concrete work touches weak boundaries, but there is no active generic “raise the percentage” task.
-
-Audit remaining broad exception/suppression boundaries and classify each as one of:
-
-- expected fail-closed behavior with logging,
-- user-visible diagnostic required,
-- specific exception types required,
-- intentional best-effort behavior that should be documented.
-
-Initial targets:
-
-- remaining download action fallbacks after polling and `DownloadManager.sync_jobs()` hardening,
-- platform hardware probes.
-
-The goal is not “remove every `except Exception`”; it is to eliminate unobservable failures where they can mislead users or hide correctness problems.
-
-### Q2. Targeted coverage when consequential weak seams are touched
+The staged aggregate coverage goal and the residual silent-failure audit are complete. Coverage remains a merge gate and should continue to improve when concrete work touches weak boundaries; there is no active generic “raise the percentage” or “remove every broad catch” task.
 
 Remaining lower-coverage modules include:
 
 - `app/modals.py` — 25%,
-- `app/viewer.py` — 35%,
 - `tui_app.py` — 38%,
-- `core/hardware.py` — 44%,
-- `downloads/api.py` — 46%.
+- `downloads/api.py` — 46%,
+- `core/hardware.py` — 52%,
+- `app/viewer.py` — 57%.
 
 Do not create percentage-only PRs indefinitely. Add focused tests when these modules are changed for a concrete correctness, resilience, performance, or platform goal. Future aggregate gate increases should be evidence-driven and should not use new production exclusions or weaker assertions.
 
 ## P1 — Ollama Registry Resilience
 
-Ollama remote discovery still depends on `ollama.com` HTML structure. This is the largest remaining external-format fragility.
+Ollama remote discovery still depends on `ollama.com` HTML structure. This is the largest remaining external-format fragility and is now the primary P1 implementation track.
 
 ### O1. Fixture-backed parser contracts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Hardened MLX cache scanning against filesystem I/O failures and enforced a true global search result limit across cache roots.
 - Preserved orchestrator-generated provider failures as machine-readable diagnostics instead of dropping them to strings only.
 - Fixed provider pagination authority so non-paginated/multi-provider searches cannot synthesize false continuation from result counts.
+- Fixed NVIDIA hardware detection so partially successful NVML probes cannot leave a false-positive CUDA/NVIDIA state or suppress fallback vendor detection.
 
 ### REST and CLI contracts
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The TUI/orchestrator preserves this metadata internally. REST exposes it directl
 - Dynamic quantization planning.
 - Token/sec estimation from GPU memory bandwidth.
 - NVIDIA, AMD, Apple Silicon, Intel and CPU fallback detection paths.
+- NVIDIA detection commits availability/state only after a complete NVML probe, so partial probe failures cannot create a false CUDA result or suppress later vendor fallbacks.
 - Multi-GPU-aware hardware snapshots where platform tooling exposes the required data.
 
 ### Plan Mode & Comparison
@@ -132,7 +133,7 @@ Use a supported Python 3.10-3.14 interpreter for bootstrap. On Windows that can 
 
 `scripts/dev.py verify` runs the required local checks: pytest, import smoke and Ruff.
 
-`scripts/dev.py coverage` runs the deterministic pytest-cov lane and enforces the threshold configured in `pyproject.toml`. The canonical Ubuntu/Python 3.12 lane now measures **66.59% total coverage** (`5043` statements, `1685` missed) and enforces a **60%** merge floor. Focused deterministic tests raised `downloads/runner.py` from **24% to 90%** and `downloads/service_client.py` from **46% to 90%** without changing production behavior. The staged 50% → 55% → 60% coverage ratchet is complete; future increases should remain evidence-driven and must not rely on production-code exclusions.
+`scripts/dev.py coverage` runs the deterministic pytest-cov lane and enforces the threshold configured in `pyproject.toml`. The canonical Ubuntu/Python 3.12 lane now measures **67.40% total coverage** (`5095` statements, `1661` missed) and enforces a **60%** merge floor. Focused deterministic tests raised `downloads/runner.py` from **24% to 90%**, `downloads/service_client.py` from **46% to 90%**, and `core/hardware.py` from **44% to 52%** while pinning concrete correctness contracts. The staged 50% → 55% → 60% coverage ratchet is complete; future increases should remain evidence-driven and must not rely on production-code exclusions.
 
 `scripts/dev.py smoke` runs bounded/offline-safe smoke checks for the CLI, REST API, TUI startup path and download service.
 
@@ -274,11 +275,10 @@ The active post-hardening roadmap is in `.planning/roadmap.md`.
 
 Current priorities:
 
-1. residual silent-failure audit,
-2. Ollama registry parser resilience and structured-source research,
-3. safer incremental TUI DataTable updates,
-4. explicit Windows/WSL/Linux/macOS Apple Silicon acceptance matrix,
-5. targeted tests for consequential weak modules as concrete changes require them.
+1. Ollama registry parser resilience and structured-source research,
+2. safer incremental TUI DataTable updates,
+3. explicit Windows/WSL/Linux/macOS Apple Silicon acceptance matrix,
+4. targeted tests for consequential weak modules as concrete changes require them.
 
 Documentation maintenance rules are in `docs/maintenance.md`.
 

--- a/core/hardware.py
+++ b/core/hardware.py
@@ -130,33 +130,41 @@ class HardwareMonitor:
             self._detect_intel()
 
     def _detect_nvidia(self):
-        """Detect NVIDIA GPU via pynvml or nvidia_smi."""
+        """Detect NVIDIA GPU via pynvml or nvidia_smi without partial state commits."""
         try:
             import nvidia_smi
 
             nvidia_smi.nvmlInit()
-            self.handle = nvidia_smi.nvmlDeviceGetHandleByIndex(0)
-            self.gpu_name = nvidia_smi.nvmlDeviceGetName(self.handle)
-            if isinstance(self.gpu_name, bytes):
-                self.gpu_name = self.gpu_name.decode("utf-8")
-            self.nvidia_available = True
-            self.gpu_count = nvidia_smi.nvmlDeviceGetCount()
-            return
+            handle = nvidia_smi.nvmlDeviceGetHandleByIndex(0)
+            gpu_name = nvidia_smi.nvmlDeviceGetName(handle)
+            if isinstance(gpu_name, bytes):
+                gpu_name = gpu_name.decode("utf-8")
+            gpu_count = nvidia_smi.nvmlDeviceGetCount()
         except Exception:
             logger.debug("nvidia_smi NVML init failed (expected on CI/headless)")
+        else:
+            self.handle = handle
+            self.gpu_name = gpu_name
+            self.gpu_count = gpu_count
+            self.nvidia_available = True
+            return
 
         try:
             import pynvml
 
             pynvml.nvmlInit()
-            self.handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-            self.gpu_name = pynvml.nvmlDeviceGetName(self.handle)
-            if isinstance(self.gpu_name, bytes):
-                self.gpu_name = self.gpu_name.decode("utf-8")
-            self.nvidia_available = True
-            self.gpu_count = pynvml.nvmlDeviceGetCount()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            gpu_name = pynvml.nvmlDeviceGetName(handle)
+            if isinstance(gpu_name, bytes):
+                gpu_name = gpu_name.decode("utf-8")
+            gpu_count = pynvml.nvmlDeviceGetCount()
         except Exception:
             logger.debug("pynvml NVML init failed (expected on CI/headless)")
+        else:
+            self.handle = handle
+            self.gpu_name = gpu_name
+            self.gpu_count = gpu_count
+            self.nvidia_available = True
 
     def _detect_amd(self):
         """Detect AMD GPU via rocm-smi."""

--- a/tests/test_hardware_nvidia_atomicity.py
+++ b/tests/test_hardware_nvidia_atomicity.py
@@ -1,0 +1,102 @@
+"""Regression tests for atomic NVIDIA hardware detection state."""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+from core.hardware import HardwareMonitor
+
+
+def _monitor() -> HardwareMonitor:
+    monitor = HardwareMonitor.__new__(HardwareMonitor)
+    monitor.nvidia_available = False
+    monitor.amd_available = False
+    monitor.intel_available = False
+    monitor.apple_available = False
+    monitor.handle = None
+    monitor.gpu_name = "No GPU detected"
+    monitor.gpu_count = 0
+    return monitor
+
+
+def _nvml_module(
+    name: str,
+    *,
+    handle: object = "handle",
+    gpu_name: object = b"NVIDIA Test GPU",
+    gpu_count: object = 1,
+    init_error: Exception | None = None,
+    count_error: Exception | None = None,
+) -> ModuleType:
+    module = ModuleType(name)
+    module.nvmlInit = MagicMock(side_effect=init_error)
+    module.nvmlDeviceGetHandleByIndex = MagicMock(return_value=handle)
+    module.nvmlDeviceGetName = MagicMock(return_value=gpu_name)
+    module.nvmlDeviceGetCount = MagicMock(
+        side_effect=count_error,
+        return_value=gpu_count,
+    )
+    return module
+
+
+def test_partial_nvidia_backends_do_not_commit_false_positive_state():
+    monitor = _monitor()
+    primary = _nvml_module(
+        "nvidia_smi",
+        handle="partial-handle",
+        gpu_name=b"NVIDIA Partial",
+        count_error=RuntimeError("count failed"),
+    )
+    fallback = _nvml_module("pynvml", init_error=RuntimeError("fallback failed"))
+
+    with patch.dict(sys.modules, {"nvidia_smi": primary, "pynvml": fallback}):
+        monitor._detect_nvidia()
+
+    assert monitor.nvidia_available is False
+    assert monitor.handle is None
+    assert monitor.gpu_name == "No GPU detected"
+    assert monitor.gpu_count == 0
+
+
+def test_successful_pynvml_fallback_commits_only_complete_fallback_state():
+    monitor = _monitor()
+    primary = _nvml_module(
+        "nvidia_smi",
+        handle="partial-handle",
+        gpu_name=b"NVIDIA Partial",
+        count_error=RuntimeError("count failed"),
+    )
+    fallback = _nvml_module(
+        "pynvml",
+        handle="fallback-handle",
+        gpu_name=b"NVIDIA Fallback",
+        gpu_count=2,
+    )
+
+    with patch.dict(sys.modules, {"nvidia_smi": primary, "pynvml": fallback}):
+        monitor._detect_nvidia()
+
+    assert monitor.nvidia_available is True
+    assert monitor.handle == "fallback-handle"
+    assert monitor.gpu_name == "NVIDIA Fallback"
+    assert monitor.gpu_count == 2
+
+
+def test_successful_primary_backend_short_circuits_fallback():
+    monitor = _monitor()
+    primary = _nvml_module(
+        "nvidia_smi",
+        handle="primary-handle",
+        gpu_name=b"NVIDIA Primary",
+        gpu_count=1,
+    )
+    fallback = _nvml_module("pynvml", init_error=AssertionError("must not run"))
+
+    with patch.dict(sys.modules, {"nvidia_smi": primary, "pynvml": fallback}):
+        monitor._detect_nvidia()
+
+    assert monitor.nvidia_available is True
+    assert monitor.handle == "primary-handle"
+    assert monitor.gpu_name == "NVIDIA Primary"
+    assert monitor.gpu_count == 1
+    fallback.nvmlInit.assert_not_called()


### PR DESCRIPTION
Closes #80

## Goal

Prevent partially successful NVML probes from leaving a false-positive NVIDIA/CUDA hardware state.

## Final behavior

- each `nvidia_smi` / `pynvml` probe collects handle, GPU name, and GPU count in local variables
- monitor state is committed only after every required call in that backend succeeds
- a partial first-backend failure leaves state untouched before `pynvml` fallback
- if both backends fail, initialized no-NVIDIA state remains coherent so AMD/Apple/Intel fallback can continue
- successful first-backend detection still short-circuits the fallback
- existing backend priority and intentional fail-soft NVML logging are unchanged
- deterministic fake-module tests cover partial failures, fallback success, and primary success

## Residual silent-failure audit

The tracked audit is closed in this PR:

- provider registry import/detection: observable/fail-closed as appropriate
- provider selector synchronization: only expected Textual `NoMatches` is contained
- download polling/action sync: expected failures preserve last-known state with diagnostics
- download start/cancel/delete: broad catches are intentional user-visible containment and return explicit failure status
- hardware probes: AMD/Apple/Intel use bounded platform exception sets; NVIDIA broad NVML catches remain intentional backend fallbacks, with atomic state commit preventing partial false-positive CUDA state

## Non-goals

- no GPU vendor priority change
- no NVML dependency migration
- no VRAM/scoring formula changes
- no platform acceptance expansion

## Documentation sync

README, CHANGELOG, roadmap, CONCERNS, TESTING, and STACK are synchronized in this PR. Current canonical coverage evidence is `5095` statements / `1661` missed = **67.40%**, with a **60%** enforced floor; `core/hardware.py` is **52%**, up from 44%.

## Baseline

Post-#79 main: `0d16cc9298c1215f5f9da22936798e1b9591d3ae`

## Validation

Exact head: `5c790e39e81545f712449f3e57c4d3cd40694a2d`

- CI #276: success
- Package #168: success
- coverage 60% gate: success
- measured coverage: 67.40%
- open review threads: none
- submitted reviews: none