### PR TITLE
fix: detect unsupported Ollama search page shapes

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -16,20 +16,22 @@ Remote Ollama discovery still fetches `ollama.com/search`/library HTML and parse
 **Risk:**
 
 - third-party page structure can change without a versioned API contract,
-- valid “no results” and parser-structure breakage can be difficult to distinguish,
+- future search or model-detail page shapes can drift beyond the sanitized fixture corpus,
 - metadata/pagination behavior is constrained by page representation.
 
 **Current mitigation:**
 
 - retry/backoff and provider diagnostics exist,
 - sanitized fixture-backed contracts pin the currently supported search-anchor and model-detail table/card shapes,
-- deterministic tests cover ordering, dedupe, ignored links, direct/parent pull counts, GB/MB size parsing, preferred variants, and empty/unsupported HTML,
+- deterministic tests cover ordering, dedupe, ignored links, direct/parent pull counts, GB/MB size parsing, preferred variants, genuine zero results, and unsupported search HTML,
+- search HTML with recognized models follows the existing success path; a resultless page containing the verified `No models found.` marker is a clean zero result,
+- a resultless HTTP-200 search page without that marker emits the stable legacy diagnostic plus a non-retryable structured `parse_error` instead of silently reporting success,
 - nested pull-count text boundaries are regression-covered after the #86 correction.
 
 **Next work:**
 
-1. structural-failure detection/diagnostics that distinguish a genuine zero-result page from an unsupported page shape where evidence allows,
-2. research a supported structured registry/search source before considering migration.
+- research a supported structured registry/search source before considering migration,
+- keep model-detail unsupported-shape policy separate until there is concrete evidence/caller impact that justifies expanding the structural-failure boundary.
 
 ### 2. Aggregate coverage is healthy but uneven across high-risk modules
 

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -140,7 +140,7 @@ The NVIDIA probe regression suite uses fake `nvidia_smi`/`pynvml` modules so par
 Cover:
 
 - Hugging Face/Ollama retry and structured diagnostics,
-- Ollama fixture-backed HTML parser contracts for search anchors and model-detail table/card shapes,
+- Ollama fixture-backed HTML parser contracts for search anchors, genuine zero/unsupported search classification, and model-detail table/card shapes,
 - LM Studio/Docker response parse containment,
 - Docker installed-list parse containment,
 - MLX I/O containment and global limit semantics,
@@ -149,14 +149,18 @@ Cover:
 - pagination authority,
 - installed-model behavior.
 
-`tests/fixtures/ollama/` contains sanitized deterministic HTML consumed by `tests/test_ollama_scraping.py`. The fixture corpus pins the currently supported document shapes before structural-failure diagnostics are added, including:
+`tests/fixtures/ollama/` contains sanitized deterministic HTML consumed by `tests/test_ollama_scraping.py` and structured-error tests. The fixture corpus pins the currently supported document shapes and the observable structural-failure boundary, including:
 
 - search result ordering and duplicate suppression,
 - ignored non-model/tag/external links,
 - direct-anchor and parent-level pull counts,
 - model-detail table header lookup and GB/MB size parsing,
 - model-detail card filtering and preferred `:latest` selection,
-- genuine zero-result search and unsupported/empty detail HTML.
+- a resultless search page containing the verified `No models found.` marker as clean zero-result success,
+- a resultless HTTP-200 search page without recognized model anchors or that marker as a stable legacy error plus non-retryable structured `parse_error`,
+- unsupported/empty detail HTML remaining separate from the search structural-failure policy.
+
+The direct module-level search contract remains the established three-item `(results, errors, has_more)` tuple; provider-adapter tests additionally pin aligned structured diagnostics without widening that public shape.
 
 Live Ollama behavior remains a separate opt-in concern; these fixtures are the deterministic parser contract.
 

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -52,7 +52,8 @@ The following items from the old roadmap are already implemented and should not 
 - Focused NVIDIA probe coverage raised `core/hardware.py` from 44% to 52% while pinning atomic state semantics.
 - Current canonical coverage evidence: `5095` statements, `1659` missed, **67.44%** aggregate, **60% enforced floor**.
 - Residual silent-failure audit completed for the previously tracked provider registry, selector synchronization, download polling/sync/action, and hardware-probe boundaries.
-- Sanitized fixture-backed Ollama parser contracts pin supported search-anchor and model-detail table/card shapes, including ordering, dedupe, filtering, pull counts, size parsing, preferred variants, and empty/unsupported HTML behavior.
+- Sanitized fixture-backed Ollama parser contracts pin supported search-anchor and model-detail table/card shapes, including ordering, dedupe, filtering, pull counts, size parsing, preferred variants, and genuine zero-result behavior.
+- Ollama search structural-failure detection distinguishes the verified `No models found.` zero-result marker from unsupported HTTP-200 page shapes and emits aligned legacy plus non-retryable structured `parse_error` diagnostics instead of silent false success.
 
 ## P1 — Quality Baseline
 
@@ -72,16 +73,11 @@ Do not create percentage-only PRs indefinitely. Add focused tests when these mod
 
 ## P1 — Ollama Registry Resilience
 
-Ollama remote discovery still depends on `ollama.com` HTML structure. The fixture-backed parser baseline is complete; the remaining P1 work is detecting unsupported page-shape changes and evaluating a supported structured source.
-
-### O2. Structural failure detection
-
-- Distinguish a genuine zero-result search from “page shape changed and parser matched nothing” where evidence allows.
-- Surface a stable diagnostic rather than silently returning success on a broken parser contract.
+Ollama remote discovery still depends on `ollama.com` HTML structure. Fixture-backed parser contracts and search structural-failure detection are complete; the remaining P1 work is evaluating a supported structured source that could reduce or replace HTML scraping.
 
 ### O3. Structured-source/API research
 
-With deterministic fixture coverage in place, research whether Ollama exposes a supported structured registry/search source suitable for replacing or reducing HTML scraping. Do not migrate until compatibility, pagination, metadata quality, and rate-limit behavior are understood.
+With deterministic fixture coverage and observable search-shape failure detection in place, research whether Ollama exposes a supported structured registry/search source suitable for replacing or reducing HTML scraping. Do not migrate until compatibility, pagination, metadata quality, and rate-limit behavior are understood.
 
 ## P2 — TUI Results Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed provider pagination authority so non-paginated/multi-provider searches cannot synthesize false continuation from result counts.
 - Fixed NVIDIA hardware detection so partially successful NVML probes cannot leave a false-positive CUDA/NVIDIA state or suppress fallback vendor detection.
 - Fixed Ollama registry pull-count parsing so nested HTML text boundaries cannot merge model-name digits into pull counts.
+- Fixed Ollama registry search classification so unsupported HTTP-200 page shapes emit legacy and structured parse diagnostics instead of masquerading as genuine zero-result success.
 
 ### REST and CLI contracts
 

--- a/docs/superpowers/plans/2026-09-08-ollama-search-shape-detection.md
+++ b/docs/superpowers/plans/2026-09-08-ollama-search-shape-detection.md
@@ -1,0 +1,164 @@
+# Ollama Search Shape Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close GitHub issue #87 by distinguishing genuine zero-result Ollama search pages from unsupported HTTP-200 page shapes and surfacing the latter through the existing legacy and structured parse-error channels.
+
+**Architecture:** Keep `search_ollama_models()` as the single function-based search contract and preserve its `(results, errors, has_more)` return shape. After the existing supported `/library/` anchor scan, classify an empty result as genuine zero only when the parsed document contains the verified `No models found.` marker; otherwise record one stable non-retryable `parse_error`. `OllamaProvider.search()` continues to adapt the same legacy errors into `SearchResult` while collecting structured diagnostics through the existing sink.
+
+**Tech Stack:** Python, BeautifulSoup, pytest/unittest.mock, existing `ProviderError` and provider adapter contracts.
+
+**Spec:** GitHub issue #87 (`fix: detect unsupported Ollama search page shapes`).
+
+## Global Constraints
+
+- Preserve the direct three-item `(results, errors, has_more)` tuple.
+- Preserve ordering, dedupe, metadata enrichment, pagination flags, HTTP diagnostics, and transport diagnostics.
+- Reuse `ProviderError(code="parse_error", retryable=False)`; do not add a new public diagnostic code.
+- No live-network CI dependency.
+- No model-detail structural-failure policy and no structured-source/API migration in this PR.
+- Exact-head CI and the 60% coverage gate must be green before merge; Package must be green if triggered.
+
+---
+
+### Task 1: Pin Search Page Classification Contracts
+
+**Files:**
+- Modify: `tests/fixtures/ollama/search_empty.html`
+- Create: `tests/fixtures/ollama/search_unsupported.html`
+- Modify: `tests/test_ollama_scraping.py`
+- Modify: `tests/test_ollama_structured_errors.py`
+
+**Interfaces:**
+- Consumes: `search_ollama_models(query, specs, local_models, page=0, page_size=15, _structured_error_sink=None)` and `OllamaProvider.search(...)`.
+- Produces: deterministic fixture-backed contracts for model-bearing, genuine-zero, and unsupported search page shapes.
+
+- [ ] **Step 1: Update the genuine-zero fixture marker**
+
+Replace the stale `No matching models.` text in `tests/fixtures/ollama/search_empty.html` with the verified current marker:
+
+```html
+<p>No models found.</p>
+```
+
+Keep the non-model links so the fixture still proves they are ignored.
+
+- [ ] **Step 2: Add an unsupported 200-page fixture**
+
+Create `tests/fixtures/ollama/search_unsupported.html` with valid HTML, no `/library/` model anchor, and no `No models found.` marker, for example:
+
+```html
+<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <section data-registry-results="new-shape">
+        <article>Model cards moved to a new client-rendered shape.</article>
+      </section>
+      <a href="/blog/registry-news">Registry news</a>
+    </main>
+  </body>
+</html>
+```
+
+- [ ] **Step 3: Write the failing direct-search regression**
+
+Extend `TestOllamaSearch` in `tests/test_ollama_scraping.py` with a fixture-backed test that calls real `search_ollama_models()` through the existing mocked HTTP session and asserts:
+
+```python
+message = "Ollama registry parse failed: unsupported search page shape."
+assert results == []
+assert errors == [message]
+assert has_more is False
+```
+
+The production change that must make this test pass is explicit empty-page classification after the anchor scan; the current implementation should fail because it returns `errors == []`.
+
+- [ ] **Step 4: Write the failing provider-adapter structured-error regression**
+
+In `tests/test_ollama_structured_errors.py`, exercise `OllamaProvider.search()` against the unsupported fixture and assert:
+
+```python
+assert result.errors == [message]
+assert len(result.structured_errors) == 1
+error = result.structured_errors[0]
+assert error.provider == "ollama"
+assert error.code == "parse_error"
+assert error.message == message
+assert error.retryable is False
+assert error.status_code is None
+assert error.retry_after_seconds is None
+```
+
+- [ ] **Step 5: Run focused tests and verify RED**
+
+Run the focused scraping and structured-error suites through the repository test entrypoint/pytest environment. Expected failure: unsupported HTTP-200 HTML is still treated as genuine zero-result success (`errors == []`). The model-bearing fixture and updated genuine-zero fixture must remain green.
+
+---
+
+### Task 2: Implement Minimal Search-Shape Classification
+
+**Files:**
+- Modify: `providers/ollama_provider.py`
+
+**Interfaces:**
+- Consumes: the existing parsed `BeautifulSoup` document, `results`, and nested `_record_error(...)` helper.
+- Produces: one stable legacy error plus one optional structured `ProviderError` only when an HTTP-200 search document has neither recognized model results nor the genuine-zero marker.
+
+- [ ] **Step 1: Add the minimal classification after the existing anchor loop**
+
+Use the parsed page text with whitespace preserved and classify only the empty-result path:
+
+```python
+if not results and "No models found." not in soup.get_text(" ", strip=True):
+    _record_error(
+        "Ollama registry parse failed: unsupported search page shape.",
+        code="parse_error",
+        retryable=False,
+    )
+```
+
+Do not raise an exception and do not change the tuple shape or `has_more` behavior.
+
+- [ ] **Step 2: Run the focused tests and verify GREEN**
+
+Expected: model-bearing search remains normal success, `No models found.` remains a clean zero result, unsupported search HTML returns the stable legacy parse error, and the provider adapter exposes one aligned non-retryable structured `parse_error`.
+
+- [ ] **Step 3: Run the full repository verification gates**
+
+Run the normal verify lane and canonical coverage lane. If Package is triggered by the changed paths, require it to succeed on the exact same head.
+
+---
+
+### Task 3: Synchronize Active Documentation
+
+**Files:**
+- Modify: `.planning/roadmap.md`
+- Modify: `.planning/codebase/CONCERNS.md`
+- Modify: `.planning/codebase/TESTING.md`
+- Modify: `CHANGELOG.md`
+- Review only: `README.md`
+
+**Interfaces:**
+- Consumes: the completed O2 behavior and exact verification evidence.
+- Produces: current documentation where O2 is no longer listed as active work and O3 structured-source research remains the next Ollama resilience task.
+
+- [ ] **Step 1: Mark O2 complete in the roadmap**
+
+Move structural-failure detection into the completed baseline and leave O3 as the remaining active Ollama Registry Resilience task.
+
+- [ ] **Step 2: Update concerns/testing documentation**
+
+Record that search HTML now distinguishes the verified genuine-zero marker from unsupported page shapes, and that unsupported shapes emit observable legacy + structured parse diagnostics. Keep model-detail unsupported-shape policy explicitly out of scope if it remains an open concern.
+
+- [ ] **Step 3: Add an Unreleased CHANGELOG reliability entry**
+
+Record the user-visible behavior change: unsupported Ollama search page shapes no longer masquerade as zero results.
+
+- [ ] **Step 4: Review README for material impact**
+
+Only edit README if its current provider-diagnostics/search behavior becomes materially false; otherwise record in the PR body that README was reviewed and remains accurate.
+
+- [ ] **Step 5: Run final exact-head verification and review**
+
+Require CI, the 60% coverage gate, Package if triggered, and no unresolved blocking review thread. Update the PR body with exact head and workflow evidence before merge.

--- a/providers/ollama_provider.py
+++ b/providers/ollama_provider.py
@@ -431,6 +431,13 @@ def search_ollama_models(
             }
             enrich_result_with_scores(result_dict, specs)
             results.append(result_dict)
+
+        if not results and "No models found." not in soup.get_text(" ", strip=True):
+            _record_error(
+                "Ollama registry parse failed: unsupported search page shape.",
+                code="parse_error",
+                retryable=False,
+            )
     except Timeout:
         _record_error("Ollama registry request timed out.", code="timeout", retryable=True)
     except ConnectionError:

--- a/tests/fixtures/ollama/search_empty.html
+++ b/tests/fixtures/ollama/search_empty.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <body>
     <main>
-      <p>No matching models.</p>
+      <p>No models found.</p>
       <a href="/blog/registry-news">Registry news</a>
       <a href="https://example.invalid/library/external">External link</a>
     </main>

--- a/tests/fixtures/ollama/search_unsupported.html
+++ b/tests/fixtures/ollama/search_unsupported.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <section data-registry-results="new-shape">
+        <article>Model cards moved to a new client-rendered shape.</article>
+      </section>
+      <a href="/blog/registry-news">Registry news</a>
+    </main>
+  </body>
+</html>

--- a/tests/test_ollama_scraping.py
+++ b/tests/test_ollama_scraping.py
@@ -94,6 +94,31 @@ class TestOllamaSearch:
         assert has_more is False
 
     @patch("providers.ollama_provider.get_session")
+    @patch("providers.ollama_provider.get_ollama_model_metadata", return_value=None)
+    def test_search_unsupported_fixture_reports_structural_parse_failure(
+        self,
+        _mock_meta,
+        mock_session,
+    ):
+        mock_session.return_value.get.return_value = FakeResponse(
+            text=_fixture("search_unsupported.html")
+        )
+        from providers.ollama_provider import search_ollama_models
+
+        results, errors, has_more = search_ollama_models(
+            "*",
+            _specs(),
+            [],
+            page=0,
+            page_size=20,
+        )
+
+        message = "Ollama registry parse failed: unsupported search page shape."
+        assert results == []
+        assert errors == [message]
+        assert has_more is False
+
+    @patch("providers.ollama_provider.get_session")
     def test_search_network_error(self, mock_session):
         mock_session.return_value.get.side_effect = RequestException("Connection failed")
         from providers.ollama_provider import search_ollama_models

--- a/tests/test_ollama_structured_errors.py
+++ b/tests/test_ollama_structured_errors.py
@@ -1,8 +1,16 @@
+from pathlib import Path
 from unittest.mock import patch
 
 from requests.exceptions import ConnectionError, Timeout
 
 from providers.ollama_provider import OllamaProvider, search_ollama_models
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "ollama"
+
+
+def _fixture(name: str) -> str:
+    """Load one sanitized Ollama HTML fixture."""
+    return (_FIXTURE_DIR / name).read_text(encoding="utf-8")
 
 
 class FakeResponse:
@@ -144,3 +152,26 @@ def test_provider_marks_parse_failure_non_retryable():
     assert structured.code == "parse_error"
     assert structured.retryable is False
     assert structured.status_code is None
+
+
+def test_provider_reports_unsupported_search_shape_as_parse_error():
+    """Unsupported HTTP-200 search markup must not masquerade as a genuine zero result."""
+    response = FakeResponse(status_code=200, text=_fixture("search_unsupported.html"))
+    provider = OllamaProvider()
+
+    with patch(
+        "providers.ollama_provider.get_session",
+        return_value=FakeSession(response=response),
+    ):
+        result = provider.search("test", _specs(), limit=5)
+
+    message = "Ollama registry parse failed: unsupported search page shape."
+    assert result.errors == [message]
+    assert len(result.structured_errors) == 1
+    structured = result.structured_errors[0]
+    assert structured.provider == "ollama"
+    assert structured.code == "parse_error"
+    assert structured.message == message
+    assert structured.retryable is False
+    assert structured.status_code is None
+    assert structured.retry_after_seconds is None


### PR DESCRIPTION
Closes #87

## Goal

Distinguish a genuine zero-result Ollama registry search page from an HTTP-200 page whose structure is no longer recognized, so parser breakage cannot silently masquerade as zero results.

## Changes

- recognize the verified genuine-zero marker `No models found.`
- add a sanitized unsupported-search-shape fixture
- preserve supported `/library/` model-anchor behavior, ordering, dedupe and metadata enrichment
- classify resultless HTTP-200 HTML without the genuine-zero marker as structural parser failure
- preserve the direct `(results, errors, has_more)` three-item tuple
- surface the same stable message through the legacy error list and `ProviderError(code="parse_error", retryable=False)`
- preserve pagination plus existing HTTP/transport diagnostics
- synchronize roadmap, concerns, testing guidance and Unreleased CHANGELOG
- review README; its existing provider `errors` / `structured_errors` zero-result distinction remains accurate, so no README edit was required

## TDD evidence

**RED** — `1deb2ed2a347bcf508fd812eda1cc014e5f91104`, CI `34280738558`

The two new regressions failed for the intended reason: unsupported HTTP-200 HTML still produced `errors == []` in both the direct search contract and provider adapter.

**GREEN implementation** — `5e760957e16a923e96960e2ed364196c4667a652`

- CI `34281100207`: success across coverage, Ubuntu/Windows × Python 3.12/3.14 verify and smoke lanes
- Package `34281100191`: success for Ubuntu and Windows wheels

**Final documented head** — `3c809ea047743396e4b5045e485fb37cd4bc1233`

- CI `34281977682`: success across all 9 jobs, including the canonical 60% coverage gate
- Package `34281977618`: success for Ubuntu and Windows wheels
- compare against `main@ad6522013fcc32c1d8c7a1af7420da3b84cdcff2`: 4 commits ahead, 0 behind, 10 changed files, all issue #87 scoped

## Independent review

- Codex review completed on exact head `3c809ea047743396e4b5045e485fb37cd4bc1233`
- no inline review findings/threads remain
- CodeRabbit reviewed the same PR diff and added its current change summary without an inline blocker

## Preserved boundaries

- no structured-source/API migration research (O3)
- no broad parser rewrite
- no model-detail structural-failure policy
- no live-network CI dependency
- no new public diagnostic code

Implementation plan: `docs/superpowers/plans/2026-09-08-ollama-search-shape-detection.md`.

## Merge gate

Exact-head CI and Package are green, the branch is current with `main`, the acceptance checklist from #87 is satisfied, and there are no unresolved blocking review threads.