### PR TITLE
test: add fixture-backed Ollama parser contracts

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -22,13 +22,14 @@ Remote Ollama discovery still fetches `ollama.com/search`/library HTML and parse
 **Current mitigation:**
 
 - retry/backoff and provider diagnostics exist,
-- parsing has helper coverage.
+- sanitized fixture-backed contracts pin the currently supported search-anchor and model-detail table/card shapes,
+- deterministic tests cover ordering, dedupe, ignored links, direct/parent pull counts, GB/MB size parsing, preferred variants, and empty/unsupported HTML,
+- nested pull-count text boundaries are regression-covered after the #86 correction.
 
 **Next work:**
 
-1. fixture-backed parser contracts for supported shapes,
-2. structural-failure detection/diagnostics,
-3. research a supported structured registry/search source before considering migration.
+1. structural-failure detection/diagnostics that distinguish a genuine zero-result page from an unsupported page shape where evidence allows,
+2. research a supported structured registry/search source before considering migration.
 
 ### 2. Aggregate coverage is healthy but uneven across high-risk modules
 

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -35,7 +35,7 @@ Remote Ollama discovery still fetches `ollama.com/search`/library HTML and parse
 
 **Area:** TUI, download API, platform hardware probes
 
-The canonical Ubuntu/Python 3.12 coverage lane now measures **67.40% total coverage** (`5095` statements, `1661` missed) and enforces a **60%** floor.
+The canonical Ubuntu/Python 3.12 coverage lane now measures **67.44% total coverage** (`5095` statements, `1659` missed) and enforces a **60%** floor.
 
 Focused deterministic tests have removed several consequential weak points:
 
@@ -193,7 +193,7 @@ The following old concerns are retained here only to prevent accidental re-plann
 - **No REST input validation:** core model-search/plan inputs now validate to 400 responses.
 - **Provider failures hidden in REST/CLI:** resolved with REST diagnostics and CLI stderr warnings.
 - **Coverage configured but not enforced:** resolved by a canonical Ubuntu/Python 3.12 CI coverage job.
-- **Staged aggregate coverage goal:** completed at **50% → 55% → 60%**, with current measured aggregate **67.40%**.
+- **Staged aggregate coverage goal:** completed at **50% → 55% → 60%**, with current measured aggregate **67.44%**.
 - **Download runner execution largely untested:** resolved with deterministic fake-process/state coverage raising `downloads/runner.py` from 24% to 90%.
 - **Download service-client lifecycle largely untested:** resolved with deterministic lifecycle/request tests raising `downloads/service_client.py` from 46% to 90%.
 - **Legacy `shell=True` finding:** no active source match; old planning reference removed from current concerns.

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -105,10 +105,11 @@ The verify suite contains **600+ tests**. Coverage is measured separately so the
 Current canonical coverage evidence:
 
 - environment: Ubuntu / Python 3.12,
-- measured total: **67.40%**,
+- measured total: **67.44%**,
 - statements: `5095`,
-- missed: `1661`,
+- missed: `1659`,
 - enforced floor: **60%**,
+- `providers/ollama_provider.py`: **88%** after fixture-backed search/detail parser contracts,
 - `downloads/runner.py`: **90%**, up from 24%,
 - `downloads/service_client.py`: **90%**, up from 46%,
 - `core/hardware.py`: **52%**, up from 44% after atomic NVIDIA probe coverage.
@@ -155,8 +156,8 @@ The active roadmap includes a clearer acceptance matrix for Windows, WSL/Linux, 
 
 ### Uneven coverage distribution
 
-Aggregate coverage is now 67.40%; download runner and service-client lifecycle seams are both 90%. Remaining consequential lower-coverage modules include `app/modals.py` 25%, `tui_app.py` 38%, `downloads/api.py` 46%, `core/hardware.py` 52%, and `app/viewer.py` 57%. Treat these as targets when concrete work touches them, not as a perpetual percentage-only backlog.
+Aggregate coverage is now 67.44%; Ollama provider parsing is 88%, and download runner and service-client lifecycle seams are both 90%. Remaining consequential lower-coverage modules include `app/modals.py` 25%, `tui_app.py` 38%, `downloads/api.py` 46%, `core/hardware.py` 52%, and `app/viewer.py` 57%. Treat these as targets when concrete work touches them, not as a perpetual percentage-only backlog.
 
 ### Ollama registry HTML dependency
 
-The most important external-format risk remains Ollama registry HTML scraping. BeautifulSoup itself is not the problem; the contract depends on a third-party page structure that can change without API-version guarantees. Parser fixture coverage and structural-failure detection are P1 roadmap work.
+The most important external-format risk remains Ollama registry HTML scraping. BeautifulSoup itself is not the problem; the contract depends on a third-party page structure that can change without API-version guarantees. Fixture-backed parser contracts now pin the supported search/detail shapes; structural-failure detection remains P1 roadmap work.

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -40,11 +40,12 @@ Canonical CI coverage environment:
 - Ubuntu,
 - Python 3.12.
 
-Current measured evidence from the NVIDIA atomicity hardening run:
+Current measured evidence from the fixture-backed Ollama parser contract run:
 
 - statements: `5095`,
-- missed: `1661`,
-- total coverage: **67.40%**,
+- missed: `1659`,
+- total coverage: **67.44%**,
+- `providers/ollama_provider.py`: **88%**,
 - `downloads/runner.py`: **90%**,
 - `downloads/service_client.py`: **90%**,
 - `core/hardware.py`: **52%**, up from 44%.
@@ -248,8 +249,9 @@ Use live tests to validate actual external/provider behavior, not as a substitut
 
 ## Coverage Distribution and Future Targets
 
-The staged aggregate ratchet is complete at **60% enforced / 67.40% measured**. Focused execution/lifecycle/hardware work removed several consequential weak seams:
+The staged aggregate ratchet is complete at **60% enforced / 67.44% measured**. Focused execution/lifecycle/hardware/provider-parser work removed several consequential weak seams:
 
+- `providers/ollama_provider.py`: **88%** after fixture-backed search/detail parser contracts,
 - `downloads/runner.py`: **24% → 90%**,
 - `downloads/service_client.py`: **46% → 90%**,
 - `core/hardware.py`: **44% → 52%**.

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -139,6 +139,7 @@ The NVIDIA probe regression suite uses fake `nvidia_smi`/`pynvml` modules so par
 Cover:
 
 - Hugging Face/Ollama retry and structured diagnostics,
+- Ollama fixture-backed HTML parser contracts for search anchors and model-detail table/card shapes,
 - LM Studio/Docker response parse containment,
 - Docker installed-list parse containment,
 - MLX I/O containment and global limit semantics,
@@ -146,6 +147,17 @@ Cover:
 - provider registry import/detection observability,
 - pagination authority,
 - installed-model behavior.
+
+`tests/fixtures/ollama/` contains sanitized deterministic HTML consumed by `tests/test_ollama_scraping.py`. The fixture corpus pins the currently supported document shapes before structural-failure diagnostics are added, including:
+
+- search result ordering and duplicate suppression,
+- ignored non-model/tag/external links,
+- direct-anchor and parent-level pull counts,
+- model-detail table header lookup and GB/MB size parsing,
+- model-detail card filtering and preferred `:latest` selection,
+- genuine zero-result search and unsupported/empty detail HTML.
+
+Live Ollama behavior remains a separate opt-in concern; these fixtures are the deterministic parser contract.
 
 Provider error tests should assert both legacy human-readable errors and structured metadata when the provider supports both.
 

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -50,7 +50,7 @@ The following items from the old roadmap are already implemented and should not 
 - Focused fake-process/state coverage for `downloads/runner.py`, raising that module from 24% to 90%.
 - Focused lifecycle/request coverage for `downloads/service_client.py`, raising that module from 46% to 90%.
 - Focused NVIDIA probe coverage raised `core/hardware.py` from 44% to 52% while pinning atomic state semantics.
-- Current canonical coverage evidence: `5095` statements, `1661` missed, **67.40%** aggregate, **60% enforced floor**.
+- Current canonical coverage evidence: `5095` statements, `1659` missed, **67.44%** aggregate, **60% enforced floor**.
 - Residual silent-failure audit completed for the previously tracked provider registry, selector synchronization, download polling/sync/action, and hardware-probe boundaries.
 - Sanitized fixture-backed Ollama parser contracts pin supported search-anchor and model-detail table/card shapes, including ordering, dedupe, filtering, pull counts, size parsing, preferred variants, and empty/unsupported HTML behavior.
 

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -52,6 +52,7 @@ The following items from the old roadmap are already implemented and should not 
 - Focused NVIDIA probe coverage raised `core/hardware.py` from 44% to 52% while pinning atomic state semantics.
 - Current canonical coverage evidence: `5095` statements, `1661` missed, **67.40%** aggregate, **60% enforced floor**.
 - Residual silent-failure audit completed for the previously tracked provider registry, selector synchronization, download polling/sync/action, and hardware-probe boundaries.
+- Sanitized fixture-backed Ollama parser contracts pin supported search-anchor and model-detail table/card shapes, including ordering, dedupe, filtering, pull counts, size parsing, preferred variants, and empty/unsupported HTML behavior.
 
 ## P1 — Quality Baseline
 
@@ -71,13 +72,7 @@ Do not create percentage-only PRs indefinitely. Add focused tests when these mod
 
 ## P1 — Ollama Registry Resilience
 
-Ollama remote discovery still depends on `ollama.com` HTML structure. This is the largest remaining external-format fragility and is now the primary P1 implementation track.
-
-### O1. Fixture-backed parser contracts
-
-- Store representative sanitized/cached HTML fixtures for the currently supported result shapes.
-- Test table/card/anchor extraction and malformed/empty responses deterministically.
-- Pin filtering, ordering, metadata extraction, and no-result behavior.
+Ollama remote discovery still depends on `ollama.com` HTML structure. The fixture-backed parser baseline is complete; the remaining P1 work is detecting unsupported page-shape changes and evaluating a supported structured source.
 
 ### O2. Structural failure detection
 
@@ -86,7 +81,7 @@ Ollama remote discovery still depends on `ollama.com` HTML structure. This is th
 
 ### O3. Structured-source/API research
 
-After parser coverage is strong, research whether Ollama exposes a supported structured registry/search source suitable for replacing or reducing HTML scraping. Do not migrate until compatibility, pagination, metadata quality, and rate-limit behavior are understood.
+With deterministic fixture coverage in place, research whether Ollama exposes a supported structured registry/search source suitable for replacing or reducing HTML scraping. Do not migrate until compatibility, pagination, metadata quality, and rate-limit behavior are understood.
 
 ## P2 — TUI Results Performance
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Use a supported Python 3.10-3.14 interpreter for bootstrap. On Windows that can 
 
 `scripts/dev.py verify` runs the required local checks: pytest, import smoke and Ruff.
 
-`scripts/dev.py coverage` runs the deterministic pytest-cov lane and enforces the threshold configured in `pyproject.toml`. The canonical Ubuntu/Python 3.12 lane now measures **67.40% total coverage** (`5095` statements, `1661` missed) and enforces a **60%** merge floor. Focused deterministic tests raised `downloads/runner.py` from **24% to 90%**, `downloads/service_client.py` from **46% to 90%**, and `core/hardware.py` from **44% to 52%** while pinning concrete correctness contracts. The staged 50% → 55% → 60% coverage ratchet is complete; future increases should remain evidence-driven and must not rely on production-code exclusions.
+`scripts/dev.py coverage` runs the deterministic pytest-cov lane and enforces the threshold configured in `pyproject.toml`. The canonical Ubuntu/Python 3.12 lane now measures **67.44% total coverage** (`5095` statements, `1659` missed) and enforces a **60%** merge floor. Focused deterministic tests raised `downloads/runner.py` from **24% to 90%**, `downloads/service_client.py` from **46% to 90%**, and `core/hardware.py` from **44% to 52%** while pinning concrete correctness contracts. The staged 50% → 55% → 60% coverage ratchet is complete; future increases should remain evidence-driven and must not rely on production-code exclusions.
 
 `scripts/dev.py smoke` runs bounded/offline-safe smoke checks for the CLI, REST API, TUI startup path and download service.
 

--- a/tests/fixtures/ollama/empty.html
+++ b/tests/fixtures/ollama/empty.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <p>No matching models.</p>
+      <table>
+        <thead><tr><th>Name</th><th>Files</th></tr></thead>
+        <tbody><tr><td>llama3:latest</td><td>manifest</td></tr></tbody>
+      </table>
+      <a href="/library/qwen2:latest">Different model · 5.1 GB</a>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/ollama/model_cards.html
+++ b/tests/fixtures/ollama/model_cards.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <section>
+      <a href="/library/llama3:latest">Latest variant · 4.7 GB</a>
+      <a href="/library/llama3:q8_0">Q8 variant · 8.2 GB</a>
+      <a href="/library/qwen2:latest">Unrelated model · 5.1 GB</a>
+      <a href="/library/llama3">Base model without variant · 4.7 GB</a>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/ollama/model_table.html
+++ b/tests/fixtures/ollama/model_table.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <table>
+      <thead>
+        <tr><th>Variant</th><th>Files</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>ignored</td><td>ignored</td></tr>
+      </tbody>
+    </table>
+
+    <table>
+      <thead>
+        <tr><th>Size</th><th>Notes</th><th>Name</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>4.7 GB</td><td>default</td><td>llama3:latest</td></tr>
+        <tr><td>780 MB</td><td>small</td><td>llama3:tiny</td></tr>
+        <tr><td>unknown</td><td>bad size</td><td>llama3:broken</td></tr>
+        <tr><td>5.5 GB</td><td>short row</td></tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/tests/fixtures/ollama/search_empty.html
+++ b/tests/fixtures/ollama/search_empty.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <p>No matching models.</p>
+      <a href="/blog/registry-news">Registry news</a>
+      <a href="https://example.invalid/library/external">External link</a>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/ollama/search_results.html
+++ b/tests/fixtures/ollama/search_results.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <ul>
+        <li>
+          <a href="/library/llama3">Llama 3 <span>1.2M Pulls</span></a>
+        </li>
+        <li>
+          <a href="/library/qwen2">Qwen 2</a>
+          <span>500K Pulls</span>
+        </li>
+        <li>
+          <a href="/library/llama3">Duplicate Llama 3 <span>9M Pulls</span></a>
+        </li>
+        <li>
+          <a href="/library/gemma">Gemma</a>
+        </li>
+        <li>
+          <a href="/library/llama3/tags">Llama 3 tags</a>
+        </li>
+        <li>
+          <a href="/blog/registry-news">Registry news</a>
+        </li>
+        <li>
+          <a href="https://example.invalid/library/external">External link</a>
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/tests/test_ollama_scraping.py
+++ b/tests/test_ollama_scraping.py
@@ -1,30 +1,30 @@
-"""Mock-based tests for Ollama provider HTML scraping."""
+"""Fixture-backed regression coverage for Ollama HTML parsing."""
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from requests.exceptions import RequestException
 
-SEARCH_HTML = """
-<html><body>
-<a href="/library/llama3">llama3 1.2M Pulls</a>
-<a href="/library/qwen">qwen2 500K Pulls</a>
-<a href="/library/codellama">codellama 300K Pulls</a>
-</body></html>
-"""
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "ollama"
 
-DETAIL_HTML = """
-<html><body>
-<table>
-<thead><tr><th>Name</th><th>Size</th></tr></thead>
-<tbody>
-<tr><td>llama3:7b-q4</td><td>4.2 GB</td></tr>
-<tr><td>llama3:13b-q4</td><td>7.8 GB</td></tr>
-</tbody>
-</table>
-</body></html>
-"""
+
+def _fixture(name: str) -> str:
+    """Load one sanitized Ollama HTML fixture."""
+    return (_FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def _specs() -> dict[str, object]:
+    return {
+        "vram_total": 24,
+        "vram_free": 20,
+        "ram_total": 32,
+        "ram_free": 28,
+        "gpu_name": "RTX 4090",
+        "has_gpu": True,
+    }
 
 
 class FakeResponse:
@@ -40,59 +40,155 @@ class FakeResponse:
 class TestOllamaSearch:
     @patch("providers.ollama_provider.get_session")
     @patch("providers.ollama_provider.get_ollama_model_metadata", return_value=None)
-    def test_search_parses_library_links(self, mock_meta, mock_session):
-        mock_session.return_value.get.return_value = FakeResponse(text=SEARCH_HTML)
+    def test_search_fixture_pins_order_dedupe_filters_and_pull_counts(
+        self,
+        mock_meta,
+        mock_session,
+    ):
+        mock_session.return_value.get.return_value = FakeResponse(
+            text=_fixture("search_results.html")
+        )
         from providers.ollama_provider import search_ollama_models
 
-        specs = {
-            "vram_total": 24, "vram_free": 20, "ram_total": 32, "ram_free": 28,
-            "gpu_name": "RTX 4090", "has_gpu": True,
-        }
-        results, _errors, _has_more = search_ollama_models("*", specs, [], page=0, page_size=20)
-        assert len(results) >= 2
-        assert any("llama3" in r["name"] for r in results)
+        results, errors, has_more = search_ollama_models(
+            "*",
+            _specs(),
+            ["qwen2"],
+            page=0,
+            page_size=20,
+        )
+
+        assert errors == []
+        assert has_more is False
+        assert [result["name"] for result in results] == ["llama3", "qwen2", "gemma"]
+        assert [result["score"] for result in results] == [
+            "[cyan]📥 1.2M[/cyan]",
+            "[cyan]📥 500K[/cyan]",
+            "[grey50]-[/grey50]",
+        ]
+        assert results[1]["inst"] == "[green]✔[/green]"
+        assert mock_meta.call_count == 3
 
     @patch("providers.ollama_provider.get_session")
     @patch("providers.ollama_provider.get_ollama_model_metadata", return_value=None)
-    def test_search_handles_empty_results(self, mock_meta, mock_session):
-        mock_session.return_value.get.return_value = FakeResponse(text="<html></html>")
+    def test_search_empty_fixture_is_a_genuine_zero_result(
+        self,
+        _mock_meta,
+        mock_session,
+    ):
+        mock_session.return_value.get.return_value = FakeResponse(
+            text=_fixture("search_empty.html")
+        )
         from providers.ollama_provider import search_ollama_models
 
-        specs = {"vram_total": 0, "vram_free": 0, "ram_total": 0, "ram_free": 0, "gpu_name": "", "has_gpu": False}
-        results, _errors, _has_more = search_ollama_models("*", specs, [], page=0, page_size=20)
+        results, errors, has_more = search_ollama_models(
+            "*",
+            _specs(),
+            [],
+            page=0,
+            page_size=20,
+        )
+
         assert results == []
+        assert errors == []
+        assert has_more is False
 
     @patch("providers.ollama_provider.get_session")
     def test_search_network_error(self, mock_session):
         mock_session.return_value.get.side_effect = RequestException("Connection failed")
         from providers.ollama_provider import search_ollama_models
 
-        specs = {"vram_total": 0, "vram_free": 0, "ram_total": 0, "ram_free": 0, "gpu_name": "", "has_gpu": False}
-        results, _errors, _has_more = search_ollama_models("test", specs, [], page=0, page_size=20)
+        results, errors, has_more = search_ollama_models(
+            "test",
+            _specs(),
+            [],
+            page=0,
+            page_size=20,
+        )
+
         assert results == []
+        assert errors == ["Ollama search failed: Connection failed"]
+        assert has_more is False
+
+
+class TestOllamaDetailParser:
+    def test_table_fixture_pins_header_lookup_sizes_and_short_row_handling(self):
+        from providers.ollama_provider import _extract_models_table_rows
+
+        rows = _extract_models_table_rows(_fixture("model_table.html"), model_name="llama3")
+
+        assert [row["name"] for row in rows] == [
+            "llama3:latest",
+            "llama3:tiny",
+            "llama3:broken",
+        ]
+        assert rows[0]["size_text"] == "4.7 GB"
+        assert rows[0]["size_gb"] == pytest.approx(4.7)
+        assert rows[1]["size_gb"] == pytest.approx(780 / 1024)
+        assert rows[2]["size_gb"] is None
+
+    def test_card_fixture_filters_variants_and_prefers_latest(self):
+        from providers.ollama_provider import (
+            _extract_models_table_rows,
+            _select_preferred_model_variant,
+        )
+
+        rows = _extract_models_table_rows(_fixture("model_cards.html"), model_name="llama3")
+        chosen = _select_preferred_model_variant("llama3", rows)
+
+        assert [row["name"] for row in rows] == ["llama3:latest", "llama3:q8_0"]
+        assert [row["size_gb"] for row in rows] == pytest.approx([4.7, 8.2])
+        assert chosen is not None
+        assert chosen["name"] == "llama3:latest"
+        assert chosen["size_gb"] == pytest.approx(4.7)
+
+    def test_empty_detail_fixture_has_no_supported_variant_shape(self):
+        from providers.ollama_provider import _extract_models_table_rows
+
+        rows = _extract_models_table_rows(_fixture("empty.html"), model_name="llama3")
+
+        assert rows == []
 
 
 class TestOllamaMetadata:
+    @patch("providers.ollama_provider.cache_db.set_model_cache")
+    @patch("providers.ollama_provider.cache_db.get_model_cache", return_value=None)
     @patch("providers.ollama_provider.get_session")
-    def test_fetches_model_detail(self, mock_session):
-        mock_session.return_value.get.return_value = FakeResponse(text=DETAIL_HTML)
+    def test_fetches_preferred_variant_from_table_fixture(
+        self,
+        mock_session,
+        _mock_cache_get,
+        mock_cache_set,
+    ):
+        mock_session.return_value.get.return_value = FakeResponse(
+            text=_fixture("model_table.html")
+        )
         from providers.ollama_provider import get_ollama_model_metadata
 
         meta = get_ollama_model_metadata("llama3")
-        assert meta is not None
 
+        assert meta is not None
+        assert meta["variant"] == "llama3:latest"
+        assert meta["size_text"] == "4.7 GB"
+        assert meta["size_gb"] == pytest.approx(4.7)
+        mock_cache_set.assert_called_once()
+
+    @patch("providers.ollama_provider.cache_db.get_model_cache", return_value=None)
     @patch("providers.ollama_provider.get_session")
-    def test_handles_http_error(self, mock_session):
+    def test_handles_http_error(self, mock_session, _mock_cache_get):
         mock_session.return_value.get.return_value = FakeResponse(status_code=404)
         from providers.ollama_provider import get_ollama_model_metadata
 
         meta = get_ollama_model_metadata("nonexistent")
+
         assert meta is None
 
+    @patch("providers.ollama_provider.cache_db.get_model_cache", return_value=None)
     @patch("providers.ollama_provider.get_session")
-    def test_handles_network_error(self, mock_session):
+    def test_handles_network_error(self, mock_session, _mock_cache_get):
         mock_session.return_value.get.side_effect = RequestException("Network error")
         from providers.ollama_provider import get_ollama_model_metadata
 
         meta = get_ollama_model_metadata("test")
+
         assert meta is None


### PR DESCRIPTION
Closes #82

## Goal

Establish a deterministic fixture-backed contract for the currently supported Ollama HTML parser shapes before structural-failure diagnostics are added.

## Final behavior

- adds sanitized fixtures under `tests/fixtures/ollama/` for search results, genuine zero results, model-detail tables, model-detail cards, and unsupported detail HTML
- search fixtures pin exact document order, duplicate suppression, ignored non-model/tag/external links, direct/parent pull counts, missing pull counts, and installed markers
- table fixtures pin header-based column lookup, GB/MB parsing, invalid-size preservation, and short-row skipping
- card fixtures pin same-model filtering and preferred `:latest` selection
- metadata tests isolate the persistent cache and pin exact preferred-variant metadata
- production parser code is unchanged in this PR
- the real nested-text pull-count defect discovered by these fixtures was fixed separately in #86 before this branch was rebased onto current `main`

## Documentation sync

- roadmap marks the O1 fixture-backed parser baseline complete
- active Ollama P1 work is now O2 structural-failure detection plus O3 structured-source/API research
- `CONCERNS.md`, `TESTING.md`, and `STACK.md` document the fixture contract and current mitigation
- README/planning evidence is synchronized to canonical coverage **67.44%** (`5095` statements / `1659` missed); `providers/ollama_provider.py` is **88%**
- CHANGELOG was reviewed; no additional test-only release note is needed

## Non-goals

- no structural-failure diagnostic yet (O2)
- no parser rewrite
- no structured-source/API migration research (O3)
- no live network dependency

## Baseline

Current `main`: `b55eb1d5514a733444a0713cb960fef4ee7afecf` (#86)

## Validation

Exact head: `394fb946189e536719d810c135edf5b719a7c1b9`

- CI #291: success
- canonical coverage gate: success — **67.44%** (`5095` / `1659`)
- `providers/ollama_provider.py`: **88%**
- Package: not triggered by test/docs-only paths
- open review threads: none
- submitted reviews: none