### PR TITLE
fix: preserve Ollama pull-count text boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Preserved orchestrator-generated provider failures as machine-readable diagnostics instead of dropping them to strings only.
 - Fixed provider pagination authority so non-paginated/multi-provider searches cannot synthesize false continuation from result counts.
 - Fixed NVIDIA hardware detection so partially successful NVML probes cannot leave a false-positive CUDA/NVIDIA state or suppress fallback vendor detection.
+- Fixed Ollama registry pull-count parsing so nested HTML text boundaries cannot merge model-name digits into pull counts.
 
 ### REST and CLI contracts
 

--- a/providers/ollama_provider.py
+++ b/providers/ollama_provider.py
@@ -374,14 +374,14 @@ def search_ollama_models(
                 continue
             found_keys.add(unique_key)
 
-            full_text = anchor.get_text(strip=True)
+            full_text = anchor.get_text(" ", strip=True)
             pulls = re.search(r"(\d+(?:\.\d+)?[KM]?)\s*Pulls", full_text, re.IGNORECASE)
             if not pulls:
                 parent = anchor.find_parent("li")
                 if parent:
                     pulls = re.search(
                         r"(\d+(?:\.\d+)?[KM]?)\s*Pulls",
-                        parent.get_text(strip=True),
+                        parent.get_text(" ", strip=True),
                         re.IGNORECASE,
                     )
 

--- a/tests/test_ollama_pull_count_spacing.py
+++ b/tests/test_ollama_pull_count_spacing.py
@@ -4,19 +4,20 @@ from unittest.mock import patch
 
 
 class FakeResponse:
-    status_code = 200
-    headers = {}
-    text = """
-    <html><body><ul>
-      <li>
-        <a href="/library/llama3">Llama 3 <span>1.2M Pulls</span></a>
-      </li>
-      <li>
-        <a href="/library/qwen2">Qwen 2</a>
-        <span>500K Pulls</span>
-      </li>
-    </ul></body></html>
-    """
+    def __init__(self):
+        self.status_code = 200
+        self.headers = {}
+        self.text = """
+        <html><body><ul>
+          <li>
+            <a href="/library/llama3">Llama 3 <span>1.2M Pulls</span></a>
+          </li>
+          <li>
+            <a href="/library/qwen2">Qwen 2</a>
+            <span>500K Pulls</span>
+          </li>
+        </ul></body></html>
+        """
 
 
 def _specs() -> dict[str, object]:

--- a/tests/test_ollama_pull_count_spacing.py
+++ b/tests/test_ollama_pull_count_spacing.py
@@ -1,0 +1,49 @@
+"""Regression coverage for Ollama pull-count text-node boundaries."""
+
+from unittest.mock import patch
+
+
+class FakeResponse:
+    status_code = 200
+    headers = {}
+    text = """
+    <html><body><ul>
+      <li>
+        <a href="/library/llama3">Llama 3 <span>1.2M Pulls</span></a>
+      </li>
+      <li>
+        <a href="/library/qwen2">Qwen 2</a>
+        <span>500K Pulls</span>
+      </li>
+    </ul></body></html>
+    """
+
+
+def _specs() -> dict[str, object]:
+    return {
+        "vram_total": 0,
+        "vram_free": 0,
+        "ram_total": 16,
+        "ram_free": 8,
+        "gpu_name": "",
+        "has_gpu": False,
+    }
+
+
+def test_nested_text_nodes_do_not_pollute_pull_counts():
+    with (
+        patch("providers.ollama_provider.get_session") as get_session,
+        patch("providers.ollama_provider.get_ollama_model_metadata", return_value=None),
+    ):
+        get_session.return_value.get.return_value = FakeResponse()
+        from providers.ollama_provider import search_ollama_models
+
+        results, errors, has_more = search_ollama_models("*", _specs(), [])
+
+    assert errors == []
+    assert has_more is False
+    assert [result["name"] for result in results] == ["llama3", "qwen2"]
+    assert [result["score"] for result in results] == [
+        "[cyan]📥 1.2M[/cyan]",
+        "[cyan]📥 500K[/cyan]",
+    ]


### PR DESCRIPTION
Closes #85

## Goal

Prevent nested Ollama registry markup from contaminating pull-count extraction with digits from the model name or neighboring text nodes.

## Final behavior

- anchor pull-count text extraction uses `get_text(" ", strip=True)` so nested text nodes retain whitespace boundaries
- the parent-`<li>` fallback uses the same separator-aware extraction
- the existing pull-count regex, result ordering, dedupe, metadata enrichment, diagnostics, and pagination behavior remain unchanged
- focused deterministic regression coverage pins both direct nested-anchor and parent-level pull counts
- production diff is exactly +2/-2 in `providers/ollama_provider.py`

## Non-goals

- no structural-failure diagnostic (O2)
- no broad parser refactor
- no fixture-corpus rollout; that remains #82/#84
- no model-detail parser change

## Discovery

This defect was exposed by the fixture-backed parser contract work in #84. That PR remains separate and will resume against the corrected parser baseline.

## Documentation sync

CHANGELOG Unreleased reliability notes record the pull-count parsing correction. README/roadmap/codebase docs were reviewed; no broader user/config/roadmap contract changes in this PR.

## Baseline

Post-#81 main: `27245834973e81fccb9591c33b54725af784a450`

## Validation

Exact head: `45d361178d2cdc73ec41f208f0b0ee6f184dcdee`

- CI #281: success
- Package #171: success
- coverage 60% gate: success
- open review threads: none
- submitted reviews: none